### PR TITLE
Perf: Paint the renderer before the backend handshake

### DIFF
--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -1,9 +1,9 @@
 import { ConfigProvider } from 'antd';
 import 'antd/dist/antd.css';
-import series from 'async/series';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import i18nHttpApi from 'i18next-http-backend';
+import once from 'lodash/once';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { initReactI18next } from 'react-i18next';
@@ -34,15 +34,29 @@ function setupLog() {
     log.setLevel(settings.log.level);
 }
 
+// Translations are the one thing worth waiting for -- painting without them
+// shows raw keys. Capped so an unreachable backend delays the paint by at most
+// I18N_TIMEOUT; i18next carries on loading in the background either way.
+const I18N_TIMEOUT = 3000;
+
 async function setupI18next() {
     return new Promise((resolve) => {
+        const done = once(resolve);
+
         i18next
             .use(i18nHttpApi)
             .use(LanguageDetector)
             .use(initReactI18next)
             .init(settings.i18next, () => {
-                resolve();
+                done();
             });
+
+        setTimeout(() => {
+            if (!i18next.isInitialized) {
+                log.warn(`i18n not ready after ${I18N_TIMEOUT}ms, painting anyway`);
+            }
+            done();
+        }, I18N_TIMEOUT);
     });
 }
 
@@ -66,29 +80,7 @@ async function setup() {
     log.info('Bootstrap finished.');
 }
 
-series([
-    async (next) => {
-        // setup
-        await setup();
-        next();
-    },
-    (next) => {
-        const token = machineStore.get('session.token');
-        user.signin({ token: token })
-            .then(({ authenticated }) => {
-                startupMark('renderer: signin done');
-                if (authenticated) {
-                    log.error('Create and establish a WebSocket connection');
-                    controller.connect(() => {
-                        startupMark('renderer: socket connected');
-                        next();
-                    });
-                    return;
-                }
-                next();
-            });
-    },
-], () => {
+function renderApp() {
     log.info(`Launching Snapmaker Luban v${settings.version}...`);
 
     // Prevent browser from loading a drag-and-dropped file
@@ -128,4 +120,32 @@ series([
             log.info(`\n${formatStartupTimeline('Luban startup - renderer')}`);
         }
     );
-});
+}
+
+// Authenticate and open the socket. Deliberately not awaited: nothing on the
+// home screen needs a session, and controller.connect()'s callback only fires
+// once the server answers -- which used to mean an unreachable backend left the
+// user staring at the spinner for ever.
+function connectBackend() {
+    const token = machineStore.get('session.token');
+
+    return user.signin({ token: token })
+        .then(({ authenticated }) => {
+            startupMark('renderer: signin done');
+            if (!authenticated) {
+                log.warn('Not authenticated; socket not opened');
+                return;
+            }
+            controller.connect(() => {
+                startupMark('renderer: socket connected');
+            });
+        })
+        .catch(err => log.error('Backend connect failed', err));
+}
+
+setup()
+    .catch(err => log.error('Bootstrap failed', err))
+    .then(() => {
+        renderApp();
+        connectBackend();
+    });

--- a/src/app/lib/socket-controller.js
+++ b/src/app/lib/socket-controller.js
@@ -9,6 +9,13 @@ class SocketController {
 
     callbacks = {};
 
+    // Registrations made before connect(). The renderer now mounts before the
+    // socket exists, so on/once/channel have to survive a null socket and be
+    // replayed once there is one.
+    pending = [];
+
+    connectWaiters = [];
+
     get connected() {
         return !!(this.socket && this.socket.connected);
     }
@@ -34,6 +41,28 @@ class SocketController {
                 next = null;
             }
         });
+
+        const pending = this.pending;
+        this.pending = [];
+        for (const { method, args } of pending) {
+            this[method](...args);
+        }
+
+        const waiters = this.connectWaiters;
+        this.connectWaiters = [];
+        for (const resolve of waiters) {
+            resolve();
+        }
+    }
+
+    /** Resolves once a socket exists. Already-connected callers resolve immediately. */
+    whenSocketExists() {
+        if (this.socket) {
+            return Promise.resolve();
+        }
+        return new Promise((resolve) => {
+            this.connectWaiters.push(resolve);
+        });
     }
 
     disconnect() {
@@ -48,6 +77,10 @@ class SocketController {
     }
 
     on(eventName, callback) {
+        if (!this.socket) {
+            this.pending.push({ method: 'on', args: [eventName, callback] });
+            return;
+        }
         if (!this.callbacks[eventName]) {
             this.callbacks[eventName] = [];
         }
@@ -63,6 +96,10 @@ class SocketController {
     }
 
     once(eventName, callback) {
+        if (!this.socket) {
+            this.pending.push({ method: 'once', args: [eventName, callback] });
+            return this;
+        }
         this.socket.once(eventName, (...args) => {
             callback(...args);
         });
@@ -71,6 +108,9 @@ class SocketController {
     }
 
     channel(topic, params, onMessage) {
+        if (!this.socket) {
+            return this.whenSocketExists().then(() => this.channel(topic, params, onMessage));
+        }
         return new Promise((resolve, reject) => {
             const actionid = uuid();
             const listener = (_actionid, _STATUS_, result) => {


### PR DESCRIPTION
Closes #4. Stacked on #14.

`index.jsx` ran a two-step `series` before rendering anything: `setup()` (i18n), then
`user.signin()` followed by `controller.connect()`. Only when the socket emitted `startup` did
it remove `#loading` and mount `<App/>`.

Nothing on the home screen needs a session, and `controller.connect()` has no timeout and no
error path — if the socket never opened, `next()` never fired and the app never rendered at all.
That is the offline failure mode, not a latency one.

### Change

- Render as soon as i18n is ready. `signin` and `controller.connect()` run afterwards, unawaited.
- i18n keeps a 3s cap (`I18N_TIMEOUT`). Translations are worth waiting for — painting without
  them shows raw keys — but not indefinitely. i18next keeps loading in the background regardless.
- `series` (and the `async/series` import) dropped; the flow is now two calls.

### socket-controller

`on`, `once` and `channel` dereferenced `this.socket` directly. That was safe only because
`connect()` always ran before mount. It no longer does, so those registrations are buffered
while `socket` is null and replayed on connect; `channel()` waits on a promise resolved at the
same point. `emit` was already null-safe.

### Verified

Production build, warm start, isolated `--user-data-dir`:

```
Luban startup - renderer (ms since process start)
   3338  + 3338  document start
   4453  + 1115  script eval
   4526  +   73  i18n ready
   4683  +  157  first paint
```

`signin done` and `socket connected` are absent from the table because they now happen *after*
first paint — which is the point. The socket still comes up: the server logs
`socket:discover-handlers Subscribe discover machines...` at 7.76s, well after the paint, which
also exercises the buffered-listener replay. No errors in the run.

Warm latency saved is small (~75ms — signin and the socket were both fast against a local
server). The value is that first paint no longer has a backend dependency, which is what #3
needs and what stops an unreachable backend hanging the app.

### Incidentally

A cold run of this build (caches evicted by the rebuild) put the #2 gap at **26.6s** — server
child's first log at 13.35s, `createServer()` at 39.97s. Worse than any of the 12 launches in
the log I sampled for that issue.
