### PR TITLE
Perf: Startup timing instrumentation

### DIFF
--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -20,7 +20,15 @@ import './styles/app.styl';
 import './styles/vendor.styl';
 import workerManager from './lib/manager/workerManager';
 import App from './ui/App';
+import { formatTimeline as formatStartupTimeline, mark as startupMark, markAt as startupMarkAt } from '../startup-timeline';
 
+
+// Marked here, at module scope, so the gap from navigation to the first line
+// of app code (bundle download + parse) is visible in the table.
+if (typeof performance !== 'undefined' && performance.timeOrigin) {
+    startupMarkAt('renderer: document start', performance.timeOrigin);
+}
+startupMark('renderer: script eval');
 
 function setupLog() {
     log.setLevel(settings.log.level);
@@ -50,6 +58,7 @@ async function setup() {
 
     // Setup i18n
     await setupI18next();
+    startupMark('renderer: i18n ready');
 
     // Setup worker
     setupWorkerManager();
@@ -67,9 +76,11 @@ series([
         const token = machineStore.get('session.token');
         user.signin({ token: token })
             .then(({ authenticated }) => {
+                startupMark('renderer: signin done');
                 if (authenticated) {
                     log.error('Create and establish a WebSocket connection');
                     controller.connect(() => {
+                        startupMark('renderer: socket connected');
                         next();
                     });
                     return;
@@ -111,6 +122,11 @@ series([
                 <App />
             </Provider>
         </ConfigProvider>,
-        container
+        container,
+        () => {
+            startupMark('renderer: first paint');
+            log.info(`
+${formatStartupTimeline('Luban startup - renderer')}`);
+        }
     );
 });

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -125,8 +125,7 @@ series([
         container,
         () => {
             startupMark('renderer: first paint');
-            log.info(`
-${formatStartupTimeline('Luban startup - renderer')}`);
+            log.info(`\n${formatStartupTimeline('Luban startup - renderer')}`);
         }
     );
 });

--- a/src/main.js
+++ b/src/main.js
@@ -340,8 +340,7 @@ const startToBegin = (data) => {
         .then(() => mainWindow.loadURL(loadUrl)
             .then(() => {
                 startupMark('main: app page loaded');
-                log.info(`
-${formatStartupTimeline('Luban startup - main process')}`);
+                log.info(`\n${formatStartupTimeline('Luban startup - main process')}`);
             })
             .catch(err => {
                 console.log('err', err.message);

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import DataStorage from './DataStorage';
 import MenuBuilder, { addRecentFile, cleanAllRecentFiles } from './electron-app/Menu';
 import { configureWindow } from './electron-app/window';
 import pkg from './package.json';
+import { ENV_KEY as STARTUP_EPOCH_KEY, epoch as startupEpoch, formatTimeline as formatStartupTimeline, mark as startupMark } from './startup-timeline';
 
 import * as Sentry from "@sentry/electron/main";
 
@@ -39,6 +40,9 @@ Sentry.init({
 });
 
 log.setLevel(log.levels.INFO);
+
+// One clock for main, the forked server and the renderer.
+process.env[STARTUP_EPOCH_KEY] = String(startupEpoch);
 
 const config = new Store();
 const userDataDir = app.getPath('userData');
@@ -331,10 +335,17 @@ const startToBegin = (data) => {
     const webContentsSession = mainWindow.webContents.session;
     electronEnable(mainWindow.webContents);
 
+    startupMark('main: navigate to app');
     webContentsSession.setProxy({ proxyRules: 'direct://' })
-        .then(() => mainWindow.loadURL(loadUrl).catch(err => {
-            console.log('err', err.message);
-        }));
+        .then(() => mainWindow.loadURL(loadUrl)
+            .then(() => {
+                startupMark('main: app page loaded');
+                log.info(`
+${formatStartupTimeline('Luban startup - main process')}`);
+            })
+            .catch(err => {
+                console.log('err', err.message);
+            }));
 
     try {
         // TODO: move to server
@@ -346,8 +357,10 @@ const startToBegin = (data) => {
 
 let serverProcess;
 const showMainWindow = async () => {
+    startupMark('main: app ready');
     const windowOptions = getBrowserWindowOptions();
     const window = new BrowserWindow(windowOptions);
+    startupMark('main: window created');
     mainWindow = window;
     // Monitor policy links, do not allow redirection
     window.webContents.on('did-attach-webview', (e, webContent)=>  {
@@ -377,6 +390,7 @@ const showMainWindow = async () => {
                 startToBegin({ ...data, port: CLIENT_PORT });
             });
         } else {
+            startupMark('main: server fork requested');
             serverProcess = childProcess.fork(
                 path.resolve(__dirname, 'server-cli.js'),
                 [],
@@ -390,6 +404,7 @@ const showMainWindow = async () => {
             );
             serverProcess.on('message', (data) => {
                 if (data.type === SERVER_DATA) {
+                    startupMark('main: server ready');
                     startToBegin(data);
                 } else if (data.type === UPLOAD_WINDOWS) {
                     window.loadURL(loadUrl).catch(err => {
@@ -399,6 +414,7 @@ const showMainWindow = async () => {
             });
         }
         // window.webContents.openDevTools();
+        startupMark('main: splash requested');
         window.loadURL(path.resolve(__dirname, 'app', 'loading.html'))
             .then(() => window.setTitle(`Snapmaker Luban ${pkg.version}`))
             .catch(err => {

--- a/src/server-cli.js
+++ b/src/server-cli.js
@@ -4,6 +4,7 @@ import path from 'path';
 import program from 'commander';
 import isElectron from 'is-electron';
 import pkg from './package.json';
+import { formatTimeline as formatStartupTimeline, mark as startupMark } from './startup-timeline';
 
 const SERVER_DATA = 'serverData';
 // Defaults to 'production'
@@ -44,10 +45,15 @@ const launchServer = () => new Promise((resolve, reject) => {
         userDataDir: process.env.USER_DATA_DIR
     };
 
+    startupMark('server: child entry');
+
     // Change working directory to 'server' before require('./server')
     process.chdir(path.resolve(__dirname, 'server'));
 
-    require('./server').createServer({
+    const server = require('./server');
+    startupMark('server: bundle required');
+
+    server.createServer({
         port: options.port,
         host: options.host,
         backlog: options.backlog,
@@ -61,6 +67,10 @@ const launchServer = () => new Promise((resolve, reject) => {
             reject(err);
             return;
         }
+        startupMark('server: ready');
+        // eslint-disable-next-line no-console
+        console.log(`
+${formatStartupTimeline('Luban startup - server child')}`);
         process.send({ type: SERVER_DATA, ...data });
         resolve(data);
     });

--- a/src/server-cli.js
+++ b/src/server-cli.js
@@ -69,8 +69,7 @@ const launchServer = () => new Promise((resolve, reject) => {
         }
         startupMark('server: ready');
         // eslint-disable-next-line no-console
-        console.log(`
-${formatStartupTimeline('Luban startup - server child')}`);
+        console.log(`\n${formatStartupTimeline('Luban startup - server child')}`);
         process.send({ type: SERVER_DATA, ...data });
         resolve(data);
     });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -15,11 +15,13 @@ import logger from './lib/logger';
 import { startServices } from './services';
 import config from './services/configstore';
 import monitor from './services/monitor';
+import { mark as startupMark } from '../startup-timeline';
 
 
 const log = logger('init');
 
 const createServer = (options, callback) => {
+    startupMark('server: createServer entry');
     options = { ...options };
 
     const profile = path.resolve(settings.rcfile);
@@ -79,12 +81,16 @@ const createServer = (options, callback) => {
     process.env.Tmpdir = DataStorage.tmpDir;
 
     const app = createApplication();
+    startupMark('server: application created');
 
     const { port = 0, host, backlog } = options;
     const server = http.createServer(app);
     server.listen(port, host, backlog, () => {
+        startupMark('server: listening');
+
         // Start socket service
         startServices(server);
+        startupMark('server: services started');
 
         // Deal with address bindings
         const realAddress = server.address().address;

--- a/src/startup-timeline.js
+++ b/src/startup-timeline.js
@@ -1,0 +1,71 @@
+/*
+ * Startup timing marks, shared by the Electron main process, the forked server
+ * child and the renderer.
+ *
+ * All three read the same epoch from LUBAN_START_T0 -- main sets it, the fork
+ * inherits it, and the renderer sees it through nodeIntegration -- so marks
+ * from every process land on one timeline and interleave in the log.
+ *
+ * No dependencies and no I/O until something asks for the table.
+ */
+
+const ENV_KEY = 'LUBAN_START_T0';
+
+const readEpoch = () => {
+    try {
+        // In the renderer, webpack replaces bare `process` with a shim whose env
+        // holds only what DefinePlugin injected. `window.process` is the real
+        // Node process and is left alone, so read that first.
+        if (typeof window !== 'undefined' && window.process && window.process.env) {
+            return Number(window.process.env[ENV_KEY]);
+        }
+        return process && process.env && Number(process.env[ENV_KEY]);
+    } catch (err) {
+        return 0;
+    }
+};
+
+// Set by whichever process starts first; main writes it back to the environment
+// so children and the renderer share it.
+const epoch = readEpoch() || Date.now();
+
+const marks = [];
+
+const elapsed = () => Date.now() - epoch;
+
+/** Record a named point in startup. Returns ms since the shared epoch. */
+const mark = (name) => {
+    const at = elapsed();
+    marks.push({ name, at });
+    return at;
+};
+
+/** Record a point that already happened, given its absolute epoch time. */
+const markAt = (name, absoluteMs) => {
+    const at = Math.round(absoluteMs - epoch);
+    marks.push({ name, at });
+    marks.sort((a, b) => a.at - b.at);
+    return at;
+};
+
+/** Render the marks recorded in this process as one ordered table. */
+const formatTimeline = (title) => {
+    const lines = [`${title} (ms since process start)`];
+    let previous = 0;
+    for (const entry of marks) {
+        const step = entry.at - previous;
+        lines.push(`  ${String(entry.at).padStart(7)}  +${String(step).padStart(6)}  ${entry.name}`);
+        previous = entry.at;
+    }
+    return lines.join('\n');
+};
+
+export {
+    ENV_KEY,
+    epoch,
+    elapsed,
+    mark,
+    markAt,
+    marks,
+    formatTimeline,
+};


### PR DESCRIPTION
Closes #1.

First of a stack. Adds the marks the rest of the stack will be judged against; changes no behaviour.

### What

`src/startup-timeline.js` - ~40 lines, no dependencies. Lives at the top of `src/` so all four entry points can reach it without a build change: `src/*.js` is babel-compiled for the main process, and the server and app webpack bundles resolve `../startup-timeline`.

One clock for three processes. Main stamps `LUBAN_START_T0` into its environment at module load; the forked server inherits it (`main.js` already spreads `process.env` into the fork) and the renderer sees it through `nodeIntegration`. Marks from every process are therefore comparable and interleave in the log.

### Marks

| process | marks |
| --- | --- |
| main | app ready, window created, splash requested, server fork requested, server ready, navigate to app, app page loaded |
| server child | child entry, bundle required, createServer entry, application created, listening, services started, ready |
| renderer | script eval, i18n ready, signin done, socket connected, first paint |

Each process prints its own ordered table once, at the end of its startup, with cumulative and step times - paste-able into a bug report.

### Cost

An array push per mark and one `log.info` per process. Nothing on the critical path.

### Checks

- `eslint` on the four touched files: error/warning counts unchanged from base (main.js already carries 20 errors / 11 warnings; the new file is clean).

### Measured on a build of this branch

Warm start, production build, isolated `--user-data-dir`. The three tables stitch together
(main `navigate to app` 2380 -> renderer `document start` 2397):

```
Luban startup - main process          Luban startup - renderer
    706  +  706  app ready               2397  + 2397  document start
    736  +   30  window created          3224  +  827  script eval
    737  +    1  server fork requested   3253  +   29  i18n ready
    747  +   10  splash requested        3292  +   39  signin done
   2375  + 1628  server ready            3328  +   36  socket connected
   2380  +    5  navigate to app         3451  +  123  first paint
   3260  +  880  app page loaded

Luban startup - server child
    912  +  912  child entry
   2285  + 1373  bundle required
   2337  +   52  ready
```

Which already localises the cost for the rest of the stack: 1628 ms of the main process is
spent waiting on the fork (1373 ms of that is `require`ing the server bundle, #2), 827 ms is
bundle download and parse before a line of app code runs (#3), and the renderer's own blocking
work is only 227 ms (#4).
