### PR TITLE
Refactor: Make the backend origin explicit

### DIFF
--- a/src/app/api/base.ts
+++ b/src/app/api/base.ts
@@ -4,11 +4,21 @@ import superagent from 'superagent';
 import TaskQueue from './TaskQueue';
 import { machineStore } from '../store/local-storage';
 import ensureArray from '../lib/ensure-array';
+import { getBackendOrigin } from '../lib/backend-origin';
 
 const bearer = (request) => {
     const token = machineStore.get('session.token');
     if (token) {
         request.set('Authorization', `Bearer ${token}`);
+    }
+};
+
+// Relative URLs only resolve while the page is served from the backend. Once it
+// is loaded off disk they need the origin spelling out.
+const backendOrigin = (request) => {
+    const origin = getBackendOrigin();
+    if (origin && typeof request.url === 'string' && request.url.charAt(0) === '/') {
+        request.url = origin + request.url;
     }
 };
 
@@ -25,6 +35,7 @@ const noCache = (request) => {
 
 const request = superagentUse(superagent);
 request.use(bearer);
+request.use(backendOrigin);
 request.use(noCache);
 
 

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -11,6 +11,7 @@ import { Provider } from 'react-redux';
 
 import settings from './config/settings';
 import { controller } from './communication/socket-communication';
+import { listenForBackendOrigin } from './lib/backend-origin';
 import { initialize } from './lib/gaEvent';
 import log from './lib/log';
 import user from './lib/user';
@@ -69,6 +70,9 @@ async function setup() {
 
     // Setup log level
     setupLog();
+
+    // Find out where the backend is before anything asks for it
+    listenForBackendOrigin();
 
     // Setup i18n
     await setupI18next();

--- a/src/app/lib/backend-origin.js
+++ b/src/app/lib/backend-origin.js
@@ -1,0 +1,70 @@
+import isElectron from 'is-electron';
+
+/*
+ * Where the Luban backend lives.
+ *
+ * The renderer is served from the backend's own origin today, so relative URLs
+ * resolve on their own. That stops being true once the window loads the app off
+ * disk over luban:// before the server exists, so the API and socket layers ask
+ * here instead of relying on the page origin.
+ */
+
+// Same-origin when the page came from the server, which is the current case and
+// keeps behaviour identical. Empty under luban://, until main hands us the URL.
+const originFromLocation = () => {
+    if (typeof window === 'undefined' || !window.location) {
+        return '';
+    }
+    return /^https?:$/.test(window.location.protocol) ? window.location.origin : '';
+};
+
+let origin = originFromLocation();
+let waiters = [];
+
+const getBackendOrigin = () => origin;
+
+const setBackendOrigin = (value) => {
+    if (!value || value === origin) {
+        return;
+    }
+    origin = value;
+
+    const pending = waiters;
+    waiters = [];
+    for (const resolve of pending) {
+        resolve(origin);
+    }
+};
+
+/** Resolves once the backend origin is known. */
+const whenBackendOrigin = () => {
+    if (origin) {
+        return Promise.resolve(origin);
+    }
+    return new Promise((resolve) => {
+        waiters.push(resolve);
+    });
+};
+
+/** Ask main for the server URL, and listen for it in case it is not up yet. */
+const listenForBackendOrigin = () => {
+    if (!isElectron() || origin) {
+        return;
+    }
+
+    const { ipcRenderer } = window.require('electron');
+
+    ipcRenderer.on('server-origin', (event, url) => setBackendOrigin(url));
+    ipcRenderer.invoke('get-server-origin')
+        .then(url => setBackendOrigin(url))
+        .catch(() => {
+            // Server not up yet; the 'server-origin' event will arrive later.
+        });
+};
+
+export {
+    getBackendOrigin,
+    setBackendOrigin,
+    whenBackendOrigin,
+    listenForBackendOrigin,
+};

--- a/src/app/lib/socket-controller.js
+++ b/src/app/lib/socket-controller.js
@@ -2,6 +2,8 @@ import noop from 'lodash/noop';
 import io from 'socket.io-client';
 import { v4 as uuid } from 'uuid';
 
+import { getBackendOrigin } from './backend-origin';
+
 class SocketController {
     socket = null;
 
@@ -31,7 +33,7 @@ class SocketController {
 
         this.socket && this.socket.destroy();
 
-        this.socket = io.connect('', {
+        this.socket = io.connect(getBackendOrigin(), {
             query: `token=${token}`,
         });
 

--- a/src/main.js
+++ b/src/main.js
@@ -65,6 +65,10 @@ const UPLOAD_WINDOWS = 'uploadWindows';
 
 const { CLIENT_PORT, SERVER_PORT } = pkg.config;
 
+// The renderer asks for this as soon as it boots, which can be before the server
+// is listening. Answering null is fine - 'server-origin' follows when it is up.
+ipcMain.handle('get-server-origin', () => loadUrl || null);
+
 
 function getBrowserWindowOptions() {
     const defaultOptions = {
@@ -284,6 +288,13 @@ const startToBegin = (data) => {
     updateHandle();
 
     loadUrl = `http://${address}:${port}`;
+
+    // Tell the renderer where the backend is. Sent now for a page that is already
+    // up, and again on load for one that is not.
+    mainWindow.webContents.send('server-origin', loadUrl);
+    mainWindow.webContents.on('did-finish-load', () => {
+        mainWindow.webContents.send('server-origin', loadUrl);
+    });
 
     // register file protocol
     protocol.registerFileProtocol(


### PR DESCRIPTION
Part of #3. Stacked on #16.

Plumbing only — no behaviour change. #3 needs the window to load the app off disk over
`luban://` before the backend exists, and two things assume the page and the backend share an
origin:

- `src/app/api/base.ts` issues origin-relative paths (`request.post('/api/signin')`)
- `src/app/lib/socket-controller.js` does `io.connect('')`

Under `luban://` those resolve against the file protocol handler.

### Change

`src/app/lib/backend-origin.js` owns the answer:

- defaults to `window.location.origin` when the page is `http(s)`, which is the case today, so
  nothing moves
- otherwise stays empty until main supplies it, and `whenBackendOrigin()` lets callers wait
- `listenForBackendOrigin()` invokes `get-server-origin` and subscribes to `server-origin`

Main side: `ipcMain.handle('get-server-origin')` answers on demand — registered at module scope
because the renderer may ask before the server is listening — and `startToBegin` pushes
`server-origin` once `loadUrl` is known, both immediately and on `did-finish-load`, so it lands
whether or not the page is already up.

`base.ts` gains a superagent plugin that prefixes a leading-slash URL with the origin;
`socket-controller` passes it to `io.connect()`.

### Verified

Production build, warm start. CDP network capture shows the API and socket still working, and
still after first paint:

```
   3256  +   99  renderer: first paint
[4.00s] 200 http://127.0.0.1:61190/api/utils/fonts
[4.03s] 200 http://127.0.0.1:61190/api/signin
[4.13s] 200 http://127.0.0.1:61190/socket.io/?token=...
[4.22s] 200 http://127.0.0.1:61190/api/information-flow
```

Absolute URLs, so the prefix is active; 200s, so it resolves to the same place relative paths
did. Timeline unchanged from #16 (paint 3275ms there, 3256ms here — run-to-run noise).
