### PR TITLE
Fix: Keep one saved token per machine (multi-machine token persistence)

### DIFF
--- a/src/app/flux/workspace/actions-connect.ts
+++ b/src/app/flux/workspace/actions-connect.ts
@@ -79,6 +79,81 @@ const setServerToken = (token) => (dispatch) => {
     machineStore.set('server.token', token);
 };
 
+/**
+ * Saved machine record, one per known machine.
+ *
+ * Tokens remain valid until the machine is powered off, so keep one
+ * per machine instead of only the last connected one.
+ */
+interface SavedMachineRecord {
+    name: string;
+    address: string;
+    token: string;
+    lastConnectedAt: number;
+}
+
+const getSavedMachines = (): SavedMachineRecord[] => {
+    const machines = machineStore.get('server.machines');
+    if (Array.isArray(machines)) {
+        return machines;
+    }
+
+    // Migrate legacy single-machine keys (server.address / server.name / server.token)
+    const address = machineStore.get('server.address');
+    const token = machineStore.get('server.token');
+    if (address && token) {
+        const migrated: SavedMachineRecord[] = [{
+            name: machineStore.get('server.name') || '',
+            address,
+            token,
+            lastConnectedAt: 0,
+        }];
+        machineStore.replace('server.machines', migrated);
+        return migrated;
+    }
+
+    return [];
+};
+
+/**
+ * Find saved token for the agent.
+ *
+ * Match by address first; fall back to name in case the address got re-allocated.
+ * On multiple matches, prefer the most recently connected record.
+ */
+const findSavedToken = (agent: MachineAgent): string => {
+    const machines = getSavedMachines();
+
+    const byAddress = machines.filter(m => m.address === agent.address);
+    const byName = machines.filter(m => m.name === agent.name);
+    const candidates = byAddress.length > 0 ? byAddress : byName;
+
+    if (candidates.length === 0) {
+        return '';
+    }
+
+    return candidates.reduce((a, b) => (a.lastConnectedAt >= b.lastConnectedAt ? a : b)).token;
+};
+
+/**
+ * Upsert machine record on successful connect, keyed by address.
+ *
+ * Records with the same name but a different address are kept — the machine
+ * may come back on its old address; stale ones lose on lastConnectedAt.
+ */
+const saveMachineToken = (agent: MachineAgent) => {
+    const machines = getSavedMachines().filter(m => m.address !== agent.address);
+
+    machines.push({
+        name: agent.name,
+        address: agent.address,
+        token: agent.getToken(),
+        lastConnectedAt: Date.now(),
+    });
+
+    machineStore.replace('server.machines', machines);
+};
+
 const setManualIP = (manualIp) => (dispatch) => {
     dispatch(baseActions.updateState({ manualIp }));
 
@@ -139,15 +214,9 @@ const connect = (agent: MachineAgent) => {
         }
 
         // Re-use saved token if possible
-        const savedServerName = getState().workspace.savedServerName;
-        const savedServerAddress = getState().workspace.savedServerAddress;
-        const savedServerToken = getState().workspace.savedServerToken;
-
-        if (agent.address === savedServerAddress) {
-            agent.setToken(savedServerToken);
-        } else if (agent.name === savedServerName) {
-            // In case server address is re-allocated, check for saved server name
-            agent.setToken(savedServerToken);
+        const savedToken = findSavedToken(agent);
+        if (savedToken) {
+            agent.setToken(savedToken);
         }
 
         // update connection status
@@ -171,6 +240,10 @@ const connect = (agent: MachineAgent) => {
                     isOpen: true,
                 }));
 
+                // per-machine token registry
+                saveMachineToken(agent);
+
+                // legacy last-connected keys, kept for external readers and UI auto-select
                 dispatch(setServerName(agent.name));
                 dispatch(setServerAddress(agent.address));
                 dispatch(setServerToken(agent.getToken()));


### PR DESCRIPTION
PR 1 of the MCP stack. Fixes #6.

machine.json persisted one `server.{name,address,token}` triple (local-storage.js:18; actions-connect.ts writes at :67/:73/:79). Connecting to machine B overwrote machine A's token, so switching back to A demanded a touchscreen re-auth even though A's token stays valid until power-off.

Change, confined to `src/app/flux/workspace/actions-connect.ts`:
- new persisted key `server.machines: [{name, address, token, lastConnectedAt}]`
- `connect()` token reuse now looks up this registry: address match first, name as DHCP-reallocation fallback (same precedence as before, now per machine); most recent record wins
- upsert on successful connect, keyed by address
- legacy `server.*` keys: migrated into the registry on first read, still written on every connect — external readers (e.g. snapmaker_status.py) and the connection widget's auto-select keep working unchanged

Verified: `npx eslint` clean on the file; full `npm run build` (production) passes. Not verified against real hardware — switching between two live machines needs a manual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)