### PR TITLE
Fix: Bound every outbound call so offline fails instead of hanging

### DIFF
--- a/src/app/lib/backend-origin.js
+++ b/src/app/lib/backend-origin.js
@@ -36,13 +36,29 @@ const setBackendOrigin = (value) => {
     }
 };
 
-/** Resolves once the backend origin is known. */
+// Long enough to cover a cold server start, short enough that a backend which
+// is never coming fails the call instead of queueing it for ever.
+const ORIGIN_TIMEOUT = 30000;
+
+/**
+ * Resolves once the backend origin is known.
+ *
+ * Rejects if it never arrives, so callers fail rather than hang.
+ */
 const whenBackendOrigin = () => {
     if (origin) {
         return Promise.resolve(origin);
     }
-    return new Promise((resolve) => {
-        waiters.push(resolve);
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error(`Backend origin unknown after ${ORIGIN_TIMEOUT}ms`)),
+            ORIGIN_TIMEOUT
+        );
+
+        waiters.push((value) => {
+            clearTimeout(timer);
+            resolve(value);
+        });
     });
 };
 

--- a/src/app/resources/i18n/en/resource.json
+++ b/src/app/resources/i18n/en/resource.json
@@ -1388,6 +1388,7 @@
     "key-HomePage/CaseLibrary-Lion Box": "Lion Box",
     "key-HomePage/CaseLibrary-Lion Chess Piece": "Lion Chess Piece",
     "key-HomePage/CaseLibrary-Luban Lock": "Luban Lock",
+    "key-HomePage/CaseLibrary-Offline": "Online case library unavailable offline. Local examples are shown below.",
     "key-HomePage/CaseLibrary-Pen Holder": "Pen Holder",
     "key-HomePage/CaseLibrary-Phone Holder": "Phone Holder",
     "key-HomePage/CaseLibrary-Quick Start": "Quick Start",

