### PR TITLE
Feature: Workspace console verbose toggle with machine state and MCP activity

### DIFF
--- a/src/app/communication/socket-communication.ts
+++ b/src/app/communication/socket-communication.ts
@@ -71,6 +71,9 @@ class SocketCommunication {
         'machine:module-info': [],
         'machine:laser-status': [],
 
+        // MCP server activity (verbose console)
+        'mcp:activity': [],
+
         [SocketEvent.UploadFileProgress]: [],
         [SocketEvent.UploadFileCompressing]: [],
         [SocketEvent.UploadFileDecompressing]: [],

--- a/src/app/ui/widgets/Console/Console.jsx
+++ b/src/app/ui/widgets/Console/Console.jsx
@@ -45,6 +45,9 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
     const history = useHistory();
     const dispatch = useDispatch();
     const terminalRef = useRef();
+    // Verbose mode: also show machine heartbeat state and MCP tool activity
+    const verboseRef = useRef(false);
+    const lastVerboseLineRef = useRef('');
     const prevProps = usePrevious({
         isConnected, port, server, clearRenderStamp, consoleLogs, minimized, isDefault
     });
@@ -69,12 +72,68 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
             const terminal = terminalRef.current;
             terminal && terminal.writeln(data);
         },
-        [SocketEvent.ExecuteGCode]: ({ err, reply }) => {
+        [SocketEvent.ExecuteGCode]: ({ err, gcode, reply }) => {
+            // In verbose mode echo what was sent - the WiFi path has no
+            // serialport:write equivalent, so without this only the bare
+            // replies ("ok") appear with no hint of the commands behind them.
+            if (verboseRef.current && gcode) {
+                const terminal = terminalRef.current;
+                if (terminal) {
+                    String(gcode).split(/\r?\n/).forEach((line) => {
+                        line = line.trim();
+                        line && terminal.writeln(color.blackBright(`> ${line}`));
+                    });
+                    if (err) {
+                        terminal.writeln(color.red(`error (${err}) executing the above`));
+                    }
+                }
+            }
             if (!err) {
                 if (reply) {
                     const newLogs = [reply];
                     dispatch(workspaceActions.addConsoleLogs(newLogs));
                 }
+            }
+        },
+        // Heartbeat state, printed only in verbose mode and only on change
+        // (the heartbeat ticks ~1/s; repeating identical lines is noise).
+        'Marlin:state': (options) => {
+            if (!verboseRef.current) {
+                return;
+            }
+            const state = (options && options.state) || {};
+            const pos = state.pos || {};
+            const off = state.originOffset || {};
+            const fmt = (v) => (Number.isFinite(Number(v)) ? Number(v).toFixed(2) : '?');
+            const fmtMachine = (v, o) => (
+                Number.isFinite(Number(v)) && Number.isFinite(Number(o))
+                    ? (Number(v) - Number(o)).toFixed(2) : '?'
+            );
+            const b = pos.isFourAxis ? ` B${fmt(pos.b)}` : '';
+            const line = `pos work(${fmt(pos.x)}, ${fmt(pos.y)}, ${fmt(pos.z)})${b}`
+                + ` machine(${fmtMachine(pos.x, off.x)}, ${fmtMachine(pos.y, off.y)}, ${fmtMachine(pos.z, off.z)})`
+                + ` ${state.status || ''}`;
+            if (line === lastVerboseLineRef.current) {
+                return;
+            }
+            lastVerboseLineRef.current = line;
+            const terminal = terminalRef.current;
+            terminal && terminal.writeln(color.blackBright(line));
+        },
+        // MCP tool activity mirrored from the server (verbose mode)
+        'mcp:activity': (options) => {
+            if (!verboseRef.current) {
+                return;
+            }
+            const { tool, ok, durationMs, error } = options || {};
+            const terminal = terminalRef.current;
+            if (!terminal) {
+                return;
+            }
+            if (ok) {
+                terminal.writeln(color.cyan(`[mcp] ${tool} ok ${durationMs}ms`));
+            } else {
+                terminal.writeln(color.red(`[mcp] ${tool} failed ${durationMs}ms: ${String(error || '').slice(0, 160)}`));
             }
         }
     };
@@ -199,6 +258,15 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
             terminal && terminal.clear();
         },
 
