### PR TITLE
Feature: MCP gcode validation and human-gated job submission

### DIFF
--- a/src/server/services/machine/ConnectionManager.ts
+++ b/src/server/services/machine/ConnectionManager.ts
@@ -144,6 +144,13 @@ class ConnectionManager {
     }
 
     /**
+     * The active channel, or null when disconnected. Read-only use (MCP).
+     */
+    public getCurrentChannel(): Channel | null {
+        return this.channel;
+    }
+
+    /**
      * Last heartbeat state from the active channel, or null when the channel
      * does not report one (no heartbeat yet, or unsupported channel type).
      */

--- a/src/server/services/machine/channels/SstpHttpChannel.ts
+++ b/src/server/services/machine/channels/SstpHttpChannel.ts
@@ -624,6 +624,38 @@ class SstpHttpChannel extends Channel implements
             });
     };
 
+    /**
+     * Promise variants of startGcode/stopGcode for callers that need the
+     * result rather than a socket emit (MCP job gate).
+     */
+    public async startGcodeJob(): Promise<{ ok: boolean; code?: number; text?: string }> {
+        const api = `${this.host}/api/v1/start_print`;
+        return new Promise((resolve) => {
+            request
+                .post(api)
+                .timeout(120000)
+                .send(`token=${this.token}`)
+                .end((err, res) => {
+                    const { code, text, msg } = _getResult(err, res) || {};
+                    resolve({ ok: !err, code, text: text || msg });
+                });
+        });
+    }
+
+    public async stopGcodeJob(): Promise<{ ok: boolean; code?: number; text?: string }> {
+        const api = `${this.host}/api/v1/stop_print`;
+        return new Promise((resolve) => {
+            request
+                .post(api)
+                .timeout(120000)
+                .send(`token=${this.token}`)
+                .end((err, res) => {
+                    const { code, text, msg } = _getResult(err, res) || {};
+                    resolve({ ok: !err, code, text: text || msg });
+                });
+        });
+    }
+
     public resumeGcode = (options: EventOptions) => {
         const { eventName } = options;
         const api = `${this.host}/api/v1/resume_print`;

--- a/src/server/services/mcp/McpServer.ts
+++ b/src/server/services/mcp/McpServer.ts
@@ -38,14 +38,14 @@ function rpcError(id: number | string | null, code: number, message: string): ob
 // Requests from browsers carry an Origin header; a permitted one is only
 // ever localhost (or the app's own luban:// scheme). Anything else is a
 // DNS-rebinding attempt on a loopback-only server, per MCP spec guidance.
-function isAllowedOrigin(origin: string | undefined): boolean {
+export function isAllowedOrigin(origin: string | undefined): boolean {
     if (!origin) {
         return true;
     }
     return /^(luban:\/\/|https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$)/.test(origin);
 }
 
-function isLoopback(address: string | undefined): boolean {
+export function isLoopback(address: string | undefined): boolean {
     return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
 }
 

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -3,8 +3,10 @@ import http from 'http';
 import pkg from '../../../package.json';
 import logger from '../../lib/logger';
 import config from '../configstore';
-import { McpServer } from './McpServer';
+import { McpServer, isAllowedOrigin, isLoopback } from './McpServer';
+import { jobManager } from './jobs';
 import { ToolRegistry } from './registry';
+import { registerGcodeTools } from './tools/gcode';
 import { registerMachineTools } from './tools/machine';
 import { registerStatusTools } from './tools/status';
 
@@ -44,10 +46,28 @@ export function startMcpService(): void {
     const registry = new ToolRegistry();
     registerStatusTools(registry);
     registerMachineTools(registry);
+    registerGcodeTools(registry, () => `http://127.0.0.1:${port}`);
 
     const mcpServer = new McpServer(registry, 'snapmaker-luban', pkg.version);
 
-    httpServer = http.createServer(mcpServer.handleRequest);
+    httpServer = http.createServer((req, res) => {
+        // Same trust boundary for every route: local processes only, and no
+        // browser contexts other than localhost or the app's own scheme.
+        if (!isLoopback(req.socket.remoteAddress) || !isAllowedOrigin(req.headers.origin)) {
+            res.writeHead(403, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'forbidden' }));
+            return;
+        }
+
+        const url = new URL(req.url, 'http://localhost');
+        if (url.pathname.startsWith('/confirm')) {
+            // Human job-confirmation pages (jobs.ts)
+            jobManager.handleConfirmRequest(req, res, url.pathname);
+            return;
+        }
+
+        mcpServer.handleRequest(req, res);
+    });
     httpServer.on('error', (err) => {
         log.error(`MCP server error: ${err.message}`);
         httpServer = null;

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -1,0 +1,248 @@
+import crypto from 'crypto';
+import * as fs from 'fs-extra';
+import http from 'http';
+import path from 'path';
+
+import DataStorage from '../../DataStorage';
+import logger from '../../lib/logger';
+import { GcodeValidationReport } from './validator';
+
+const log = logger('service:mcp:jobs');
+
+// A submitted job may only start after a human approves it in a browser.
+// The approval page mints the confirm token and shows it to the human;
+// the token is never returned over MCP, so a model driving the MCP surface
+// cannot self-authorise motion. (A process with arbitrary local HTTP access
+// is outside this trust boundary - it could drive Luban's own APIs anyway.)
+const CONFIRM_TOKEN_TTL_MS = 15 * 60 * 1000;
+const JOB_RETENTION_LIMIT = 50;
+
+export type McpJobState =
+    | 'awaiting_confirmation'
+    | 'approved'
+    | 'rejected'
+    | 'starting'
+    | 'started'
+    | 'start_failed'
+    | 'stopped';
+
+export interface McpJob {
+    id: string;
+    name: string;
+    headType: string;
+    filePath: string;
+    createdAt: number;
+    validation: GcodeValidationReport;
+    state: McpJobState;
+    confirmToken: string | null;
+    approvedAt: number | null;
+    tokenUsed: boolean;
+    startedAt: number | null;
+    error: string | null;
+}
+
+function escapeHtml(text: string): string {
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function range(r: { min: number; max: number } | null): string {
+    return r ? `${r.min} .. ${r.max}` : '-';
+}
+
+export class JobManager {
+    private jobs = new Map<string, McpJob>();
+
+    private jobsDir: string | null = null;
+
+    private ensureJobsDir(): string {
+        if (!this.jobsDir) {
+            this.jobsDir = path.join(DataStorage.tmpDir, 'mcp-jobs');
+            fs.ensureDirSync(this.jobsDir);
+        }
+        return this.jobsDir;
+    }
+
+    public submit(gcode: string, name: string, headType: string, validation: GcodeValidationReport): McpJob {
+        const id = crypto.randomBytes(6).toString('hex');
+        const safeName = (name || 'job').replace(/[^\w.-]/g, '_').slice(0, 64);
+        const filePath = path.join(this.ensureJobsDir(), `${id}_${safeName}.nc`);
+        fs.writeFileSync(filePath, gcode, 'utf8');
+
+        const job: McpJob = {
+            id,
+            name: safeName,
+            headType,
+            filePath,
+            createdAt: Date.now(),
+            validation,
+            state: 'awaiting_confirmation',
+            confirmToken: null,
+            approvedAt: null,
+            tokenUsed: false,
+            startedAt: null,
+            error: null,
+        };
+        this.jobs.set(id, job);
+        this.prune();
+        log.info(`MCP job submitted: ${id} (${safeName}), awaiting human confirmation`);
+        return job;
+    }
+
+    public get(id: string): McpJob | null {
+        return this.jobs.get(id) || null;
+    }
+
+    /**
+     * Verify a human-supplied confirm token for a job. Single-use, expiring.
+     */
+    public consumeToken(job: McpJob, token: string): { ok: boolean; reason?: string } {
+        if (job.state !== 'approved' || !job.confirmToken) {
+            return { ok: false, reason: `Job is ${job.state}, not approved.` };
+        }
+        if (job.tokenUsed) {
+            return { ok: false, reason: 'Confirm token already used.' };
+        }
+        if (Date.now() - (job.approvedAt || 0) > CONFIRM_TOKEN_TTL_MS) {
+            return { ok: false, reason: 'Confirm token expired; ask the operator to approve again.' };
+        }
+        const expected = Buffer.from(job.confirmToken, 'utf8');
+        const given = Buffer.from(String(token || ''), 'utf8');
+        if (expected.length !== given.length || !crypto.timingSafeEqual(expected, given)) {
+            return { ok: false, reason: 'Confirm token does not match.' };
+        }
+        job.tokenUsed = true;
+        return { ok: true };
+    }
+
+    /**
+     * Public view of a job - everything except the confirm token.
+     */
+    public describe(job: McpJob): object {
+        return {
+            id: job.id,
+            name: job.name,
+            headType: job.headType,
+            state: job.state,
+            createdAt: job.createdAt,
+            approvedAt: job.approvedAt,
+            startedAt: job.startedAt,
+            error: job.error,
+            validation: job.validation,
+        };
+    }
+
+    private prune(): void {
+        if (this.jobs.size <= JOB_RETENTION_LIMIT) {
+            return;
+        }
+        const oldest = [...this.jobs.values()]
+            .filter((job) => job.state !== 'started' && job.state !== 'starting')
+            .sort((a, b) => a.createdAt - b.createdAt);
+        for (const job of oldest.slice(0, this.jobs.size - JOB_RETENTION_LIMIT)) {
+            this.jobs.delete(job.id);
+            fs.remove(job.filePath).catch(() => undefined);
+        }
+    }
+
+    // ============ human confirmation pages (loopback browser) ============
+
+    /**
+     * Routes /confirm/<id> (GET review page, POST approve/reject).
+     * Loopback and Origin checks are done by the caller.
+     */
+    public handleConfirmRequest(req: http.IncomingMessage, res: http.ServerResponse, pathname: string): void {
+        const match = pathname.match(/^\/confirm\/([0-9a-f]+)(\/(approve|reject))?$/);
+        if (!match) {
+            this.page(res, 404, '<p>Not found.</p>');
+            return;
+        }
+        const job = this.jobs.get(match[1]);
+        if (!job) {
+            this.page(res, 404, '<p>Unknown or expired job.</p>');
+            return;
+        }
+        const action = match[3];
+
+        if (req.method === 'GET' && !action) {
+            this.page(res, 200, this.reviewPage(job));
+            return;
+        }
+        if (req.method === 'POST' && action === 'approve') {
+            if (job.state !== 'awaiting_confirmation') {
+                this.page(res, 409, `<p>Job is ${escapeHtml(job.state)}; nothing to approve.</p>`);
+                return;
+            }
+            job.confirmToken = crypto.randomBytes(4).toString('hex');
+            job.approvedAt = Date.now();
+            job.state = 'approved';
+            log.info(`MCP job ${job.id} approved by operator`);
+            this.page(res, 200, `
+                <h2>Approved</h2>
+                <p>Give this one-time code to the agent to start <strong>${escapeHtml(job.name)}</strong>:</p>
+                <p style="font-size:2em;font-family:monospace;letter-spacing:0.2em">${job.confirmToken}</p>
+                <p>It expires in 15 minutes and works once.</p>`);
+            return;
+        }
+        if (req.method === 'POST' && action === 'reject') {
+            job.state = 'rejected';
+            job.confirmToken = null;
+            log.info(`MCP job ${job.id} rejected by operator`);
+            this.page(res, 200, '<h2>Rejected</h2><p>The job will not run.</p>');
+            return;
+        }
+        res.writeHead(405, { Allow: 'GET, POST' });
+        res.end();
+    }
+
+    private reviewPage(job: McpJob): string {
+        const v = job.validation;
+        const gcodeText = fs.readFileSync(job.filePath, 'utf8');
+        const lines = gcodeText.split(/\r?\n/);
+        const preview = lines.length > 80
+            ? [...lines.slice(0, 40), `... ${lines.length - 80} lines elided ...`, ...lines.slice(-40)].join('\n')
+            : gcodeText;
+
+        const warnings = v.warnings.length
+            ? `<ul>${v.warnings.map((w) => `<li>${escapeHtml(w)}</li>`).join('')}</ul>`
+            : '<p>None.</p>';
+
+        return `
+            <h2>Confirm G-code job: ${escapeHtml(job.name)}</h2>
+            <p>Submitted by an agent over MCP. Review before approving - approval mints a
+               one-time code the agent needs to start the job.</p>
+            <table border="1" cellpadding="6" style="border-collapse:collapse">
+                <tr><td>Head</td><td>${escapeHtml(job.headType)}</td></tr>
+                <tr><td>Lines / motion lines</td><td>${v.lineCount} / ${v.motionLineCount}</td></tr>
+                <tr><td>X extents</td><td>${range(v.extents.x)}</td></tr>
+                <tr><td>Y extents</td><td>${range(v.extents.y)}</td></tr>
+                <tr><td>Z extents</td><td>${range(v.extents.z)}</td></tr>
+                <tr><td>B extents</td><td>${range(v.extents.b)}</td></tr>
+                <tr><td>Feed rates</td><td>${range(v.feedRates)}</td></tr>
+                <tr><td>Spindle</td><td>on x${v.spindle.onCommands}, off x${v.spindle.offCommands}, max S ${v.spindle.maxS === null ? '-' : v.spindle.maxS}</td></tr>
+                <tr><td>Min Z with spindle on</td><td>${v.minZWithSpindleOn === null ? '-' : v.minZWithSpindleOn}</td></tr>
+            </table>
+            <h3>Warnings</h3>
+            ${warnings}
+            <form method="post" action="/confirm/${job.id}/approve" style="display:inline">
+                <button type="submit" style="font-size:1.2em;padding:8px 24px">Approve</button>
+            </form>
+            <form method="post" action="/confirm/${job.id}/reject" style="display:inline;margin-left:16px">
+                <button type="submit" style="font-size:1.2em;padding:8px 24px">Reject</button>
+            </form>
+            <h3>G-code${lines.length > 80 ? ' (first and last 40 lines)' : ''}</h3>
+            <pre style="background:#f6f6f6;padding:12px;overflow:auto;max-height:400px">${escapeHtml(preview)}</pre>`;
+    }
+
+    private page(res: http.ServerResponse, status: number, body: string): void {
+        const html = `<!doctype html><html><head><meta charset="utf-8"><title>Luban MCP job confirmation</title></head>
+            <body style="font-family:sans-serif;max-width:720px;margin:40px auto">${body}</body></html>`;
+        res.writeHead(status, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(html);
+    }
+}
+
+export const jobManager = new JobManager();

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -1,0 +1,219 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention.
+import { connectionManager } from '../../machine/ConnectionManager';
+import { jobManager } from '../jobs';
+import { McpToolError, ToolRegistry } from '../registry';
+import { validateGcode } from '../validator';
+
+// Motion policy (#23): compound motion leaves this process only as a G-code
+// file submitted through the same prepare/start path as "Start on Luban",
+// so the controller's job state machine and the enclosure door interlock
+// apply. Starting requires a one-time code that only the human approval
+// page mints (see jobs.ts).
+
+const HEAD_TYPES = ['cnc', 'laser', 'printing'];
+
+interface JobChannel {
+    uploadGcodeFile?: (filePath: string, type: string, renderName: string, callback: (msg: unknown, data?: unknown) => void) => void;
+    startGcodeJob?: () => Promise<{ ok: boolean; code?: number; text?: string }>;
+    stopGcodeJob?: () => Promise<{ ok: boolean; code?: number; text?: string }>;
+}
+
+function getJobChannel(): JobChannel {
+    const channel = connectionManager.getCurrentChannel() as unknown as JobChannel;
+    if (!channel) {
+        throw new McpToolError('No machine connected.');
+    }
+    if (typeof channel.uploadGcodeFile !== 'function' || typeof channel.startGcodeJob !== 'function') {
+        throw new McpToolError('The connected channel does not support file job submission.');
+    }
+    return channel;
+}
+
+function machineStatus(): string | null {
+    const state = connectionManager.getLatestMachineState();
+    return state ? ((state as { status?: string }).status || null) : null;
+}
+
+export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: () => string): void {
+    registry.register({
+        name: 'validate_gcode',
+        description: 'Statically inspect G-code: motion extents, feeds, spindle commands and '
+            + 'warnings. Sends nothing to the machine.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                gcode: { type: 'string', description: 'Complete G-code text.' },
+            },
+            required: ['gcode'],
+            additionalProperties: false,
+        },
+        handler: async (args: { gcode?: string }) => {
+            if (typeof args.gcode !== 'string' || !args.gcode.trim()) {
+                throw new McpToolError('gcode must be a non-empty string.');
+            }
+            return validateGcode(args.gcode) as unknown as object;
+        },
+    });
+
+    registry.register({
+        name: 'submit_gcode_job',
+        description: 'Stage a G-code job for human confirmation. Returns a validation report and '
+            + 'a confirm_url the OPERATOR must open in a browser; approving there mints a one-time '
+            + 'code the operator gives you for start_gcode_job. Nothing is sent to the machine yet.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                gcode: { type: 'string', description: 'Complete G-code text.' },
+                name: { type: 'string', description: 'Short job name shown to the operator.' },
+                head_type: { type: 'string', enum: HEAD_TYPES, description: 'Toolhead kind. Default cnc.' },
+            },
+            required: ['gcode', 'name'],
+            additionalProperties: false,
+        },
+        handler: async (args: { gcode?: string; name?: string; head_type?: string }) => {
+            if (typeof args.gcode !== 'string' || !args.gcode.trim()) {
+                throw new McpToolError('gcode must be a non-empty string.');
+            }
+            if (typeof args.name !== 'string' || !args.name.trim()) {
+                throw new McpToolError('name must be a non-empty string.');
+            }
+            const headType = args.head_type || 'cnc';
+            if (!HEAD_TYPES.includes(headType)) {
+                throw new McpToolError(`head_type must be one of: ${HEAD_TYPES.join(', ')}`);
+            }
+
+            const validation = validateGcode(args.gcode);
+            const job = jobManager.submit(args.gcode, args.name, headType, validation);
+
+            return {
+                job: jobManager.describe(job),
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url in a browser, review, and approve. '
+                    + 'They will receive a one-time code to give you for start_gcode_job.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'start_gcode_job',
+        description: 'Start an approved job: uploads the file to the machine through the same '
+            + 'prepare/start path as "Start on Luban" (door interlock applies) and starts it. '
+            + 'Requires the one-time code the operator received when approving.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                job_id: { type: 'string' },
+                confirm_token: { type: 'string', description: 'One-time code from the operator.' },
+            },
+            required: ['job_id', 'confirm_token'],
+            additionalProperties: false,
+        },
+        handler: async (args: { job_id?: string; confirm_token?: string }) => {
+            const job = jobManager.get(String(args.job_id || ''));
+            if (!job) {
+                throw new McpToolError('Unknown job_id.');
+            }
+
+            // Connectivity and idleness are checked before the token is
+            // consumed, so an offline attempt does not waste an approval.
+            const channel = getJobChannel();
+            const status = machineStatus();
+            if (status !== 'idle') {
+                throw new McpToolError(`Machine is ${status || 'in an unknown state'}, not idle.`);
+            }
+
+            // Consumed from here on, success or not - a failed start needs a
+            // fresh human approval, not a retry loop.
+            const verdict = jobManager.consumeToken(job, String(args.confirm_token || ''));
+            if (!verdict.ok) {
+                throw new McpToolError(verdict.reason || 'Confirmation failed.');
+            }
+
+            job.state = 'starting';
+            const uploadError = await new Promise<string | null>((resolve) => {
+                channel.uploadGcodeFile(job.filePath, job.headType, `${job.name}.nc`, (msg) => {
+                    resolve(msg ? String(msg) : null);
+                });
+            });
+            if (uploadError) {
+                job.state = 'start_failed';
+                job.error = `Upload failed: ${uploadError}`;
+                throw new McpToolError(job.error);
+            }
+
+            const started = await channel.startGcodeJob();
+            if (!started.ok) {
+                job.state = 'start_failed';
+                job.error = `Start failed: ${started.text || started.code || 'unknown error'}`;
+                throw new McpToolError(job.error);
+            }
+
+            job.state = 'started';
+            job.startedAt = Date.now();
+            return {
+                job: jobManager.describe(job),
+                note: 'Job started. Poll get_gcode_job_status; the controller, its door interlock '
+                    + 'and the machine UI remain in control.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'get_gcode_job_status',
+        description: 'Job record plus live progress from the machine heartbeat. Read-only.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                job_id: { type: 'string' },
+            },
+            required: ['job_id'],
+            additionalProperties: false,
+        },
+        handler: async (args: { job_id?: string }) => {
+            const job = jobManager.get(String(args.job_id || ''));
+            if (!job) {
+                throw new McpToolError('Unknown job_id.');
+            }
+            const state = connectionManager.getLatestMachineState();
+            return {
+                job: jobManager.describe(job),
+                machineStatus: machineStatus(),
+                printingInfo: state ? ((state as { gcodePrintingInfo?: object }).gcodePrintingInfo || null) : null,
+                reportAgeMs: state ? Date.now() - state.timestamp : null,
+            };
+        },
+    });
+
+    registry.register({
+        name: 'stop_gcode_job',
+        description: 'Stop the running job on the machine. Stopping needs no confirmation.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                job_id: { type: 'string', description: 'Job to mark stopped; the machine stop is global.' },
+            },
+            required: ['job_id'],
+            additionalProperties: false,
+        },
+        handler: async (args: { job_id?: string }) => {
+            const job = jobManager.get(String(args.job_id || ''));
+            if (!job) {
+                throw new McpToolError('Unknown job_id.');
+            }
+            const channel = getJobChannel();
+            if (typeof channel.stopGcodeJob !== 'function') {
+                throw new McpToolError('The connected channel does not support stopping jobs.');
+            }
+            const stopped = await channel.stopGcodeJob();
+            if (stopped.ok) {
+                job.state = 'stopped';
+            }
+            return {
+                ok: stopped.ok,
+                text: stopped.text || null,
+                job: jobManager.describe(job),
+            };
+        },
+    });
+}