--- a/src/app/ui/layouts/AppLayout.jsx
+++ b/src/app/ui/layouts/AppLayout.jsx
@@ -293,6 +293,16 @@ class AppLayout extends React.PureComponent {
             });
         },
         renderCaseResource: () => {
+            // CaseResource was mounted unconditionally and merely hidden with
+            // display-none, so every launch loaded an iframe from
+            // resources.snapmaker.com and ran its access probe even for users
+            // who never open the Library. Mount it on first open, then keep it
+            // so reopening stays instant.
+            if (!this.props.showCaseResource && !this.caseResourceOpened) {
+                return null;
+            }
+            this.caseResourceOpened = true;
+
             const onClose = () => { this.props.updateShowCaseReource(false); };
             const onCallBack = () => { };
             return (

--- a/src/app/ui/pages/CaseResource/index.jsx
+++ b/src/app/ui/pages/CaseResource/index.jsx
@@ -80,17 +80,34 @@ const CaseResource = (props) => {
     let mainToolBarHeight = 66;
     // test access of iframe src by path /access-test.css.
     // Front end should provid this file in server
+    // Bounded, like the one on the home page. Unbounded, an unreachable host
+    // left the reader on a blank frame until the 60s iframe timer fired.
+    const ACCESS_TEST_TIMEOUT = 2000;
+
     const accessTest = (cb) => {
         const link = document.createElement('link');
+        let isOver = false;
+
+        const failed = () => {
+            if (isOver) return;
+            isOver = true;
+            cb();
+            setIsIframeLoaded(false);
+            link.parentNode && document.head.removeChild(link);
+        };
+
         link.rel = 'stylesheet';
         link.type = 'text/css';
         link.href = `${resourcesDomain}/access-test.css`;
-        link.onerror = () => {
-            cb();
-            setIsIframeLoaded(false);
-            document.head.removeChild(link);
+        link.onerror = failed;
+        link.onload = () => {
+            if (isOver) return;
+            isOver = true;
+            link.parentNode && document.head.removeChild(link);
         };
         document.head.appendChild(link);
+
+        setTimeout(failed, ACCESS_TEST_TIMEOUT);
     };
     const handleIframe = () => {
         const iframe = caseResourceIframe.current;

--- a/src/app/ui/pages/HomePage/CaseLibrary.tsx
+++ b/src/app/ui/pages/HomePage/CaseLibrary.tsx
@@ -236,6 +236,15 @@ const CaseLibrary = (props) => {
                         </Spin>
                     </div>
                 )}
+            {/*
+              * Offline or behind a VPN the online case library simply is not
+              * there. Say so inline, above the local examples - not in a dialog.
+              */}
+            {!showCaseResource && canAccessWeb === AccessResourceWebState.BLOCKED && (
+                <div className={classNames(styles['case-list-empty'], 'margin-bottom-8')}>
+                    {i18n._('key-HomePage/CaseLibrary-Offline')}
+                </div>
+            )}
             {!showCaseResource && <QuickStart history={props.history} noTitle />}
             {showQuickStartModal && renderQuickStartModal()}
         </>

--- a/src/app/ui/pages/HomePage/styles.styl
+++ b/src/app/ui/pages/HomePage/styles.styl
@@ -200,6 +200,14 @@
     }
 }
 
+// Shown in place of the online case grid when it cannot be reached.
+.case-list-empty {
+    padding: 2vw 3.33vw 0;
+    color: #85888C;
+    font-size: 14px;
+    line-height: 20px;
+}
+
 .quick-start-container {
     display: flex;
     flex-direction: column;

--- a/src/server/lib/downloadManager.ts
+++ b/src/server/lib/downloadManager.ts
@@ -1,34 +1,52 @@
 import fetch from 'node-fetch';
 import fs from 'fs';
+import logger from './logger';
+
+const log = logger('lib:downloadManager');
+
+// These downloads are optional extras - a CJK font, the camera calibration maps.
+// Offline they used to reject with no catch and no timeout, leaving a floating
+// rejection for the process-wide handler to pick up.
+const DOWNLOAD_TIMEOUT = 15000;
 
 class DownloadManager {
-    public async download(url: string, savePath: string): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            fetch(url, {
+    public async download(url: string, savePath: string): Promise<boolean> {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT);
+
+        try {
+            const res = await fetch(url, {
                 headers: { 'Content-Type': 'application/octet-stream' },
-            })
-                .then(res => res.buffer())
-                .then(_ => {
-                    fs.writeFile(savePath, _, 'binary', (err) => {
-                        if (err) {
-                            reject();
-                        } else {
-                            resolve();
-                        }
-                    });
-                });
-        });
+                signal: controller.signal,
+            });
+
+            if (!res.ok) {
+                log.warn(`Download failed (${res.status}): ${url}`);
+                return false;
+            }
+
+            const buffer = await res.buffer();
+            await fs.promises.writeFile(savePath, buffer, 'binary');
+            return true;
+        } catch (err) {
+            log.warn(`Download failed: ${url} (${err && err.message ? err.message : err})`);
+            return false;
+        } finally {
+            clearTimeout(timer);
+        }
     }
 
     /**
      * Download if file on target path not exists.
+     *
+     * Resolves either way - callers treat these as best-effort.
      */
-    public async downloadIfNotExist(url: string, savePath: string): Promise<void> {
+    public async downloadIfNotExist(url: string, savePath: string): Promise<boolean> {
         if (fs.existsSync(savePath)) {
-            return;
+            return true;
         }
 
-        await this.download(url, savePath);
+        return this.download(url, savePath);
     }
 }
 

--- a/src/server/services/api/api-online-resources-service.js
+++ b/src/server/services/api/api-online-resources-service.js
@@ -10,6 +10,13 @@ if (process.env.NODE_ENV === 'production') {
 
 const log = logger('api:commands');
 
+// Offline, or behind a VPN with no route to api.snapmaker.com, an unbounded
+// request leaves the renderer's XHR open until the socket gives up. Fail fast
+// and answer instead: the caller can render an offline state, but only if it
+// is told.
+const RESPONSE_TIMEOUT = 5000;
+const DEADLINE_TIMEOUT = 10000;
+
 const agent = superagentUse(superagent);
 const addPrefix = (prefix) => {
     return function (request) {
@@ -22,9 +29,28 @@ const addPrefix = (prefix) => {
 };
 agent.use(addPrefix(domain));
 
+const withTimeout = (request) => request.timeout({
+    response: RESPONSE_TIMEOUT,
+    deadline: DEADLINE_TIMEOUT,
+});
+
+// Every one of these used to log and return, leaving the response open.
+const failed = (res, what, err) => {
+    log.error(`${what} failed:`, err && err.message ? err.message : JSON.stringify(err));
+
+    if (res.headersSent) {
+        return;
+    }
+
+    res.status(503).send({
+        error: what,
+        offline: true,
+        message: 'Snapmaker online resources are unreachable.',
+    });
+};
 
 export function getCaseList(req, res) {
-    agent.get('/api/resource/sample/list/client')
+    withTimeout(agent.get('/api/resource/sample/list/client'))
         .query({
             page: 1,
             pageSize: 10,
@@ -36,14 +62,12 @@ export function getCaseList(req, res) {
             res.status(200).send({
                 ...result.body
             });
-        }).catch((err) => {
-            log.error('get case list err:', JSON.stringify(err));
-        });
+        }).catch((err) => failed(res, 'get case list', err));
 }
 
 
 export function getSvgShapeList(req, res) {
-    agent.get('/api/resource/svg-shape-library/client/list')
+    withTimeout(agent.get('/api/resource/svg-shape-library/client/list'))
         .query({
             page: 1,
             pageSize: 10,
@@ -53,14 +77,12 @@ export function getSvgShapeList(req, res) {
             res.status(200).send({
                 ...result.body
             });
-        }).catch((err) => {
-            log.error(`get svg shape libray list  with query: ${JSON.stringify(req.query)}, err:`, JSON.stringify(err));
-        });
+        }).catch((err) => failed(res, 'get svg shape library list', err));
 }
 
 
 export function getSvgShapeLabelList(req, res) {
-    agent.get('/api/resource/svg-shape-library/client/label/list')
+    withTimeout(agent.get('/api/resource/svg-shape-library/client/label/list'))
         .query({
             page: 1,
             pageSize: 10,
@@ -70,41 +92,32 @@ export function getSvgShapeLabelList(req, res) {
             res.status(200).send({
                 ...result.body
             });
-        }).catch((err) => {
-            log.error(`get svg shape libray list  with query: ${JSON.stringify(req.query)}, err:`, JSON.stringify(err));
-        });
+        }).catch((err) => failed(res, 'get svg shape label list', err));
 }
 
 
 export function getInformationFlowData(req, res) {
     const { lang } = req.query;
-    agent.get(`/v1/luban-information-flow?lang=${lang}`)
+    withTimeout(agent.get(`/v1/luban-information-flow?lang=${lang}`))
         .then((result) => {
             res.status(200).send({
                 ...result.body
             });
-        }).catch((err) => {
-            log.error('get information flow err:', JSON.stringify(err));
-        });
+        }).catch((err) => failed(res, 'get information flow', err));
 }
