### PR TITLE
Perf: Load the app off disk instead of waiting for the server

### DIFF
--- a/src/app/api/base.ts
+++ b/src/app/api/base.ts
@@ -4,7 +4,7 @@ import superagent from 'superagent';
 import TaskQueue from './TaskQueue';
 import { machineStore } from '../store/local-storage';
 import ensureArray from '../lib/ensure-array';
-import { getBackendOrigin } from '../lib/backend-origin';
+import { getBackendOrigin, whenBackendOrigin } from '../lib/backend-origin';
 
 const bearer = (request) => {
     const token = machineStore.get('session.token');
@@ -44,21 +44,28 @@ const taskQueue = new TaskQueue(4);
 
 // Default API factory that performs the request, and then convert its result to `Promise`.
 const defaultAPIFactory = (genRequest) => {
-    return async (...args) => new Promise((resolve, reject) => {
-        taskQueue.push(
-            () => genRequest(...args),
-            (response, cb) => {
-                response.end((err, res) => {
-                    if (err) {
-                        reject(res);
-                    } else {
-                        resolve(res);
-                    }
-                    cb();
-                });
-            }
-        );
-    });
+    return async (...args) => {
+        // The window is up before the server is, and components start calling
+        // the API as soon as they mount. Hold each call until we know where the
+        // backend is, or it resolves against the luban:// handler instead.
+        await whenBackendOrigin();
+
+        return new Promise((resolve, reject) => {
+            taskQueue.push(
+                () => genRequest(...args),
+                (response, cb) => {
+                    response.end((err, res) => {
+                        if (err) {
+                            reject(res);
+                        } else {
+                            resolve(res);
+                        }
+                        cb();
+                    });
+                }
+            );
+        });
+    };
 };
 
 export {

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -11,7 +11,7 @@ import { Provider } from 'react-redux';
 
 import settings from './config/settings';
 import { controller } from './communication/socket-communication';
-import { listenForBackendOrigin } from './lib/backend-origin';
+import { listenForBackendOrigin, whenBackendOrigin } from './lib/backend-origin';
 import { initialize } from './lib/gaEvent';
 import log from './lib/log';
 import user from './lib/user';
@@ -131,19 +131,25 @@ function renderApp() {
 // once the server answers -- which used to mean an unreachable backend left the
 // user staring at the spinner for ever.
 function connectBackend() {
-    const token = machineStore.get('session.token');
+    // The page can be up before the server is, so wait to be told where it is
+    // rather than firing at a URL that would resolve to the file handler.
+    return whenBackendOrigin().then(() => {
+        startupMark('renderer: backend origin known');
 
-    return user.signin({ token: token })
-        .then(({ authenticated }) => {
-            startupMark('renderer: signin done');
-            if (!authenticated) {
-                log.warn('Not authenticated; socket not opened');
-                return;
-            }
-            controller.connect(() => {
-                startupMark('renderer: socket connected');
+        const token = machineStore.get('session.token');
+
+        return user.signin({ token: token })
+            .then(({ authenticated }) => {
+                startupMark('renderer: signin done');
+                if (!authenticated) {
+                    log.warn('Not authenticated; socket not opened');
+                    return;
+                }
+                controller.connect(() => {
+                    startupMark('renderer: socket connected');
+                });
             });
-        })
+    })
         .catch(err => log.error('Backend connect failed', err));
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -65,6 +65,10 @@ const UPLOAD_WINDOWS = 'uploadWindows';
 
 const { CLIENT_PORT, SERVER_PORT } = pkg.config;
 
+// The app is served off disk through the luban:// handler, so the window no
+// longer has to wait for the server to be listening before it can load.
+const APP_URL = 'luban://127.0.0.1/';
+
 // The renderer asks for this as soon as it boots, which can be before the server
 // is listening. Answering null is fine - 'server-origin' follows when it is up.
 ipcMain.handle('get-server-origin', () => loadUrl || null);
@@ -280,30 +284,38 @@ if (process.platform === 'win32') {
     }
 }
 
-const startToBegin = (data) => {
-    serverData = data;
-    const { address, port } = data;
-    configureWindow(mainWindow);
+// Everything the window needs before it can load the app off disk. Runs once,
+// before the first navigation, and no longer waits on the server.
+let appEnvironmentReady = false;
+const prepareAppEnvironment = (window) => {
+    electronEnable(window.webContents);
 
-    updateHandle();
-
-    loadUrl = `http://${address}:${port}`;
-
-    // Tell the renderer where the backend is. Sent now for a page that is already
-    // up, and again on load for one that is not.
-    mainWindow.webContents.send('server-origin', loadUrl);
-    mainWindow.webContents.on('did-finish-load', () => {
-        mainWindow.webContents.send('server-origin', loadUrl);
-    });
+    if (appEnvironmentReady) {
+        return Promise.resolve();
+    }
+    appEnvironmentReady = true;
 
     // register file protocol
     protocol.registerFileProtocol(
         'luban',
         (request, callback) => {
-            console.log('file protocol URL:', request.url);
             const { pathname } = url.parse(request.url);
-            const p = pathname === '/' ? 'index.html' : pathname.substr(1);
+            let p = pathname === '/' ? 'index.html' : pathname.substr(1);
+
+            // The server mounts the app directory at both / and /worker, so a
+            // worker URL carries a prefix that is not part of the path on disk.
+            if (p.indexOf('worker/') === 0) {
+                p = p.substr('worker/'.length);
+            }
+
             const filePath = path.normalize(`${__dirname}/app/${p}`);
+
+            if (!fs.existsSync(filePath)) {
+                console.error('luban protocol: not found', filePath);
+                callback({ error: -6 }); // net::ERR_FILE_NOT_FOUND
+                return;
+            }
+
             callback(fs.createReadStream(filePath));
         },
         (error) => {
@@ -341,21 +353,31 @@ const startToBegin = (data) => {
     // Ignore proxy settings
     // https://electronjs.org/docs/api/session#sessetproxyconfig-callback
 
+
+
     electronRemoteMainInitialize();
 
-    const webContentsSession = mainWindow.webContents.session;
-    electronEnable(mainWindow.webContents);
+    // Ignore proxy settings
+    // https://electronjs.org/docs/api/session#sessetproxyconfig-callback
+    return window.webContents.session.setProxy({ proxyRules: 'direct://' });
+};
 
-    startupMark('main: navigate to app');
-    webContentsSession.setProxy({ proxyRules: 'direct://' })
-        .then(() => mainWindow.loadURL(loadUrl)
-            .then(() => {
-                startupMark('main: app page loaded');
-                log.info(`\n${formatStartupTimeline('Luban startup - main process')}`);
-            })
-            .catch(err => {
-                console.log('err', err.message);
-            }));
+const startToBegin = (data) => {
+    serverData = data;
+    const { address, port } = data;
+    configureWindow(mainWindow);
+
+    updateHandle();
+
+    loadUrl = `http://${address}:${port}`;
+
+    // Tell the renderer where the backend is. Sent now for a page that is already
+    // up, and again on load for one that is not.
+    mainWindow.webContents.send('server-origin', loadUrl);
+    mainWindow.webContents.on('did-finish-load', () => {
+        mainWindow.webContents.send('server-origin', loadUrl);
+    });
+
 
     try {
         // TODO: move to server
@@ -417,16 +439,21 @@ const showMainWindow = async () => {
                     startupMark('main: server ready');
                     startToBegin(data);
                 } else if (data.type === UPLOAD_WINDOWS) {
-                    window.loadURL(loadUrl).catch(err => {
+                    window.loadURL(APP_URL).catch(err => {
                         console.log('err', err.message);
                     });
                 }
             });
         }
         // window.webContents.openDevTools();
-        startupMark('main: splash requested');
-        window.loadURL(path.resolve(__dirname, 'app', 'loading.html'))
-            .then(() => window.setTitle(`Snapmaker Luban ${pkg.version}`))
+        startupMark('main: app load requested');
+        prepareAppEnvironment(window)
+            .then(() => window.loadURL(APP_URL))
+            .then(() => {
+                window.setTitle(`Snapmaker Luban ${pkg.version}`);
+                startupMark('main: app page loaded');
+                log.info(`\n${formatStartupTimeline('Luban startup - main process')}`);
+            })
             .catch(err => {
                 console.log('err', err.message);
             });
@@ -767,7 +794,17 @@ app.on('second-instance', (event, commandLine) => {
         }
     }
 });
-protocol.registerSchemesAsPrivileged([{ scheme: 'luban', privileges: { standard: true, corsEnabled: true } }]);
+protocol.registerSchemesAsPrivileged([{
+    scheme: 'luban',
+    privileges: {
+        standard: true,
+        corsEnabled: true,
+        // i18next and the worker pool fetch over this scheme now that the app is
+        // loaded from it. Not marked secure: the API still lives on plain http.
+        supportFetchAPI: true,
+        stream: true,
+    }
+}]);
 
 /**
  * when ready

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -54,6 +54,9 @@ const verifyToken = (token) => {
 };
 const DEFAULT_FILE = 'index.html';
 
+// Origins allowed to call this server cross-origin: the app loaded off disk.
+const LUBAN_ORIGIN = /^luban:\/\//;
+
 const createApplication = () => {
     const app = express();
 
@@ -90,6 +93,32 @@ const createApplication = () => {
     ]); // The view directory path
 
     log.debug('app.settings: %j', app.settings);
+
+    // The renderer is served off disk over luban:// so that it need not wait for
+    // this server to start, which makes every call to it cross-origin. Only that
+    // scheme is allowed; it can only be produced by our own protocol handler.
+    app.use((req, res, next) => {
+        const origin = req.get('Origin');
+
+        if (origin && LUBAN_ORIGIN.test(origin)) {
+            res.setHeader('Access-Control-Allow-Origin', origin);
+            res.setHeader('Access-Control-Allow-Credentials', 'true');
+            res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+            res.setHeader(
+                'Access-Control-Allow-Headers',
+                'Authorization, Content-Type, Cache-Control, X-Requested-With'
+            );
+
+            // superagent sets Authorization and Cache-Control, so these are
+            // preflighted rather than simple requests.
+            if (req.method === 'OPTIONS') {
+                res.status(204).end();
+                return;
+            }
+        }
+
+        next();
+    });
 
     // Check if client's IP address is in the whitelist
     app.use((req, res, next) => {

--- a/src/server/lib/SocketManager/index.ts
+++ b/src/server/lib/SocketManager/index.ts
@@ -35,7 +35,14 @@ class SocketServer extends EventEmitter {
             allowEIO3: true,
             pingTimeout: 180000, // 60s without pong to consider the connection closed
             path: '/socket.io',
-            maxHttpBufferSize: 1e8
+            maxHttpBufferSize: 1e8,
+            // The renderer may be served from luban:// rather than from this
+            // server, which makes the handshake cross-origin. socket.io v4
+            // rejects that by default.
+            cors: {
+                origin: (origin, callback) => callback(null, !origin || /^luban:\/\//.test(origin)),
+                credentials: true,
+            }
         });
 
         // JWT (JSON Web Tokens) support


### PR DESCRIPTION
Closes #3. Stacked on #17.

The window loaded `app/loading.html` and did not navigate to the app until the forked server
reported its port. That wait is the splash: **1.6s warm, 12-26s cold** (I measured 26.6s on one
cold run of this branch's parent).

Nothing about the renderer actually needs the server to start. `index.html`, the bundles, the
images and the i18n JSON all ship on disk, and the `luban://` handler already serves `app/**`.
Only the API and socket need the backend, and #16 made those non-blocking.

### Change

`main.js` navigates to `luban://127.0.0.1/` as soon as the window exists. The protocol
registration, `@electron/remote` init and the proxy config move ahead of the first load into
`prepareAppEnvironment()`; `startToBegin()` keeps only bookkeeping and the `server-origin` push.

That makes every backend call cross-origin, so:

- `server/app.js` answers CORS for `luban://` origins, including the `OPTIONS` preflight
  superagent forces by setting `Authorization` and `Cache-Control`
- `SocketManager` gets the `cors` option socket.io v4 requires — it rejects cross-origin
  handshakes by default

### Three things the move exposed

1. **The scheme lacked `supportFetchAPI`.** Registered `{ standard, corsEnabled }` only, so
   i18next's fetches never reached the handler — i18n hit its 3s cap on every start. Added
   `supportFetchAPI` and `stream`. Deliberately **not** `secure`: a secure origin calling
   `http://127.0.0.1` would be blocked as mixed content.
2. **Worker URLs carry a prefix that is not on disk.** Express mounts the app directory at both
   `/` and `/worker`, so `/worker/Pool.worker.js` serves `app/Pool.worker.js` with the prefix
   stripped. The handler now strips it too, and reports `ERR_FILE_NOT_FOUND` instead of handing
   back a stream that throws on open.
3. **Components call the API as they mount**, about a second before the origin arrives, so those
   calls resolved against `luban://` and 404'd. `defaultAPIFactory` now holds each call until
   `whenBackendOrigin()` resolves.

### Measured

Production build, warm, isolated `--user-data-dir`.

```
                        #17      this PR
document start         2240   ->    581
script eval            3148   ->   1401
i18n ready             3186   ->   1440    (3003 on the first cut of this PR - the cap)
first paint            3275   ->   1503
main: app page loaded  3166   ->   1419
```

The structural result matters more than the number: **first paint 1526ms, server ready 1764ms**.
The UI is up before the backend exists, so however long the fork takes the window no longer
waits on it.

Clean run otherwise: zero protocol 404s, API calls all 204-preflight-then-200, socket.io
connects and `socket:discover-handlers Subscribe discover machines...` round-trips, no worker
errors, no exceptions.

### Known gap, deliberately left to #5

`whenBackendOrigin()` is unbounded. If the server never starts, API calls queue rather than
fail. Bounding that belongs with the rest of the timeout work in the offline PR.