--- a/src/server/services/mcp/validator.ts
+++ b/src/server/services/mcp/validator.ts
@@ -1,0 +1,162 @@
+/**
+ * Static G-code inspection for the MCP gate.
+ *
+ * Reports facts an agent and a human reviewer need before a job runs:
+ * motion extents, feeds, spindle commands, and hazards worth flagging.
+ * It renders judgment material, not judgment - starting a job still
+ * requires human confirmation.
+ */
+
+export interface GcodeValidationReport {
+    lineCount: number;
+    motionLineCount: number;
+    extents: {
+        x: { min: number; max: number } | null;
+        y: { min: number; max: number } | null;
+        z: { min: number; max: number } | null;
+        b: { min: number; max: number } | null;
+    };
+    feedRates: { min: number; max: number } | null;
+    spindle: {
+        onCommands: number; // M3/M4 count
+        offCommands: number; // M5 count
+        maxS: number | null;
+    };
+    usesRelativeMotion: boolean; // any G91 present
+    usesArcs: boolean; // G2/G3 present (extents are approximated from endpoints)
+    fourAxis: boolean; // any B-axis word
+    minZWithSpindleOn: number | null;
+    warnings: string[];
+}
+
+const MOTION_RE = /^G0*[0123](?:\.\d+)?$/;
+
+function parseWords(line: string): { code: string | null; words: { [letter: string]: number } } {
+    // strip comments: ; to end, and ( ... )
+    const stripped = line.replace(/;.*$/, '').replace(/\([^)]*\)/g, '').trim();
+    if (!stripped) {
+        return { code: null, words: {} };
+    }
+
+    const tokens = stripped.toUpperCase().split(/\s+/);
+    const words: { [letter: string]: number } = {};
+    let code: string | null = null;
+
+    for (const token of tokens) {
+        const letter = token[0];
+        const value = Number(token.slice(1));
+        if (!letter || Number.isNaN(value)) {
+            continue;
+        }
+        if ((letter === 'G' || letter === 'M') && code === null) {
+            code = token;
+        } else {
+            words[letter] = value;
+        }
+    }
+    return { code, words };
+}
+
+function extend(range: { min: number; max: number } | null, value: number): { min: number; max: number } {
+    if (!range) {
+        return { min: value, max: value };
+    }
+    return { min: Math.min(range.min, value), max: Math.max(range.max, value) };
+}
+
+export function validateGcode(gcode: string): GcodeValidationReport {
+    const lines = gcode.split(/\r?\n/);
+
+    let x: { min: number; max: number } | null = null;
+    let y: { min: number; max: number } | null = null;
+    let z: { min: number; max: number } | null = null;
+    let b: { min: number; max: number } | null = null;
+    let feed: { min: number; max: number } | null = null;
+    let maxS: number | null = null;
+    let onCommands = 0;
+    let offCommands = 0;
+    let motionLineCount = 0;
+    let usesRelativeMotion = false;
+    let usesArcs = false;
+    let relativeMode = false;
+    let spindleOn = false;
+    let minZWithSpindleOn: number | null = null;
+    const warnings: string[] = [];
+
+    for (const line of lines) {
+        const { code, words } = parseWords(line);
+        if (!code) {
+            continue;
+        }
+
+        if (code === 'G90') {
+            relativeMode = false;
+        } else if (code === 'G91') {
+            relativeMode = true;
+            usesRelativeMotion = true;
+        } else if (code === 'M3' || code === 'M03' || code === 'M4' || code === 'M04') {
+            onCommands += 1;
+            spindleOn = true;
+            if (words.S !== undefined) {
+                maxS = maxS === null ? words.S : Math.max(maxS, words.S);
+            }
+        } else if (code === 'M5' || code === 'M05') {
+            offCommands += 1;
+            spindleOn = false;
+        } else if (MOTION_RE.test(code)) {
+            motionLineCount += 1;
+            if (code === 'G2' || code === 'G02' || code === 'G3' || code === 'G03') {
+                usesArcs = true;
+            }
+            if (relativeMode) {
+                // Relative moves make static extents unreliable; report the
+                // fact instead of accumulating wrong numbers.
+                continue;
+            }
+            if (words.X !== undefined) x = extend(x, words.X);
+            if (words.Y !== undefined) y = extend(y, words.Y);
+            if (words.Z !== undefined) {
+                z = extend(z, words.Z);
+                if (spindleOn) {
+                    minZWithSpindleOn = minZWithSpindleOn === null
+                        ? words.Z : Math.min(minZWithSpindleOn, words.Z);
+                }
+            }
+            if (words.B !== undefined) b = extend(b, words.B);
+            if (words.F !== undefined) feed = extend(feed, words.F);
+        }
+
+        if (words.S !== undefined && (code === 'M3' || code === 'M03' || code === 'M4' || code === 'M04' || MOTION_RE.test(code))) {
+            maxS = maxS === null ? words.S : Math.max(maxS, words.S);
+        }
+    }
+
+    if (usesRelativeMotion) {
+        warnings.push('Contains G91 relative motion; extents exclude relative segments and are unreliable.');
+    }
+    if (usesArcs) {
+        warnings.push('Contains arcs (G2/G3); extents are computed from endpoints only and may understate the true envelope.');
+    }
+    if (onCommands > 0 && offCommands === 0) {
+        warnings.push('Spindle/laser is turned on (M3/M4) but never turned off (M5).');
+    }
+    if (minZWithSpindleOn !== null && minZWithSpindleOn < 0) {
+        warnings.push(`Cutting below Z0 with spindle on (min Z ${minZWithSpindleOn}). Verify Z0 is the stock top.`);
+    }
+    if (motionLineCount === 0) {
+        warnings.push('No motion commands found.');
+    }
+
+    return {
+        lineCount: lines.length,
+        motionLineCount,
+        extents: { x, y, z, b },
+        feedRates: feed,
+        spindle: { onCommands, offCommands, maxS },
+        usesRelativeMotion,
+        usesArcs,
+        fourAxis: b !== null,
+        minZWithSpindleOn,
+        warnings,
+    };
+}


