### PR TITLE
Feature: MCP server scaffold, flag-gated, loopback-only

### DIFF
--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -6,6 +6,7 @@ import * as meshHandlers from './channel-handlers/mesh';
 import configstore from './configstore';
 import { connectionManager } from './machine/ConnectionManager';
 import { textSerialChannel } from './machine/channels/TextSerialChannel';
+import { startMcpService } from './mcp';
 import monitor from './monitor';
 import { register as registerDiscoverHandlers } from './socket/discover-handlers';
 import { register as registerMachineHandlers } from './socket/machine-handlers';
@@ -70,6 +71,11 @@ function startServices(server) {
     socketServer.registerChannel('get-free-memory', system.getSystemFreeMemorySize);
 
     socketServer.start(server);
+
+    // ===============
+    // MCP server (off unless a port is configured)
+    // ===============
+    startMcpService();
 }
 
 function registerApis(app) {

--- a/src/server/services/machine/ConnectionManager.ts
+++ b/src/server/services/machine/ConnectionManager.ts
@@ -115,6 +115,9 @@ class ConnectionManager {
     // connected machine instance to handle life cycle
     private machineInstance: MachineInstance = null;
 
+    // identifier of the connected machine, kept for status reporting
+    private machineIdentifier: string | null = null;
+
     private scheduledTasksHandle;
 
     /**
@@ -122,6 +125,36 @@ class ConnectionManager {
      */
     public getProtocol(): NetworkProtocol | SerialPortProtocol {
         return this.protocol;
+    }
+
+    /**
+     * Stable channel name for reporting. constructor.name is useless in
+     * production builds (webpack minifies class names to single letters).
+     */
+    private describeChannel(): string | null {
+        switch (this.channel) {
+            case null: return null;
+            case sstpHttpChannel: return 'sstp-http';
+            case sacpTcpChannel: return 'sacp-tcp';
+            case sacpUdpChannel: return 'sacp-udp';
+            case sacpSerialChannel: return 'sacp-serial';
+            case textSerialChannel: return 'text-serial';
+            default: return 'unknown';
+        }
+    }
+
+    /**
+     * Read-only snapshot of the connection, for status reporting (MCP).
+     */
+    public getConnectionStatus() {
+        return {
+            connected: !!this.channel,
+            channelName: this.describeChannel(),
+            connectionType: this.channel ? this.connectionType : null,
+            protocol: this.channel ? this.protocol : null,
+            machineIdentifier: this.machineIdentifier,
+            machineReady: !!this.machineInstance,
+        };
     }
 
     // TODO: Refactor this
@@ -203,6 +236,7 @@ class ConnectionManager {
         const machineIdentifier = data?.machineIdentifier;
 
         log.debug(`machineIdentifier = ${machineIdentifier}`);
+        this.machineIdentifier = machineIdentifier || null;
 
         // configure machine instance
         this.machineInstance = null;
@@ -398,6 +432,7 @@ class ConnectionManager {
         // destroy channel
         this.unbindChannelEvents();
         this.channel = null;
+        this.machineIdentifier = null;
 
         // destroy machine instance
         if (this.machineInstance) {

--- a/src/server/services/mcp/McpServer.ts
+++ b/src/server/services/mcp/McpServer.ts
@@ -1,0 +1,229 @@
+import http from 'http';
+
+import logger from '../../lib/logger';
+import { McpToolError, ToolRegistry } from './registry';
+
+const log = logger('service:mcp');
+
+// MCP Streamable HTTP transport, stateless mode, implemented directly:
+// the official SDK requires Node >= 18 and Electron 15 embeds Node 16.
+//
+// Scope: JSON-RPC 2.0 over POST /mcp. No session ids, no SSE stream (GET
+// returns 405, which the spec permits for servers that don't offer one).
+const PROTOCOL_VERSION = '2025-03-26';
+
+const JSONRPC_PARSE_ERROR = -32700;
+const JSONRPC_INVALID_REQUEST = -32600;
+const JSONRPC_METHOD_NOT_FOUND = -32601;
+const JSONRPC_INVALID_PARAMS = -32602;
+const JSONRPC_INTERNAL_ERROR = -32603;
+
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+interface JsonRpcMessage {
+    jsonrpc?: string;
+    id?: number | string | null;
+    method?: string;
+    params?: { [key: string]: unknown };
+}
+
+function rpcResult(id: number | string, result: object): object {
+    return { jsonrpc: '2.0', id, result };
+}
+
+function rpcError(id: number | string | null, code: number, message: string): object {
+    return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+// Requests from browsers carry an Origin header; a permitted one is only
+// ever localhost (or the app's own luban:// scheme). Anything else is a
+// DNS-rebinding attempt on a loopback-only server, per MCP spec guidance.
+function isAllowedOrigin(origin: string | undefined): boolean {
+    if (!origin) {
+        return true;
+    }
+    return /^(luban:\/\/|https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$)/.test(origin);
+}
+
+function isLoopback(address: string | undefined): boolean {
+    return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
+}
+
+export class McpServer {
+    private registry: ToolRegistry;
+
+    private serverName: string;
+
+    private serverVersion: string;
+
+    public constructor(registry: ToolRegistry, serverName: string, serverVersion: string) {
+        this.registry = registry;
+        this.serverName = serverName;
+        this.serverVersion = serverVersion;
+    }
+
+    public handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+        // Bound to loopback; re-check per request as defense in depth.
+        if (!isLoopback(req.socket.remoteAddress)) {
+            this.respond(res, 403, { error: 'loopback only' });
+            return;
+        }
+        if (!isAllowedOrigin(req.headers.origin)) {
+            log.warn(`MCP request with disallowed origin rejected: ${req.headers.origin}`);
+            this.respond(res, 403, { error: 'origin not allowed' });
+            return;
+        }
+
+        const url = new URL(req.url, 'http://localhost');
+        if (url.pathname !== '/mcp') {
+            this.respond(res, 404, { error: 'not found' });
+            return;
+        }
+        if (req.method !== 'POST') {
+            // No SSE stream is offered (GET) and no sessions exist to end (DELETE).
+            res.writeHead(405, { Allow: 'POST' });
+            res.end();
+            return;
+        }
+
+        this.readBody(req, res, (body) => {
+            this.handlePost(body, res);
+        });
+    };
+
+    private readBody(req: http.IncomingMessage, res: http.ServerResponse, callback: (body: string) => void): void {
+        const chunks: Buffer[] = [];
+        let size = 0;
+        req.on('data', (chunk: Buffer) => {
+            size += chunk.length;
+            if (size > MAX_BODY_BYTES) {
+                req.destroy();
+                this.respond(res, 413, { error: 'body too large' });
+                return;
+            }
+            chunks.push(chunk);
+        });
+        req.on('end', () => {
+            if (!res.writableEnded) {
+                callback(Buffer.concat(chunks).toString('utf8'));
+            }
+        });
+        req.on('error', (err) => {
+            log.warn(`MCP request error: ${err.message}`);
+        });
+    }
+
+    private async handlePost(body: string, res: http.ServerResponse): Promise<void> {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(body);
+        } catch (err) {
+            this.respond(res, 400, rpcError(null, JSONRPC_PARSE_ERROR, 'Parse error'));
+            return;
+        }
+
+        const messages: JsonRpcMessage[] = Array.isArray(parsed) ? parsed : [parsed as JsonRpcMessage];
+        if (messages.length === 0) {
+            this.respond(res, 400, rpcError(null, JSONRPC_INVALID_REQUEST, 'Empty batch'));
+            return;
+        }
+
+        const responses = [];
+        for (const message of messages) {
+            // eslint-disable-next-line no-await-in-loop
+            const response = await this.handleMessage(message);
+            if (response) {
+                responses.push(response);
+            }
+        }
+
+        if (responses.length === 0) {
+            // Notifications only
+            res.writeHead(202);
+            res.end();
+        } else if (Array.isArray(parsed)) {
+            this.respond(res, 200, responses);
+        } else {
+            this.respond(res, 200, responses[0]);
+        }
+    }
+
+    private async handleMessage(message: JsonRpcMessage): Promise<object | null> {
+        if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') {
+            return rpcError((message && message.id) || null, JSONRPC_INVALID_REQUEST, 'Invalid request');
+        }
+
+        // Notification: no response
+        if (message.id === undefined || message.id === null) {
+            return null;
+        }
+
+        const { id, method, params } = message;
+        try {
+            switch (method) {
+                case 'initialize':
+                    return rpcResult(id, {
+                        protocolVersion: PROTOCOL_VERSION,
+                        capabilities: {
+                            tools: { listChanged: false },
+                        },
+                        serverInfo: {
+                            name: this.serverName,
+                            version: this.serverVersion,
+                        },
+                    });
+                case 'ping':
+                    return rpcResult(id, {});
+                case 'tools/list':
+                    return rpcResult(id, { tools: this.registry.list() });
+                case 'tools/call':
+                    return await this.handleToolCall(id, params);
+                default:
+                    return rpcError(id, JSONRPC_METHOD_NOT_FOUND, `Method not found: ${method}`);
+            }
+        } catch (err) {
+            log.error(`MCP ${method} failed: ${err.message}`);
+            return rpcError(id, JSONRPC_INTERNAL_ERROR, 'Internal error');
+        }
+    }
+
+    private async handleToolCall(id: number | string, params: JsonRpcMessage['params']): Promise<object> {
+        const name = params && params.name;
+        if (typeof name !== 'string') {
+            return rpcError(id, JSONRPC_INVALID_PARAMS, 'tools/call requires a tool name');
+        }
+        if (!this.registry.has(name)) {
+            return rpcError(id, JSONRPC_INVALID_PARAMS, `Unknown tool: ${name}`);
+        }
+
+        // One line per call, arguments elided (they can carry whole gcode
+        // files); enough to follow agent activity from the server log.
+        const startedAt = Date.now();
+        try {
+            const result = await this.registry.call(name, ((params && params.arguments) as object) || {});
+            log.info(`tool ${name} ok in ${Date.now() - startedAt}ms`);
+            return rpcResult(id, {
+                content: [{ type: 'text', text: JSON.stringify(result) }],
+                isError: false,
+            });
+        } catch (err) {
+            // Tool failures are results, not protocol errors, so the model
+            // calling the tool can read them.
+            const text = err instanceof McpToolError ? err.message : `Tool failed: ${err.message}`;
+            log.warn(`tool ${name} failed in ${Date.now() - startedAt}ms: ${text}`);
+            return rpcResult(id, {
+                content: [{ type: 'text', text }],
+                isError: true,
+            });
+        }
+    }
+
+    private respond(res: http.ServerResponse, status: number, payload: object): void {
+        const body = JSON.stringify(payload);
+        res.writeHead(status, {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+        });
+        res.end(body);
+    }
+}

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -1,0 +1,63 @@
+import http from 'http';
+
+import pkg from '../../../package.json';
+import logger from '../../lib/logger';
+import config from '../configstore';
+import { McpServer } from './McpServer';
+import { ToolRegistry } from './registry';
+import { registerStatusTools } from './tools/status';
+
+const log = logger('service:mcp');
+
+// Off by default. Enabled by setting a port, either through the environment
+// or the server configstore; loopback only, so reachable by local processes
+// but never from the LAN the machine itself sits on.
+const PORT_ENV = 'LUBAN_MCP_PORT';
+const PORT_CONFIG_KEY = 'mcpPort';
+
+let httpServer: http.Server | null = null;
+
+function resolvePort(): number | null {
+    const raw = process.env[PORT_ENV] || config.get(PORT_CONFIG_KEY);
+    if (!raw) {
+        return null;
+    }
+    const port = Number(raw);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        log.error(`Ignoring invalid MCP port: ${raw}`);
+        return null;
+    }
+    return port;
+}
+
+export function startMcpService(): void {
+    if (httpServer) {
+        return;
+    }
+
+    const port = resolvePort();
+    if (port === null) {
+        return;
+    }
+
+    const registry = new ToolRegistry();
+    registerStatusTools(registry);
+
+    const mcpServer = new McpServer(registry, 'snapmaker-luban', pkg.version);
+
+    httpServer = http.createServer(mcpServer.handleRequest);
+    httpServer.on('error', (err) => {
+        log.error(`MCP server error: ${err.message}`);
+        httpServer = null;
+    });
+    httpServer.listen(port, '127.0.0.1', () => {
+        log.info(`MCP server listening at http://127.0.0.1:${port}/mcp`);
+    });
+}
+
+export function stopMcpService(): void {
+    if (httpServer) {
+        httpServer.close();
+        httpServer = null;
+    }
+}

--- a/src/server/services/mcp/registry.ts
+++ b/src/server/services/mcp/registry.ts
@@ -1,0 +1,52 @@
+/**
+ * MCP tool registry.
+ *
+ * Tools are registered at service start and exposed over the MCP endpoint
+ * via tools/list and tools/call. Handlers receive already-parsed arguments
+ * and return a JSON-serializable result; throw McpToolError for failures
+ * that should surface as a tool error rather than a protocol error.
+ */
+
+export class McpToolError extends Error {
+}
+
+export interface McpToolDefinition {
+    name: string;
+    description: string;
+
+    // JSON Schema for the tool arguments
+    inputSchema: object;
+
+    handler: (args: object) => Promise<object>;
+}
+
+export class ToolRegistry {
+    private tools = new Map<string, McpToolDefinition>();
+
+    public register(tool: McpToolDefinition): void {
+        if (this.tools.has(tool.name)) {
+            throw new Error(`MCP tool already registered: ${tool.name}`);
+        }
+        this.tools.set(tool.name, tool);
+    }
+
+    public list(): object[] {
+        return [...this.tools.values()].map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+        }));
+    }
+
+    public has(name: string): boolean {
+        return this.tools.has(name);
+    }
+
+    public async call(name: string, args: object): Promise<object> {
+        const tool = this.tools.get(name);
+        if (!tool) {
+            throw new McpToolError(`Unknown tool: ${name}`);
+        }
+        return tool.handler(args || {});
+    }
+}