+        toggleVerbose: () => {
+            verboseRef.current = !verboseRef.current;
+            lastVerboseLineRef.current = '';
+            const terminal = terminalRef.current;
+            terminal && terminal.writeln(color.yellow(verboseRef.current
+                ? 'Verbose on: showing machine state changes and MCP activity'
+                : 'Verbose off'));
+        },
+
         printConsoleLogs: (_consoleLogs) => {
             for (let consoleLog of _consoleLogs) {
                 if (consoleLog.endsWith('\n')) {
@@ -252,6 +320,12 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
     useEffect(() => {
         widgetActions.setTitle(i18n._('key-Workspace/Console-Console'));
         widgetActions.setControlButtons([
+            {
+                title: 'Verbose',
+                name: 'Information',
+                onClick: actions.toggleVerbose,
+                type: ['static']
+            },
             {
                 title: 'Eliminate',
                 name: 'Eliminate',

--- a/src/server/lib/SocketManager/index.ts
+++ b/src/server/lib/SocketManager/index.ts
@@ -81,6 +81,13 @@ class SocketServer extends EventEmitter {
         // this.events = [];
     }
 
+    /**
+     * Emit to every connected client (server-initiated notifications).
+     */
+    public broadcast = (eventName: string, options?: object) => {
+        this.io && this.io.emit(eventName, options);
+    };
+
     // established a new socket connection
     public onConnection = (socket) => {
         const address = socket.handshake.address;

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -75,7 +75,7 @@ function startServices(server) {
     // ===============
     // MCP server (off unless a port is configured)
     // ===============
-    startMcpService();
+    startMcpService(socketServer);
 }
 
 function registerApis(app) {

--- a/src/server/services/mcp/McpServer.ts
+++ b/src/server/services/mcp/McpServer.ts
@@ -56,10 +56,18 @@ export class McpServer {
 
     private serverVersion: string;
 
-    public constructor(registry: ToolRegistry, serverName: string, serverVersion: string) {
+    private onActivity: ((activity: object) => void) | null;
+
+    public constructor(
+        registry: ToolRegistry,
+        serverName: string,
+        serverVersion: string,
+        onActivity?: (activity: object) => void
+    ) {
         this.registry = registry;
         this.serverName = serverName;
         this.serverVersion = serverVersion;
+        this.onActivity = onActivity || null;
     }
 
     public handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): void => {
@@ -202,6 +210,7 @@ export class McpServer {
         try {
             const result = await this.registry.call(name, ((params && params.arguments) as object) || {});
             log.info(`tool ${name} ok in ${Date.now() - startedAt}ms`);
+            this.onActivity && this.onActivity({ tool: name, ok: true, durationMs: Date.now() - startedAt });
             // A tool that returns non-text content (e.g. an image) supplies
             // the MCP content array itself via mcpContent.
             const content = (result as { mcpContent?: object[] })?.mcpContent
@@ -215,6 +224,7 @@ export class McpServer {
             // calling the tool can read them.
             const text = err instanceof McpToolError ? err.message : `Tool failed: ${err.message}`;
             log.warn(`tool ${name} failed in ${Date.now() - startedAt}ms: ${text}`);
+            this.onActivity && this.onActivity({ tool: name, ok: false, durationMs: Date.now() - startedAt, error: text });
             return rpcResult(id, {
                 content: [{ type: 'text', text }],
                 isError: true,

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -35,7 +35,11 @@ function resolvePort(): number | null {
     return port;
 }
 
-export function startMcpService(): void {
+export interface McpBroadcaster {
+    broadcast: (eventName: string, options?: object) => void;
+}
+
+export function startMcpService(socketServer?: McpBroadcaster): void {
     if (httpServer) {
         return;
     }
@@ -52,7 +56,13 @@ export function startMcpService(): void {
     registerCameraTools(registry);
     registerCalibrationTools(registry);
 
-    const mcpServer = new McpServer(registry, 'snapmaker-luban', pkg.version);
+    // Mirror tool activity to connected UI clients so the Workspace console
+    // can show agent traffic (verbose toggle).
+    const onActivity = (activity: object) => {
+        socketServer && socketServer.broadcast('mcp:activity', activity);
+    };
+
+    const mcpServer = new McpServer(registry, 'snapmaker-luban', pkg.version, onActivity);
 
     httpServer = http.createServer((req, res) => {
         // Same trust boundary for every route: local processes only, and no


### PR DESCRIPTION
Closes #32. Stacked on the calibration/servo PR.

Verbose toggle on the Workspace console (Information icon in the widget header, off by default, state announced in the scrollback):

- **Heartbeat state**: position and status printed on change only — the heartbeat ticks ~1/s and repeating identical lines is noise. Both coordinate systems on one line: `pos work(…) machine(…) idle`, with B when the rotary reports.
- **MCP activity**: tool calls mirrored live from the server via a new `mcp:activity` broadcast (`SocketServer.broadcast`) — `[mcp] get_position ok 3ms` cyan, failures red with the error. Arguments are never shown (they can carry whole gcode files).

Server side this rides the same per-call point that writes the server log, so the two views can't disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