### PR DESCRIPTION
Closes #12. Implements the #23 motion policy. Stacked on the profile/position PR.

Motion leaves this process **only as a G-code file through the same `prepare_print`/`start_print` path as "Start on Luban"**, so the controller's job state machine and the enclosure door interlock apply. The direct path is not used here at all.

- `validate_gcode`: static report — extents, feeds, spindle use, relative-motion/arc caveats, min Z with spindle on, warnings. Verified against the real skim draft (X ±40 / Y ±30 / Z −4..50, F100–3000, S12000 all read correctly).
- `submit_gcode_job`: stages the file, returns the validation report and a `confirm_url`.
- **Human gate**: the operator opens `confirm_url` in a browser (loopback + Origin-checked), reviews the report and the gcode, and approving mints a one-time 15-minute code. The code is displayed to the human only — never returned over MCP — so a model driving the MCP surface cannot self-authorise motion. (A process with arbitrary local HTTP access is outside this boundary; it could drive Luban's own APIs anyway.)
- `start_gcode_job(job_id, confirm_token)`: requires an idle machine; **consumes the token whether or not the start succeeds** — a failed start needs fresh human approval, not a retry loop. Upload and start return real results via new promise variants on `SstpHttpChannel` (the existing methods only emit to the renderer socket).
- `get_gcode_job_status`: job record + live heartbeat progress. `stop_gcode_job`: no confirmation — stopping is safety-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
