### PR TITLE
Feature: MCP persisted camera calibration and visual_servo

### DIFF
--- a/src/server/services/mcp/calibration.ts
+++ b/src/server/services/mcp/calibration.ts
@@ -1,0 +1,113 @@
+import crypto from 'crypto';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+import DataStorage from '../../DataStorage';
+import logger from '../../lib/logger';
+
+const log = logger('service:mcp:calibration');
+
+// Persisted pixel-to-machine calibration (#13). On the SM2 gantry the
+// platform travels in Y, so a mapping derived from a frame is only valid
+// at the machine Y it was captured at - entries are keyed by that Y (and
+// record Z, since camera height changes scale).
+//
+// The 2x2 matrix maps a pixel delta (du, dv) to the machine XY move (mm)
+// that cancels it: [dx, dy] = M . [du, dv]. Deriving M (rectification,
+// parallax handling) is the calibrating agent's job; the store only keeps
+// and serves it.
+
+export interface CalibrationEntry {
+    id: string;
+    validAtY: number; // machine Y the frame was captured at
+    z: number; // machine Z the frame was captured at
+    matrix: [[number, number], [number, number]];
+    notes: string | null;
+    createdAt: number;
+}
+
+interface CalibrationFile {
+    entries: CalibrationEntry[];
+}
+
+export class CalibrationStore {
+    private filePath: string | null = null;
+
+    private cache: CalibrationFile | null = null;
+
+    private file(): string {
+        if (!this.filePath) {
+            this.filePath = path.join(DataStorage.userDataDir, 'mcp-camera-calibration.json');
+        }
+        return this.filePath;
+    }
+
+    private load(): CalibrationFile {
+        if (this.cache) {
+            return this.cache;
+        }
+        try {
+            const raw = fs.readJsonSync(this.file());
+            this.cache = { entries: Array.isArray(raw?.entries) ? raw.entries : [] };
+        } catch (err) {
+            this.cache = { entries: [] };
+        }
+        return this.cache;
+    }
+
+    private save(): void {
+        try {
+            fs.writeJsonSync(this.file(), this.cache, { spaces: 2 });
+        } catch (err) {
+            log.error(`Failed to persist camera calibration: ${err.message}`);
+        }
+    }
+
+    public add(entry: Omit<CalibrationEntry, 'id' | 'createdAt'>): CalibrationEntry {
+        const data = this.load();
+        const full: CalibrationEntry = {
+            ...entry,
+            id: crypto.randomBytes(4).toString('hex'),
+            createdAt: Date.now(),
+        };
+        data.entries.push(full);
+        this.save();
+        log.info(`Camera calibration ${full.id} stored (valid at Y ${full.validAtY}, Z ${full.z})`);
+        return full;
+    }
+
+    public list(): CalibrationEntry[] {
+        return this.load().entries;
+    }
+
+    public get(id: string): CalibrationEntry | null {
+        return this.load().entries.find((entry) => entry.id === id) || null;
+    }
+
+    public remove(id: string): boolean {
+        const data = this.load();
+        const before = data.entries.length;
+        data.entries = data.entries.filter((entry) => entry.id !== id);
+        if (data.entries.length !== before) {
+            this.save();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Nearest entry by |validAtY - y|, or null when none is within tolerance.
+     */
+    public findNearest(y: number, toleranceMm: number): { entry: CalibrationEntry; distance: number } | null {
+        let best: { entry: CalibrationEntry; distance: number } | null = null;
+        for (const entry of this.load().entries) {
+            const distance = Math.abs(entry.validAtY - y);
+            if (!best || distance < best.distance) {
+                best = { entry, distance };
+            }
+        }
+        return best && best.distance <= toleranceMm ? best : null;
+    }
+}
+
+export const calibrationStore = new CalibrationStore();

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -6,6 +6,7 @@ import config from '../configstore';
 import { McpServer, isAllowedOrigin, isLoopback } from './McpServer';
 import { jobManager } from './jobs';
 import { ToolRegistry } from './registry';
+import { registerCalibrationTools } from './tools/calibration';
 import { registerCameraTools } from './tools/camera';
 import { registerGcodeTools } from './tools/gcode';
 import { registerMachineTools } from './tools/machine';
@@ -49,6 +50,7 @@ export function startMcpService(): void {
     registerMachineTools(registry);
     registerGcodeTools(registry, () => `http://127.0.0.1:${port}`);
     registerCameraTools(registry);
+    registerCalibrationTools(registry);
 
     const mcpServer = new McpServer(registry, 'snapmaker-luban', pkg.version);
 

--- a/src/server/services/mcp/tools/calibration.ts
+++ b/src/server/services/mcp/tools/calibration.ts
@@ -1,0 +1,237 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention.
+import { CalibrationEntry, calibrationStore } from '../calibration';
+import { McpToolError, ToolRegistry } from '../registry';
+import { executeBoundedMoveAndCapture } from './camera';
+import { getPositionSnapshot } from './machine';
+
+// visual_servo executes ONE correction step per call - the agent supplies
+// the pixel error, the stored calibration turns it into a machine XY move,
+// and the loop lives in the agent, not here. Each step goes through the
+// same guarded single-move path as move_and_capture (#23).
+
+const DEFAULT_STEP_LIMIT_MM = 5;
+const MAX_STEP_LIMIT_MM = 20;
+const DEFAULT_Y_TOLERANCE_MM = 2;
+
+function isMatrix(value: unknown): value is [[number, number], [number, number]] {
+    return Array.isArray(value) && value.length === 2
+        && value.every((row) => Array.isArray(row) && row.length === 2
+            && row.every((cell) => Number.isFinite(Number(cell))));
+}
+
+function describeEntry(entry: CalibrationEntry): object {
+    return entry;
+}
+
+export function registerCalibrationTools(registry: ToolRegistry): void {
+    registry.register({
+        name: 'set_camera_calibration',
+        description: 'Persist a pixel-to-machine calibration, keyed by the machine Y it was '
+            + 'derived at (the SM2 platform travels in Y, so a mapping is only valid at that Y). '
+            + 'matrix maps a pixel delta [du, dv] to the machine XY move [dx, dy] in mm that '
+            + 'cancels it. Survives restarts.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                valid_at_y: { type: 'number', description: 'Machine Y the calibration frame was captured at.' },
+                z: { type: 'number', description: 'Machine Z the calibration frame was captured at.' },
+                matrix: {
+                    type: 'array',
+                    description: '2x2 row-major: [[m00, m01], [m10, m11]]; [dx, dy] = M . [du, dv].',
+                    items: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                    minItems: 2,
+                    maxItems: 2,
+                },
+                notes: { type: 'string', description: 'Free-form provenance: grid used, residuals, tilt.' },
+            },
+            required: ['valid_at_y', 'z', 'matrix'],
+            additionalProperties: false,
+        },
+        handler: async (args: { valid_at_y?: number; z?: number; matrix?: unknown; notes?: string }) => {
+            const validAtY = Number(args.valid_at_y);
+            const z = Number(args.z);
+            if (!Number.isFinite(validAtY) || !Number.isFinite(z)) {
+                throw new McpToolError('valid_at_y and z must be finite numbers.');
+            }
+            if (!isMatrix(args.matrix)) {
+                throw new McpToolError('matrix must be a 2x2 array of numbers.');
+            }
+            const entry = calibrationStore.add({
+                validAtY,
+                z,
+                matrix: args.matrix,
+                notes: args.notes ? String(args.notes) : null,
+            });
+            return { entry: describeEntry(entry) };
+        },
+    });
+
+    registry.register({
+        name: 'get_camera_calibration',
+        description: 'Fetch calibrations: by id, nearest to a machine Y (within tolerance), or all. '
+            + 'Read-only.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { type: 'string' },
+                y: { type: 'number', description: 'Machine Y to match against valid_at_y.' },
+                tolerance_mm: { type: 'number', description: `Match tolerance for y, default ${DEFAULT_Y_TOLERANCE_MM}.` },
+            },
+            additionalProperties: false,
+        },
+        handler: async (args: { id?: string; y?: number; tolerance_mm?: number }) => {
+            if (args.id) {
+                const entry = calibrationStore.get(String(args.id));
+                if (!entry) {
+                    throw new McpToolError('Unknown calibration id.');
+                }
+                return { entry: describeEntry(entry) };
+            }
+            if (args.y !== undefined) {
+                const tolerance = Number(args.tolerance_mm) || DEFAULT_Y_TOLERANCE_MM;
+                const match = calibrationStore.findNearest(Number(args.y), tolerance);
+                return {
+                    entry: match ? describeEntry(match.entry) : null,
+                    distance_mm: match ? match.distance : null,
+                    all: calibrationStore.list().map((e) => ({ id: e.id, validAtY: e.validAtY, z: e.z })),
+                };
+            }
+            return { entries: calibrationStore.list().map(describeEntry) };
+        },
+    });
+
+    registry.register({
+        name: 'delete_camera_calibration',
+        description: 'Delete one stored calibration by id.',
+        inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+            required: ['id'],
+            additionalProperties: false,
+        },
+        handler: async (args: { id?: string }) => {
+            const removed = calibrationStore.remove(String(args.id || ''));
+            if (!removed) {
+                throw new McpToolError('Unknown calibration id.');
+            }
+            return { removed: true };
+        },
+    });
+
+    registry.register({
+        name: 'visual_servo',
+        description: 'One visual-servo correction step: turns a pixel error (target_pixel - '
+            + 'feature_pixel) into a machine XY move using a stored calibration, executes it '
+            + 'through the same guarded single-move path as move_and_capture, and returns the '
+            + 'new frame. The iteration loop belongs to the caller. Step size is clamped '
+            + `(max_step_mm, default ${DEFAULT_STEP_LIMIT_MM}, cap ${MAX_STEP_LIMIT_MM}).`,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                feature_pixel: {
+                    type: 'object',
+                    properties: { u: { type: 'number' }, v: { type: 'number' } },
+                    required: ['u', 'v'],
+                    description: 'Where the feature currently images.',
+                },
+                target_pixel: {
+                    type: 'object',
+                    properties: { u: { type: 'number' }, v: { type: 'number' } },
+                    required: ['u', 'v'],
+                    description: 'Where the feature should image.',
+                },
+                calibration_id: { type: 'string', description: 'Omit to auto-select nearest to the current machine Y.' },
+                max_step_mm: { type: 'number' },
+                feed_rate: { type: 'number' },
+                operator_confirmed_clearance: {
+                    type: 'boolean',
+                    description: 'Set true ONLY when the human operator has explicitly confirmed the '
+                        + 'current Z and an obstacle-free path at this Z; skips the homed-first requirement.',
+                },
+            },
+            required: ['feature_pixel', 'target_pixel'],
+            additionalProperties: false,
+        },
+        handler: async (args: {
+            feature_pixel?: { u?: number; v?: number };
+            target_pixel?: { u?: number; v?: number };
+            calibration_id?: string;
+            max_step_mm?: number;
+            feed_rate?: number;
+            operator_confirmed_clearance?: boolean;
+        }) => {
+            const du = Number(args.target_pixel?.u) - Number(args.feature_pixel?.u);
+            const dv = Number(args.target_pixel?.v) - Number(args.feature_pixel?.v);
+            if (!Number.isFinite(du) || !Number.isFinite(dv)) {
+                throw new McpToolError('feature_pixel and target_pixel must have numeric u and v.');
+            }
+
+            const position = getPositionSnapshot();
+            if (position.machine.x === null || position.machine.y === null) {
+                throw new McpToolError('Current machine position unknown.');
+            }
+
+            let entry: CalibrationEntry | null = null;
+            let entryDistance: number | null = null;
+            if (args.calibration_id) {
+                entry = calibrationStore.get(String(args.calibration_id));
+                if (!entry) {
+                    throw new McpToolError('Unknown calibration id.');
+                }
+                entryDistance = Math.abs(entry.validAtY - position.machine.y);
+            } else {
+                const match = calibrationStore.findNearest(position.machine.y, DEFAULT_Y_TOLERANCE_MM);
+                if (!match) {
+                    throw new McpToolError(`No calibration within ${DEFAULT_Y_TOLERANCE_MM} mm of machine Y `
+                        + `${position.machine.y.toFixed(1)}. Store one with set_camera_calibration, or pass calibration_id.`);
+                }
+                entry = match.entry;
+                entryDistance = match.distance;
+            }
+
+            const [[m00, m01], [m10, m11]] = entry.matrix;
+            let dx = m00 * du + m01 * dv;
+            let dy = m10 * du + m11 * dv;
+
+            const stepLimit = Math.min(Number(args.max_step_mm) || DEFAULT_STEP_LIMIT_MM, MAX_STEP_LIMIT_MM);
+            const magnitude = Math.hypot(dx, dy);
+            const clamped = magnitude > stepLimit;
+            if (clamped && magnitude > 0) {
+                dx *= stepLimit / magnitude;
+                dy *= stepLimit / magnitude;
+            }
+
+            const warnings: string[] = [];
+            if (entryDistance !== null && entryDistance > DEFAULT_Y_TOLERANCE_MM) {
+                warnings.push(`Calibration ${entry.id} is ${entryDistance.toFixed(1)} mm from the current Y; scale may be off.`);
+            }
+            if (Math.abs(dy) > DEFAULT_Y_TOLERANCE_MM) {
+                warnings.push('This step moves Y; the calibration is keyed to Y, so re-derive or re-select after the move.');
+            }
+
+            const result = await executeBoundedMoveAndCapture({
+                x: position.machine.x + dx,
+                y: position.machine.y + dy,
+                coordinate_system: 'machine',
+                feed_rate: args.feed_rate,
+                operator_confirmed_clearance: args.operator_confirmed_clearance,
+            }) as { mcpContent: object[] };
+
+            // Splice servo metadata into the text part of the frame result.
+            const servoMeta = {
+                pixel_error: { du, dv },
+                applied_mm: { dx, dy },
+                clamped,
+                calibration: { id: entry.id, validAtY: entry.validAtY, z: entry.z, distance_mm: entryDistance },
+                warnings,
+            };
+            return {
+                mcpContent: [
+                    ...result.mcpContent,
+                    { type: 'text', text: JSON.stringify({ visual_servo: servoMeta }) },
+                ],
+            };
+        },
+    });
+}

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -78,6 +78,125 @@ function assertSafeToMove(position: PositionSnapshot, operatorConfirmedClearance
     }
 }
 