-
-const addAuthorization = (token) => {
-    return function (request) {
-        request.set('Authorization', `Bearer ${token}`);
-        return request;
-    };
-};
 
 export function getUserInfoData(req, res) {
     const userDomain = 'https://account.snapmaker.com';
     const { token } = req.query;
-    agent.use(addAuthorization(token));
-    agent.get(`${userDomain}/api/common/accounts/current`)
+
+    // Set per request. This used to agent.use() a new Authorization plugin on
+    // every call, which accumulated on the shared agent and leaked whichever
+    // token was set last into unrelated requests.
+    withTimeout(agent.get(`${userDomain}/api/common/accounts/current`))
+        .set('Authorization', `Bearer ${token}`)
         .then((result) => {
             res.status(200).send({
                 ...result.body
             });
-        }).catch((err) => {
-            log.error('get information flow err:', JSON.stringify(err));
-        });
+        }).catch((err) => failed(res, 'get user info', err));
 }


### PR DESCRIPTION
Closes #5. Stacked on #19.

Offline, or behind a VPN with no route to `api.snapmaker.com`, several things did not fail —
they hung.

### Server: always answer

All five handlers in `api-online-resources-service.js` were shaped

```js
.then(result => res.status(200).send({ ...result.body }))
.catch(err => { log.error(...); });   // <- never touches res
```

No timeout, and the `catch` left the response open, so the renderer's XHR to
`/api/information-flow`, `/api/case-resources/case-list` and friends stayed open until the socket
gave up. They now carry a 5s response / 10s deadline timeout and always reply — 503 with
`offline: true` on failure.

`getUserInfoData` also called `agent.use(addAuthorization(token))` on every request. That
accumulated Authorization plugins on the shared agent without bound, and leaked whichever token
was set last into unrelated calls. Now set per request.

### downloadManager

`fetch` with no timeout and no `.catch()`, called un-awaited from `initFonts` (a CJK font) and
`initLaserResources` (two camera-calibration maps). Offline that left a floating rejection for
the process-wide handler. Now aborts at 15s and resolves a boolean — these are best-effort.

### whenBackendOrigin

Unbounded, which #18 flagged as a known gap. Rejects after 30s so API calls fail rather than
queue for ever.

### CaseResource

Two problems, both found while testing this offline:

- Its access probe had **no timeout at all** — an unreachable host left a blank frame until the
  60s iframe timer fired. Bounded at 2s, matching the home page's probe.
- It was mounted unconditionally and merely hidden with `display-none`, so **every launch loaded
  an iframe from `resources.snapmaker.com`** and ran the probe, even for users who never open the
  Library. It now mounts on first open and stays mounted afterwards, so reopening is still
  instant.

### The UI says so, inline

An empty grid with a label above the local examples. No dialog, no alert, no spinner that never
resolves.

### Verified

**Server timeout**, by pointing the built bundle at an unroutable host:

```
[2.29s] 204 http://127.0.0.1:56177/api/information-flow?...
[7.34s] error api:commands get information flow failed: Response timeout of 5000ms exceeded
[7.43s] 503 http://127.0.0.1:56177/api/information-flow?...
```

503 rather than an open socket.

**Renderer**, with `*snapmaker.com*`, `*cloudfront.net*` and the analytics hosts blocked at the
network layer:

```
OFFLINE-LABEL: Online case library unavailable offline. Local examples are shown below.
dialogs(1): ... StarterGuideModal ... Configuration Wizard Select Language English Cancel Next
```

The label renders; the only remaining dialog is the first-run Configuration Wizard, which is
expected on a fresh profile. Before this change the same probe also found a mounted-but-hidden
`Library loading page failed! please reload` modal — that is the iframe which no longer loads.

**Online**, on a configured profile: first paint 1413ms, six API 200s, socket connected, no
exceptions, no 503s.
