### PR TITLE
Fix: Refuse socket.io handshakes during startup instead of parking them

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -85,6 +85,15 @@ const createServer = (options, callback) => {
             app(req, res);
             return;
         }
+        // socket.io handshakes must not be parked: on replay they would hit
+        // Express (404) because socket.io only attaches its own request
+        // interceptor once services start. A prompt 503 makes the client
+        // retry with backoff into the working server instead (issue #38).
+        if (req.url && req.url.startsWith('/socket.io/')) {
+            res.writeHead(503, { 'Retry-After': '2' });
+            res.end();
+            return;
+        }
         parked.push([req, res]);
     });
 


### PR DESCRIPTION
Fixes the operator-reported Workspace breakage in #38 within this stack; the proper home for the fix is the startup stack, and this commit drops out when it lands there.

During the bind-to-ready gap (~13 s cold), parked `/socket.io` handshakes were replayed into Express and 404'd — socket.io only attaches its request interceptor at `startServices` — so entering Workspace early broke the page and every reload until services finished. The parker now answers those requests 503 + `Retry-After` immediately; the socket.io client's built-in backoff then retries into the working server. Everything else still parks and replays as before.

Verified: build clean; handshake returns 200 once services are up (no regression). The in-gap 503 wasn't caught live — warm starts are faster than the probe — but the branch is a deterministic three-line guard ahead of parking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
