### PR TITLE
Perf: Bind the port before loading the heavy services

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,13 +9,11 @@ import path from 'path';
 import http from 'http';
 
 import DataStorage from './DataStorage';
-import createApplication from './app';
 import settings from './config/settings';
 import logger from './lib/logger';
-import { startServices } from './services';
 import config from './services/configstore';
 import monitor from './services/monitor';
-import { mark as startupMark } from '../startup-timeline';
+import { elapsed as startupElapsed, mark as startupMark } from '../startup-timeline';
 
 
 const log = logger('init');
@@ -74,23 +72,24 @@ const createServer = (options, callback) => {
         set(settings, 'allowRemoteAccess', allowRemoteAccess);
     }
 
-    // Data storage initialize
-    log.info('Initializing user data storage...');
-    DataStorage.init();
-
     process.env.Tmpdir = DataStorage.tmpDir;
 
-    const app = createApplication();
-    startupMark('server: application created');
-
     const { port = 0, host, backlog } = options;
-    const server = http.createServer(app);
+
+    // Bind before loading the heavy half, so the port is known as early as
+    // possible. Anything that arrives in the gap is parked, not refused.
+    let app = null;
+    const parked = [];
+    const server = http.createServer((req, res) => {
+        if (app) {
+            app(req, res);
+            return;
+        }
+        parked.push([req, res]);
+    });
+
     server.listen(port, host, backlog, () => {
         startupMark('server: listening');
-
-        // Start socket service
-        startServices(server);
-        startupMark('server: services started');
 
         // Deal with address bindings
         const realAddress = server.address().address;
@@ -101,6 +100,36 @@ const createServer = (options, callback) => {
         });
 
         log.info(`Starting the server at ${chalk.cyan(`http://${realAddress}:${realPort}`)}`);
+
+        // Requiring these pulls in express, the machine channels, the slicer and
+        // the task workers: ~1s warm and far worse cold, which is what the splash
+        // used to wait on. Nothing above needs them.
+        setImmediate(() => {
+            // eslint-disable-next-line global-require
+            app = require('./app').default();
+            startupMark('server: application created');
+
+            // Deferred to here because app.js installs the process-wide
+            // unhandledRejection handler, and this leaves floating promises.
+            log.info('Initializing user data storage...');
+            DataStorage.init();
+
+            // eslint-disable-next-line global-require
+            require('./services').startServices(server);
+            startupMark('server: services started');
+
+            // The startup table is printed at 'ready', which is now before this
+            // point, so report the deferred phase separately.
+            log.info(`Services ready ${startupElapsed()}ms after process start`);
+
+            const waiting = parked.splice(0);
+            for (const [req, res] of waiting) {
+                app(req, res);
+            }
+            if (waiting.length) {
+                log.info(`Replayed ${waiting.length} request(s) received before the app was ready`);
+            }
+        });
 
         dns.lookup(os.hostname(), { family: 4, all: true }, (err, addresses) => {
             if (err) {


### PR DESCRIPTION
Closes #2. Stacked on #18.

`DataStorage`'s constructor logs from module scope; `createServer()` logs as its first
statement. The gap between those two lines is therefore pure `require()` of `./app` and
`./services`. Across 15 launches in my own `Logs/server.log` it was **12-24s cold** and ~0.6s
warm, and a cold run of this branch's parent measured **26.6s**.

Nothing above the listener needs either module.

### Change

The port binds on a bare `http.createServer` whose handler parks requests. The ready callback
fires immediately, and express, the machine channels, the slicer and the task workers load on
the next tick. Parked requests are replayed once the app exists, so nothing arriving in the gap
is refused — it just waits.

`DataStorage.init()` moves into the deferred block as well, and deliberately *after*
`require('./app')`: `app.js` installs the process-wide `unhandledRejection` handler, and
`initFonts`/`initLaserResources` leave floating promises (un-awaited `downloadManager` calls with
no `.catch`). Loading storage before that handler existed would make an offline font download
fatal on Node 16.

The startup table is printed at `ready`, which is now before any of this, so the deferred phase
logs its own `Services ready +Nms` line rather than silently vanishing from the timeline.

### Measured

Warm, production build:

```
server child            #18      this PR
bundle required        1081  ->    369
server: ready          1764  ->    982
Services ready            -      1711   (deferred, off the critical path)
```

Everything downstream still comes up: `socket:discover-handlers Subscribe discover machines...`
round-trips, `schedule-task started`, `/api/signin` and `/api/utils/fonts` 200, no exceptions,
no protocol 404s. No requests were parked in these runs — the renderer's first API call lands
after the app is ready — but the path exists for the cold case, where it is the point.

### Not claimed

I could not evict the OS file cache to demonstrate the cold number directly on this branch. The
mechanism is the same one measured at 26.6s on the parent; what this PR changes is that the
cost now falls after `listen` instead of before it.
