### PR TITLE
Feature: move_z - operator-confirmed direct Z move that persists

### DIFF
--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -24,11 +24,21 @@ export type McpJobState =
     | 'starting'
     | 'started'
     | 'start_failed'
-    | 'stopped';
+    | 'stopped'
+    | 'completed';
+
+/**
+ * 'file' runs through prepare_print/start_print (door interlock applies, and
+ * the firmware parks at the work origin on completion). 'direct' executes
+ * over execute_code on approval - it persists position but is NOT subject to
+ * the door interlock, so the confirm page says so and the operator supervises.
+ */
+export type McpJobKind = 'file' | 'direct';
 
 export interface McpJob {
     id: string;
     name: string;
+    kind: McpJobKind;
     headType: string;
     filePath: string;
     createdAt: number;
@@ -66,7 +76,7 @@ export class JobManager {
         return this.jobsDir;
     }
 
-    public submit(gcode: string, name: string, headType: string, validation: GcodeValidationReport): McpJob {
+    public submit(gcode: string, name: string, headType: string, validation: GcodeValidationReport, kind: McpJobKind = 'file'): McpJob {
         const id = crypto.randomBytes(6).toString('hex');
         const safeName = (name || 'job').replace(/[^\w.-]/g, '_').slice(0, 64);
         const filePath = path.join(this.ensureJobsDir(), `${id}_${safeName}.nc`);
@@ -75,6 +85,7 @@ export class JobManager {
         const job: McpJob = {
             id,
             name: safeName,
+            kind,
             headType,
             filePath,
             createdAt: Date.now(),
@@ -125,6 +136,7 @@ export class JobManager {
         return {
             id: job.id,
             name: job.name,
+            kind: job.kind,
             headType: job.headType,
             state: job.state,
             createdAt: job.createdAt,
@@ -210,10 +222,18 @@ export class JobManager {
             ? `<ul>${v.warnings.map((w) => `<li>${escapeHtml(w)}</li>`).join('')}</ul>`
             : '<p>None.</p>';
 
+        const directBanner = job.kind === 'direct'
+            ? `<p style="background:#fff3cd;border:1px solid #b8860b;padding:10px">
+                   <strong>DIRECT MOVE</strong>: on start this executes over the realtime path so the
+                   position <em>persists</em> - but it does NOT run as a job, so the enclosure door
+                   interlock does not apply. Supervise it.</p>`
+            : '';
+
         return `
-            <h2>Confirm G-code job: ${escapeHtml(job.name)}</h2>
+            <h2>Confirm ${job.kind === 'direct' ? 'DIRECT move' : 'G-code job'}: ${escapeHtml(job.name)}</h2>
             <p>Submitted by an agent over MCP. Review before approving - approval mints a
-               one-time code the agent needs to start the job.</p>
+               one-time code the agent needs to start it.</p>
+            ${directBanner}
             <table border="1" cellpadding="6" style="border-collapse:collapse">
                 <tr><td>Head</td><td>${escapeHtml(job.headType)}</td></tr>
                 <tr><td>Lines / motion lines</td><td>${v.lineCount} / ${v.motionLineCount}</td></tr>

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -22,7 +22,7 @@ const POST_SETTLE_DWELL_MS = 300;
 const HOME_TIMEOUT_MS = 120000;
 const HOME_POLL_MS = 1000;
 
-interface GcodeChannel {
+export interface GcodeChannel {
     executeGcode?: (gcode: string) => Promise<{ result: number; text?: string }>;
 }
 
@@ -31,7 +31,7 @@ interface GcodeChannel {
  * controller's reply) to the UI console, so the operator can see which
  * coordinate frame every MCP-issued command ran in.
  */
-async function sendGcodeVisible(channel: GcodeChannel, tool: string, gcode: string): Promise<{ result: number; text?: string }> {
+export async function sendGcodeVisible(channel: GcodeChannel, tool: string, gcode: string): Promise<{ result: number; text?: string }> {
     mcpBroadcast('mcp:gcode', { tool, gcode });
     const executed = await channel.executeGcode(gcode);
     mcpBroadcast('mcp:gcode', { tool, response: executed.text || (executed.result === 0 ? 'ok' : `result=${executed.result}`) });

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -1,9 +1,13 @@
 /* eslint-disable camelcase */
 // MCP tool arguments are snake_case by convention.
+import * as fs from 'fs-extra';
+
 import { connectionManager } from '../../machine/ConnectionManager';
 import { jobManager } from '../jobs';
 import { McpToolError, ToolRegistry } from '../registry';
 import { validateGcode } from '../validator';
+import { GcodeChannel, sendGcodeVisible } from './camera';
+import { PositionSnapshot, getMachineSizeByIdentifier, getPositionSnapshot } from './machine';
 
 // Motion policy (#23): compound motion leaves this process only as a G-code
 // file submitted through the same prepare/start path as "Start on Luban",
@@ -14,6 +18,7 @@ import { validateGcode } from '../validator';
 const HEAD_TYPES = ['cnc', 'laser', 'printing'];
 
 interface JobChannel {
+    executeGcode?: (gcode: string) => Promise<{ result: number; text?: string }>;
     uploadGcodeFile?: (filePath: string, type: string, renderName: string, callback: (msg: unknown, data?: unknown) => void) => void;
     startGcodeJob?: () => Promise<{ ok: boolean; code?: number; text?: string }>;
     stopGcodeJob?: () => Promise<{ ok: boolean; code?: number; text?: string }>;
@@ -28,6 +33,34 @@ function getJobChannel(): JobChannel {
         throw new McpToolError('The connected channel does not support file job submission.');
     }
     return channel;
+}
+
+/**
+ * Wait for two consecutive identical heartbeats fresher than issuedAt, so a
+ * direct move's returned position is settled firmware truth.
+ */
+async function waitForStableHeartbeat(issuedAt: number): Promise<PositionSnapshot | null> {
+    const deadline = issuedAt + 30000;
+    let previous: string | null = null;
+    while (Date.now() < deadline) {
+        await new Promise((resolve) => {
+            setTimeout(resolve, 500);
+        });
+        let now: PositionSnapshot;
+        try {
+            now = getPositionSnapshot();
+        } catch (err) {
+            continue;
+        }
+        const reportTime = Date.now() - now.reportAgeMs;
+        const fingerprint = JSON.stringify([now.work, now.originOffset]);
+        const stable = fingerprint === previous;
+        previous = fingerprint;
+        if (reportTime > issuedAt && stable && now.machineStatus === 'idle') {
+            return now;
+        }
+    }
+    return null;
 }
 
 function machineStatus(): string | null {
@@ -130,6 +163,29 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 throw new McpToolError(verdict.reason || 'Confirmation failed.');
             }
 
+            if (job.kind === 'direct') {
+                // Direct moves execute over the realtime path so position
+                // PERSISTS - the firmware parks back at the work origin when
+                // a file job completes, so a file job cannot hold a Z. The
+                // operator approved exactly this gcode on the confirm page.
+                job.state = 'starting';
+                job.startedAt = Date.now();
+                const gcodeText = fs.readFileSync(job.filePath, 'utf8');
+                const executed = await sendGcodeVisible(channel as GcodeChannel, `direct:${job.name}`, gcodeText);
+                if (executed.result !== 0) {
+                    job.state = 'start_failed';
+                    job.error = `Controller rejected the move: ${executed.text || executed.result}`;
+                    throw new McpToolError(job.error);
+                }
+                const position = await waitForStableHeartbeat(job.startedAt);
+                job.state = 'completed';
+                return {
+                    job: jobManager.describe(job),
+                    position,
+                    note: 'Direct move executed and settled; the position persists (no end-of-job park).',
+                };
+            }
+
             job.state = 'starting';
             const uploadError = await new Promise<string | null>((resolve) => {
                 channel.uploadGcodeFile(job.filePath, job.headType, `${job.name}.nc`, (msg) => {
@@ -155,6 +211,88 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 job: jobManager.describe(job),
                 note: 'Job started. Poll get_gcode_job_status; the controller, its door interlock '
                     + 'and the machine UI remain in control.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'move_z',
+        description: 'Request a SINGLE absolute Z move, executed on the direct path so the position '
+            + 'PERSISTS (file jobs park back at the work origin when they complete - firmware '
+            + 'behaviour). Every request goes to the operator confirm page showing current Z, '
+            + 'target, delta and feed; only their one-time code executes it. NOT door-interlocked - '
+            + 'the operator supervises. Spindle must be off; the toolhead always carries a tool.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                z: { type: 'number', description: 'Absolute target Z.' },
+                coordinate_system: {
+                    type: 'string',
+                    enum: ['work', 'machine'],
+                    description: 'Which frame z is in. Default work.',
+                },
+                feed_rate: { type: 'number', description: 'mm/min, default 300, max 600.' },
+                reason: { type: 'string', description: 'Shown to the operator: why this Z move is needed.' },
+            },
+            required: ['z', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { z?: number; coordinate_system?: string; feed_rate?: number; reason?: string }) => {
+            const targetZ = Number(args.z);
+            if (!Number.isFinite(targetZ)) {
+                throw new McpToolError('z must be a finite number.');
+            }
+            const coordinateSystem = args.coordinate_system || 'work';
+            if (!['work', 'machine'].includes(coordinateSystem)) {
+                throw new McpToolError('coordinate_system must be "work" or "machine".');
+            }
+            const feedRate = Math.min(Math.max(Number(args.feed_rate) || 300, 50), 600);
+
+            const position = getPositionSnapshot();
+            if (position.machineStatus !== 'idle') {
+                throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);
+            }
+            if (position.isHomed !== true) {
+                throw new McpToolError('Machine does not report homed; home before any Z positioning.');
+            }
+            const state = connectionManager.getLatestMachineState() as { headStatus?: unknown; headPower?: unknown } | null;
+            const headPower = Number(state && state.headPower);
+            if ((Number.isFinite(headPower) && headPower > 0) || (state && (state.headStatus === true || state.headStatus === 'on'))) {
+                throw new McpToolError('Toolhead appears to be on; refusing to move Z.');
+            }
+
+            const currentZ = coordinateSystem === 'work' ? position.work.z : position.machine.z;
+            if (currentZ === null) {
+                throw new McpToolError('Current Z unknown; cannot describe the move to the operator.');
+            }
+            const machineTargetZ = coordinateSystem === 'machine' ? targetZ : targetZ - position.originOffset.z;
+            const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+            if (size && (machineTargetZ < -1 || machineTargetZ > size.z + 40)) {
+                throw new McpToolError(`Target (machine Z ${machineTargetZ.toFixed(1)}) is outside the `
+                    + `0..${size.z} travel.`);
+            }
+
+            const move = `G1 Z${targetZ.toFixed(3)} F${feedRate}`;
+            const gcode = coordinateSystem === 'machine'
+                ? `G90\nG53;\n${move};\nG54;`
+                : `G90\n${move}`;
+            const delta = targetZ - currentZ;
+            const name = `z-move ${coordinateSystem} Z${targetZ.toFixed(1)} (${delta >= 0 ? '+' : ''}${delta.toFixed(1)}mm) - ${String(args.reason).slice(0, 40)}`;
+
+            const validation = validateGcode(gcode);
+            const job = jobManager.submit(gcode, name, 'cnc', validation, 'direct');
+
+            return {
+                job: jobManager.describe(job),
+                current_z: currentZ,
+                target_z: targetZ,
+                delta_mm: delta,
+                feed_rate: feedRate,
+                coordinate_system: coordinateSystem,
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url, review the DIRECT-move banner '
+                    + '(current Z, target, delta, feed), and approve. Their one-time code passed to '
+                    + 'start_gcode_job executes the move; the position then persists.',
             };
         },
     });


### PR DESCRIPTION
Hardware finding (operator's agent, confirmed by M114 + frame): **the firmware parks back at the work origin when a `prepare_print`/`start_print` job completes** — no Luban-side footer; controller behaviour. So the interlocked file path cannot hold a working Z for calibration/servoing, and the only persisting path is the direct one, which the standing operator rule reserves: *no Z without direct request and careful consideration of position, delta and movement rate*.

`move_z` operationalises the rule rather than bypassing it:

- SINGLE absolute Z move; spindle off, homed, idle, travel-envelope-checked, feed capped at 600 mm/min.
- Staged through the same browser confirm page as jobs — now with a **DIRECT MOVE banner** stating plainly that the door interlock does not apply and the operator supervises — showing current Z, target, **delta**, feed, and the agent's required `reason`.
- Only the operator's one-time code executes it (`start_gcode_job`); the model cannot self-authorise. Result waits for two stable heartbeats and returns the persisted position.
- Jobs gain `kind: file|direct` and a `completed` state; the mirror console shows the exact gcode as `[mcp:direct:…]`.

Not yet built into dist (operator session live); next quiet window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)