+
+export interface BoundedMoveArgs {
+    x?: number;
+    y?: number;
+    coordinate_system?: string;
+    feed_rate?: number;
+    operator_confirmed_clearance?: boolean;
+}
+
+/**
+ * The single bounded XY move + settle + capture behind move_and_capture,
+ * shared with visual_servo. Enforces every guard.
+ */
+export async function executeBoundedMoveAndCapture(args: BoundedMoveArgs): Promise<object> {
+    if (args.x === undefined && args.y === undefined) {
+        throw new McpToolError('Provide x and/or y.');
+    }
+    const coordinateSystem = args.coordinate_system || 'work';
+    if (!['work', 'machine'].includes(coordinateSystem)) {
+        throw new McpToolError('coordinate_system must be "work" or "machine".');
+    }
+    const feedRate = Math.min(Math.max(Number(args.feed_rate) || DEFAULT_FEED_RATE, 100), 3000);
+
+    const before = getPositionSnapshot();
+    assertSafeToMove(before, args.operator_confirmed_clearance === true);
+
+    const current = coordinateSystem === 'work' ? before.work : before.machine;
+    if (current.x === null || current.y === null) {
+        throw new McpToolError('Current position unknown; cannot bound the move.');
+    }
+    const target = {
+        x: args.x !== undefined ? Number(args.x) : current.x,
+        y: args.y !== undefined ? Number(args.y) : current.y,
+    };
+    if (!Number.isFinite(target.x) || !Number.isFinite(target.y)) {
+        throw new McpToolError('x/y must be finite numbers.');
+    }
+
+    const travel = Math.hypot(target.x - current.x, target.y - current.y);
+    const maxTravel = Number(config.get('mcpMaxJogDistance')) || DEFAULT_MAX_TRAVEL_MM;
+    if (travel > maxTravel) {
+        throw new McpToolError(`Requested travel ${travel.toFixed(1)} mm exceeds the ${maxTravel} mm `
+                    + 'per-call limit. Split the approach, or submit a gcode job.');
+    }
+
+    // Envelope check in machine coordinates when the build volume is known.
+    const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+    const machineTarget = coordinateSystem === 'machine' ? target : {
+        x: target.x - before.originOffset.x,
+        y: target.y - before.originOffset.y,
+    };
+    if (size) {
+        if (machineTarget.x < -0.5 || machineTarget.x > size.x + 0.5
+                    || machineTarget.y < -0.5 || machineTarget.y > size.y + 0.5) {
+            throw new McpToolError(`Target (machine ${machineTarget.x.toFixed(1)}, ${machineTarget.y.toFixed(1)}) `
+                        + `is outside the ${size.x}x${size.y} build area.`);
+        }
+    }
+
+    const channel = connectionManager.getCurrentChannel() as unknown as GcodeChannel;
+    if (!channel || typeof channel.executeGcode !== 'function') {
+        throw new McpToolError('The connected channel does not support direct moves.');
+    }
+
+    const move = `G0 X${target.x.toFixed(3)} Y${target.y.toFixed(3)} F${feedRate}`;
+    const gcode = coordinateSystem === 'machine' ? `G53;\n${move};\nG54;` : move;
+    const issuedAt = Date.now();
+    const executed = await channel.executeGcode(gcode);
+    if (executed.result !== 0) {
+        throw new McpToolError(`Move rejected by controller: ${executed.text || executed.result}`);
+    }
+
+    // Wait for a post-move heartbeat that reports the target, twice,
+    // so the returned position is what the firmware says, not what
+    // was commanded (#11).
+    let settled: PositionSnapshot | null = null;
+    let stableReports = 0;
+    let lastTimestamp = 0;
+    const deadline = issuedAt + SETTLE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        await sleep(SETTLE_POLL_MS);
+        const now = getPositionSnapshot();
+        const reportTime = Date.now() - now.reportAgeMs;
+        if (reportTime <= issuedAt || reportTime === lastTimestamp) {
+            continue; // not a fresh post-move report
+        }
+        lastTimestamp = reportTime;
+        const reported = coordinateSystem === 'work' ? now.work : now.machine;
+        if (reported.x !== null && reported.y !== null
+                    && Math.abs(reported.x - target.x) <= SETTLE_TOLERANCE_MM
+                    && Math.abs(reported.y - target.y) <= SETTLE_TOLERANCE_MM) {
+            stableReports += 1;
+            if (stableReports >= 2) {
+                settled = now;
+                break;
+            }
+        } else {
+            stableReports = 0;
+        }
+    }
+    if (!settled) {
+        const last = positionOrNull();
+        throw new McpToolError('Move did not settle at the target within '
+                    + `${SETTLE_TIMEOUT_MS / 1000}s. Last reported position: ${JSON.stringify(last && {
+                        work: last.work, machine: last.machine,
+                    })}`);
+    }
+
+    await sleep(POST_SETTLE_DWELL_MS);
+    const frame = await captureFrame();
+    const after = getPositionSnapshot();
+
+    return frameContent(frame, {
+        commanded: { ...target, coordinate_system: coordinateSystem, feed_rate: feedRate },
+        position: after,
+        note: 'position is firmware-reported after settling, not the commanded target',
+    });
+}
+
 export function registerCameraTools(registry: ToolRegistry): void {
     registry.register({
         name: 'list_cameras',
@@ -175,116 +294,6 @@ export function registerCameraTools(registry: ToolRegistry): void {
             },
             additionalProperties: false,
         },
-        handler: async (args: {
-            x?: number;
-            y?: number;
-            coordinate_system?: string;
-            feed_rate?: number;
-            operator_confirmed_clearance?: boolean;
-        }) => {
-            if (args.x === undefined && args.y === undefined) {
-                throw new McpToolError('Provide x and/or y.');
-            }
-            const coordinateSystem = args.coordinate_system || 'work';
-            if (!['work', 'machine'].includes(coordinateSystem)) {
-                throw new McpToolError('coordinate_system must be "work" or "machine".');
-            }
-            const feedRate = Math.min(Math.max(Number(args.feed_rate) || DEFAULT_FEED_RATE, 100), 3000);
-
-            const before = getPositionSnapshot();
-            assertSafeToMove(before, args.operator_confirmed_clearance === true);
-
-            const current = coordinateSystem === 'work' ? before.work : before.machine;
-            if (current.x === null || current.y === null) {
-                throw new McpToolError('Current position unknown; cannot bound the move.');
-            }
-            const target = {
-                x: args.x !== undefined ? Number(args.x) : current.x,
-                y: args.y !== undefined ? Number(args.y) : current.y,
-            };
-            if (!Number.isFinite(target.x) || !Number.isFinite(target.y)) {
-                throw new McpToolError('x/y must be finite numbers.');
-            }
-
-            const travel = Math.hypot(target.x - current.x, target.y - current.y);
-            const maxTravel = Number(config.get('mcpMaxJogDistance')) || DEFAULT_MAX_TRAVEL_MM;
-            if (travel > maxTravel) {
-                throw new McpToolError(`Requested travel ${travel.toFixed(1)} mm exceeds the ${maxTravel} mm `
-                    + 'per-call limit. Split the approach, or submit a gcode job.');
-            }
-
-            // Envelope check in machine coordinates when the build volume is known.
-            const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
-            const machineTarget = coordinateSystem === 'machine' ? target : {
-                x: target.x - before.originOffset.x,
-                y: target.y - before.originOffset.y,
-            };
-            if (size) {
-                if (machineTarget.x < -0.5 || machineTarget.x > size.x + 0.5
-                    || machineTarget.y < -0.5 || machineTarget.y > size.y + 0.5) {
-                    throw new McpToolError(`Target (machine ${machineTarget.x.toFixed(1)}, ${machineTarget.y.toFixed(1)}) `
-                        + `is outside the ${size.x}x${size.y} build area.`);
-                }
-            }
-
-            const channel = connectionManager.getCurrentChannel() as unknown as GcodeChannel;
-            if (!channel || typeof channel.executeGcode !== 'function') {
-                throw new McpToolError('The connected channel does not support direct moves.');
-            }
-
-            const move = `G0 X${target.x.toFixed(3)} Y${target.y.toFixed(3)} F${feedRate}`;
-            const gcode = coordinateSystem === 'machine' ? `G53;\n${move};\nG54;` : move;
-            const issuedAt = Date.now();
-            const executed = await channel.executeGcode(gcode);
-            if (executed.result !== 0) {
-                throw new McpToolError(`Move rejected by controller: ${executed.text || executed.result}`);
-            }
-
-            // Wait for a post-move heartbeat that reports the target, twice,
-            // so the returned position is what the firmware says, not what
-            // was commanded (#11).
-            let settled: PositionSnapshot | null = null;
-            let stableReports = 0;
-            let lastTimestamp = 0;
-            const deadline = issuedAt + SETTLE_TIMEOUT_MS;
-            while (Date.now() < deadline) {
-                await sleep(SETTLE_POLL_MS);
-                const now = getPositionSnapshot();
-                const reportTime = Date.now() - now.reportAgeMs;
-                if (reportTime <= issuedAt || reportTime === lastTimestamp) {
-                    continue; // not a fresh post-move report
-                }
-                lastTimestamp = reportTime;
-                const reported = coordinateSystem === 'work' ? now.work : now.machine;
-                if (reported.x !== null && reported.y !== null
-                    && Math.abs(reported.x - target.x) <= SETTLE_TOLERANCE_MM
-                    && Math.abs(reported.y - target.y) <= SETTLE_TOLERANCE_MM) {
-                    stableReports += 1;
-                    if (stableReports >= 2) {
-                        settled = now;
-                        break;
-                    }
-                } else {
-                    stableReports = 0;
-                }
-            }
-            if (!settled) {
-                const last = positionOrNull();
-                throw new McpToolError('Move did not settle at the target within '
-                    + `${SETTLE_TIMEOUT_MS / 1000}s. Last reported position: ${JSON.stringify(last && {
-                        work: last.work, machine: last.machine,
-                    })}`);
-            }
-
-            await sleep(POST_SETTLE_DWELL_MS);
-            const frame = await captureFrame();
-            const after = getPositionSnapshot();
-
-            return frameContent(frame, {
-                commanded: { ...target, coordinate_system: coordinateSystem, feed_rate: feedRate },
-                position: after,
-                note: 'position is firmware-reported after settling, not the commanded target',
-            });
-        },
+        handler: async (args: BoundedMoveArgs) => executeBoundedMoveAndCapture(args),
     });
 }


### PR DESCRIPTION
Closes #13. Top of the stack.

- Calibration store (`userDataDir/mcp-camera-calibration.json`, survives restarts): entries keyed by the **machine Y they were derived at** — the SM2 platform travels in Y, so a pixel→machine mapping is only valid at that Y — and record Z, since camera height changes scale. The mapping is a 2×2 matrix taking a pixel delta [du, dv] to the machine XY move [dx, dy] (mm) that cancels it; deriving it (rectification, parallax) stays the agent's job. `set_/get_/delete_camera_calibration`; get matches by id, nearest-Y within tolerance, or lists all.
- `visual_servo`: **one clamped correction step per call** (default 5 mm, hard cap 20 mm) through the same guarded single-move path as `move_and_capture` — the iteration loop lives in the calling agent, keeping every step a reviewable single action per #23. Auto-selects the nearest calibration by current machine Y; warns when the step itself moves Y (self-invalidating) or the calibration is off-key.

Verification: eslint/tsc clean; full production build; live endpoint test of the whole stack (see PR comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
