### PR TITLE
Improvement: Frame-reading guidance and expected tool region on captures

### DIFF
--- a/.claude/skills/cnc-visual-alignment/SKILL.md
+++ b/.claude/skills/cnc-visual-alignment/SKILL.md
@@ -120,6 +120,30 @@ Z positioning is not part of the servo: raise or lower Z via a one-line `submit_
 through the operator's confirm page. Refuse to servo from a height where parallax exceeds
 the tolerance you are claiming.
 
+## Reading a toolhead-camera frame (hardware-learned, the hard way)
+
+Two live-session failures came from misreading frames, not from geometry. Both are avoidable:
+
+**Identify by evidence, not by remembered composition.** Never assert "no board in view"
+because the frame fails to match a reference framing you were *told about* but do not have.
+Describe what IS in the frame and test it against context. On this machine the calibration
+board is a **yellow-brown surface with a printed black grid and alphanumeric cell labels
+(C1, L1, ...)** — a labeled coordinate grid is a calibration board, not a "cutting mat",
+however mat-like its colour. If you have no reference image, say so and reason from content.
+
+**The rig-mounted vs scene heuristic.** Anything whose frame position is **invariant across
+machine moves** is mounted to the same assembly as the camera — the endmill, the spindle
+housing — not part of the scene. Scene content (board, rail, bed) visibly shifts between
+captures. You always have multiple position-stamped frames; cross-reference before guessing.
+
+**The endmill's visual signature.** For a toolhead-mounted camera the tool sits millimetres
+from the lens: it images as an **oversized, extremely defocused shape entering from a frame
+edge at a fixed orientation** (here: from the bottom edge ~2/3 along, pointing diagonally
+toward top-left, ~20 % of frame height). That blur is diagnostic of near-lens distance —
+categorically different from the resolvable distance-blur of the scene. `capture_frame`
+reports the operator-configured `expectedToolRegion` box with every frame — check it before
+concluding anything about "an unidentified blurry shape".
+
 ## Datums: check the landmark is actually in frame
 
 A stated datum is worthless if it is outside the field of view. Verify visually before

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -44,6 +44,25 @@ async function sleep(ms: number): Promise<void> {
     });
 }
 
+/**
+ * The camera-to-spindle offset is fixed hardware geometry, so where the
+ * endmill images is a constant of the rig, not something to re-discover by
+ * vision each frame. The operator records it once in configstore
+ * mcpToolRegion (fractional box {u0,v0,u1,v1}, optional note) and every
+ * frame carries it - turning tool identification into a lookup.
+ */
+function expectedToolRegion(): object | null {
+    const raw = config.get('mcpToolRegion');
+    if (!raw) {
+        return null;
+    }
+    try {
+        return typeof raw === 'string' ? JSON.parse(raw) : (raw as object);
+    } catch (err) {
+        return null;
+    }
+}
+
 function frameContent(frame: CapturedFrame, meta: object): object {
     return {
         mcpContent: [
@@ -56,6 +75,7 @@ function frameContent(frame: CapturedFrame, meta: object): object {
                         provider: frame.provider,
                         device: frame.device,
                         capturedAt: frame.capturedAt,
+                        expectedToolRegion: expectedToolRegion(),
                     },
                 }),
             },


### PR DESCRIPTION
Driven by two live frame misreads that cost a blind 80 mm descent: the driving agent dismissed the calibration board as a 'cutting mat' (matching against a remembered composition it never had) and never identified the endmill (near-lens blur read as noise).

- **Skill**: new *Reading a toolhead-camera frame* section — identify by evidence, never assert absence against a reference you don't hold; the rig-mounted-vs-scene heuristic (frame-position invariance across machine moves = camera-mounted); the endmill's diagnostic near-lens blur signature with its fixed entry edge/orientation.
- **MCP**: `capture_frame` (and every frame-returning tool) now reports `expectedToolRegion` — an operator-configured fractional box (configstore `mcpToolRegion`) derived from the fixed camera-to-spindle geometry, so tool identification is a lookup, not vision. Initial approximate box recorded from the operator's description; refine against a frame.

Also proven this session on hardware: `move_z` end-to-end (multiple operator-confirmed descents to work Z −80, positions persisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)