--- a/src/server/services/mcp/tools/status.ts
+++ b/src/server/services/mcp/tools/status.ts
@@ -1,0 +1,21 @@
+import { connectionManager } from '../../machine/ConnectionManager';
+import { ToolRegistry } from '../registry';
+
+// Seed tool: read-only report of the machine connection. Proves the bridge
+// from the MCP endpoint to ConnectionManager; every later tool (#8-#13)
+// follows this shape.
+export function registerStatusTools(registry: ToolRegistry): void {
+    registry.register({
+        name: 'get_connection_status',
+        description: 'Report whether Luban is connected to a machine, and over which channel. '
+            + 'Read-only; sends nothing to the machine.',
+        inputSchema: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+        },
+        handler: async () => {
+            return connectionManager.getConnectionStatus();
+        },
+    });
+}


### PR DESCRIPTION
Closes #7.

MCP server as a backend service, off by default.

## Design

- **Own HTTP server on loopback**, not a route on the Express app. `/api/*` carries Luban's session JWT (wrong auth model for an MCP client), and anything else on that app is reachable from the whole LAN via `IP_WHITELIST`. Machine-control tools should not be LAN-reachable; `127.0.0.1` bind plus a per-request loopback re-check and an Origin allowlist (DNS-rebinding guard, per MCP spec) keeps the trust boundary at "local processes".
- **Hand-rolled Streamable HTTP transport.** Electron 15 embeds Node 16; `@modelcontextprotocol/sdk` needs Node ≥ 18. Stateless mode is small: JSON-RPC 2.0 over `POST /mcp` — `initialize`, `ping`, `tools/list`, `tools/call`, notifications, batches. No session ids; `GET` (SSE) returns 405, which the spec permits. Zero new dependencies, lockfile untouched.
- **Gating:** enabled only when a port is set via `LUBAN_MCP_PORT` or configstore key `mcpPort`. No port → `startServices` returns before constructing anything.
- **Tool registry** (`registry.ts`): `registerTool({name, description, inputSchema, handler})`; tool failures return `isError: true` results (readable by the calling model), protocol errors stay JSON-RPC errors.
- **Seed tool** `get_connection_status`: read-only snapshot from `ConnectionManager` (new `getConnectionStatus()` accessor + retained `machineIdentifier`). Proves the bridge; sends nothing to the machine.

Real tools land per #8–#13, shaped by #23 (motion = gcode-file job submission, not direct-move streams).

## Verification

- 14-case transport smoke test against the real `McpServer` (babel-register, fake tools): initialize/ping/list/call, tool error vs protocol error, unknown tool/method, parse error, batch, notification → 202, bad Origin → 403, `luban://` Origin allowed, GET → 405, wrong path → 404. All per spec.
- eslint clean on touched files (judged against base); pre-existing `ConnectionManager` tsc/lint noise unchanged.
- Full production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
