### PR TITLE
Improvement: Field fixes - jacobian check, tolerances, tool region, camera, batch Z

### DIFF
--- a/src/app/ui/widgets/Console/Console.jsx
+++ b/src/app/ui/widgets/Console/Console.jsx
@@ -145,7 +145,12 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
                 });
             }
             if (response) {
-                terminal.writeln(color.magenta(`${stamp()}[mcp:${tool}] < ${String(response).slice(0, 200)}`));
+                // Controller replies (e.g. M114 reports) are multi-line; one
+                // writeln with embedded newlines renders misaligned in xterm.
+                String(response).slice(0, 400).split(/\r?\n/).forEach((line) => {
+                    line = line.trim();
+                    line && terminal.writeln(color.magenta(`${stamp()}[mcp:${tool}] < ${line}`));
+                });
             }
         },
         // MCP tool activity mirrored from the server (verbose mode)

--- a/src/server/services/mcp/camera.ts
+++ b/src/server/services/mcp/camera.ts
@@ -126,6 +126,11 @@ async function captureViaHttp(url: string): Promise<CapturedFrame> {
 }
 
 async function captureViaFfmpeg(): Promise<CapturedFrame> {
+    // Device choice is sticky: enumeration order is not stable across
+    // restarts, and a capture that silently falls back to a different
+    // (possibly dead virtual) camera is worse than an error. The last
+    // device that produced a frame is remembered and preferred; a missing
+    // device is an error, never a substitution.
     let device = config.get('mcpCameraDevice');
     if (!device) {
         const { devices } = await listCameras();
@@ -133,19 +138,39 @@ async function captureViaFfmpeg(): Promise<CapturedFrame> {
             throw new McpToolError('No DirectShow video devices found. Set configstore key mcpCameraDevice, '
                 + 'or mcpCameraUrl for an HTTP snapshot source.');
         }
-        device = devices[0];
+        const lastGood = config.get('mcpCameraLastGood');
+        if (lastGood && devices.includes(String(lastGood))) {
+            device = lastGood;
+        } else if (lastGood) {
+            throw new McpToolError(`The last working camera ("${lastGood}") is not in the current device list `
+                + `(${devices.join(', ')}). Re-plug it and retry, or set mcpCameraDevice explicitly - refusing `
+                + 'to silently substitute a different device.');
+        } else {
+            device = devices[0];
+        }
     }
 
     const outPath = path.join(DataStorage.tmpDir, `mcp-frame-${crypto.randomBytes(4).toString('hex')}.jpg`);
     try {
-        const { code, stderr } = await runFfmpeg([
+        const ffmpegArgs = [
             '-hide_banner', '-loglevel', 'error',
             '-f', 'dshow', '-i', `video=${device}`,
             '-frames:v', '1', '-f', 'image2', '-y', outPath,
-        ]);
+        ];
+        let { code, stderr } = await runFfmpeg(ffmpegArgs);
         if (code !== 0 || !fs.existsSync(outPath)) {
-            throw new McpToolError(`ffmpeg capture failed: ${stderr.split(/\r?\n/).filter(Boolean).slice(-2).join(' ')}`);
+            // One retry after a beat: first-open flakiness on USB cameras is
+            // real and transient; a different device is never substituted.
+            await new Promise((resolve) => {
+                setTimeout(resolve, 1200);
+            });
+            ({ code, stderr } = await runFfmpeg(ffmpegArgs));
         }
+        if (code !== 0 || !fs.existsSync(outPath)) {
+            throw new McpToolError(`ffmpeg capture from "${device}" failed after retry: `
+                + `${stderr.split(/\r?\n/).filter(Boolean).slice(-2).join(' ')}`);
+        }
+        config.set('mcpCameraLastGood', String(device));
         const body = await fs.readFile(outPath);
         return {
             frameId: cacheFrame(body),

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -54,6 +54,9 @@ export interface McpJob {
     // steps and the series can be abandoned at any point.
     steps?: string[];
     nextStep?: number;
+    // Staged default for direct execution: whether start_gcode_job should
+    // block until the move verifiably settles (call-time arg overrides).
+    waitUntilMoved?: boolean;
 }
 
 function escapeHtml(text: string): string {

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -49,6 +49,11 @@ export interface McpJob {
     tokenUsed: boolean;
     startedAt: number | null;
     error: string | null;
+    // Batch direct jobs: the operator approved this exact list; each
+    // start_gcode_job call executes ONE step, so captures can happen between
+    // steps and the series can be abandoned at any point.
+    steps?: string[];
+    nextStep?: number;
 }
 
 function escapeHtml(text: string): string {
@@ -76,7 +81,7 @@ export class JobManager {
         return this.jobsDir;
     }
 
-    public submit(gcode: string, name: string, headType: string, validation: GcodeValidationReport, kind: McpJobKind = 'file'): McpJob {
+    public submit(gcode: string, name: string, headType: string, validation: GcodeValidationReport, kind: McpJobKind = 'file', steps?: string[]): McpJob {
         const id = crypto.randomBytes(6).toString('hex');
         const safeName = (name || 'job').replace(/[^\w.-]/g, '_').slice(0, 64);
         const filePath = path.join(this.ensureJobsDir(), `${id}_${safeName}.nc`);
@@ -96,6 +101,8 @@ export class JobManager {
             tokenUsed: false,
             startedAt: null,
             error: null,
+            steps,
+            nextStep: steps ? 0 : undefined,
         };
         this.jobs.set(id, job);
         this.prune();
@@ -143,6 +150,8 @@ export class JobManager {
             approvedAt: job.approvedAt,
             startedAt: job.startedAt,
             error: job.error,
+            totalSteps: job.steps ? job.steps.length : undefined,
+            nextStep: job.steps ? job.nextStep : undefined,
             validation: job.validation,
         };
     }

--- a/src/server/services/mcp/tools/calibration.ts
+++ b/src/server/services/mcp/tools/calibration.ts
@@ -13,6 +13,9 @@ import { getPositionSnapshot } from './machine';
 const DEFAULT_STEP_LIMIT_MM = 5;
 const MAX_STEP_LIMIT_MM = 20;
 const DEFAULT_Y_TOLERANCE_MM = 2;
+// Auto-select gives up only beyond this - a single servo step routinely
+// drifts Y by 2-6mm, so the old hard 2mm cutoff forced explicit ids.
+const MAX_Y_DISTANCE_MM = 25;
 
 function isMatrix(value: unknown): value is [[number, number], [number, number]] {
     return Array.isArray(value) && value.length === 2
@@ -52,11 +55,20 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
                     maxItems: 2,
                 },
                 notes: { type: 'string', description: 'Free-form provenance: grid used, residuals, tilt.' },
+                jacobian: {
+                    type: 'array',
+                    description: 'Optional 2x2 forward Jacobian J (pixel shift per mm) you fitted. When '
+                        + 'given, the tool checks M.J against +identity and REJECTS a sign-flipped matrix '
+                        + 'before it can reach hardware.',
+                    items: { type: 'array', items: { type: 'number' }, minItems: 2, maxItems: 2 },
+                    minItems: 2,
+                    maxItems: 2,
+                },
             },
             required: ['valid_at_y', 'z', 'matrix'],
             additionalProperties: false,
         },
-        handler: async (args: { valid_at_y?: number; z?: number; matrix?: unknown; notes?: string }) => {
+        handler: async (args: { valid_at_y?: number; z?: number; matrix?: unknown; notes?: string; jacobian?: unknown }) => {
             const validAtY = Number(args.valid_at_y);
             const z = Number(args.z);
             if (!Number.isFinite(validAtY) || !Number.isFinite(z)) {
@@ -65,13 +77,39 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
             if (!isMatrix(args.matrix)) {
                 throw new McpToolError('matrix must be a 2x2 array of numbers.');
             }
+
+            const warnings: string[] = [];
+            if (args.jacobian !== undefined) {
+                if (!isMatrix(args.jacobian)) {
+                    throw new McpToolError('jacobian must be a 2x2 array of numbers.');
+                }
+                // P = M.J should be +identity: -identity is the sign flip that
+                // drives the servo away from the target - reject it outright.
+                const m = args.matrix;
+                const j = args.jacobian;
+                const p = [
+                    [m[0][0] * j[0][0] + m[0][1] * j[1][0], m[0][0] * j[0][1] + m[0][1] * j[1][1]],
+                    [m[1][0] * j[0][0] + m[1][1] * j[1][0], m[1][0] * j[0][1] + m[1][1] * j[1][1]],
+                ];
+                const devPlus = Math.max(Math.abs(p[0][0] - 1), Math.abs(p[1][1] - 1), Math.abs(p[0][1]), Math.abs(p[1][0]));
+                const devMinus = Math.max(Math.abs(p[0][0] + 1), Math.abs(p[1][1] + 1), Math.abs(p[0][1]), Math.abs(p[1][0]));
+                if (devMinus < devPlus && devMinus < 0.5) {
+                    throw new McpToolError('REJECTED: matrix is sign-flipped - M.J is approximately -identity, '
+                        + 'so every correction would drive AWAY from the target. Store M = +J^-1, not -J^-1.');
+                }
+                if (devPlus > 0.25) {
+                    warnings.push(`M.J deviates from identity (max residual ${devPlus.toFixed(2)}) - the matrix `
+                        + 'may be inaccurate; expect slow or wandering convergence.');
+                }
+            }
+
             const entry = calibrationStore.add({
                 validAtY,
                 z,
                 matrix: args.matrix,
                 notes: args.notes ? String(args.notes) : null,
             });
-            return { entry: describeEntry(entry) };
+            return { entry: describeEntry(entry), warnings };
         },
     });
 
@@ -192,9 +230,9 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
                 }
                 entryDistance = Math.abs(entry.validAtY - position.machine.y);
             } else {
-                const match = calibrationStore.findNearest(position.machine.y, DEFAULT_Y_TOLERANCE_MM);
+                const match = calibrationStore.findNearest(position.machine.y, MAX_Y_DISTANCE_MM);
                 if (!match) {
-                    throw new McpToolError(`No calibration within ${DEFAULT_Y_TOLERANCE_MM} mm of machine Y `
+                    throw new McpToolError(`No calibration within ${MAX_Y_DISTANCE_MM} mm of machine Y `
                         + `${position.machine.y.toFixed(1)}. Store one with set_camera_calibration, or pass calibration_id.`);
                 }
                 entry = match.entry;

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -258,6 +258,43 @@ export function registerCameraTools(registry: ToolRegistry): void {
     });
 
     registry.register({
+        name: 'set_tool_region',
+        description: 'Update the expectedToolRegion that every capture reports: the fractional box '
+            + 'where the endmill images (fixed camera-to-spindle geometry). Refine it from live '
+            + 'frames instead of round-tripping through configuration edits. Persists.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                u0: { type: 'number' },
+                v0: { type: 'number' },
+                u1: { type: 'number' },
+                v1: { type: 'number' },
+                note: { type: 'string', description: 'Provenance: how the box was determined.' },
+            },
+            required: ['u0', 'v0', 'u1', 'v1'],
+            additionalProperties: false,
+        },
+        handler: async (args: { u0?: number; v0?: number; u1?: number; v1?: number; note?: string }) => {
+            const box = [args.u0, args.v0, args.u1, args.v1].map(Number);
+            if (box.some((value) => !Number.isFinite(value) || value < 0 || value > 1)) {
+                throw new McpToolError('u0/v0/u1/v1 must be fractions in [0, 1].');
+            }
+            if (box[0] >= box[2] || box[1] >= box[3]) {
+                throw new McpToolError('Require u0 < u1 and v0 < v1.');
+            }
+            const region = {
+                u0: box[0],
+                v0: box[1],
+                u1: box[2],
+                v1: box[3],
+                note: args.note ? String(args.note) : undefined,
+            };
+            config.set('mcpToolRegion', region);
+            return { stored: region };
+        },
+    });
+
+    registry.register({
         name: 'track_feature',
         description: 'Template-match a patch between two cached frames (by the frameId each capture '
             + 'reports): give the pixel of a feature in one frame and get its measured pixel in the '

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -423,6 +423,8 @@ export function registerCameraTools(registry: ToolRegistry): void {
             // (offset zeroed) before G54 reselects workspace 0, and returning
             // that transient produced a nonsense snapshot on hardware.
             const deadline = issuedAt + HOME_TIMEOUT_MS;
+            const initialFingerprint = JSON.stringify([before.work, before.originOffset]);
+            let sawChange = false;
             let previous: string | null = null;
             while (Date.now() < deadline) {
                 await sleep(HOME_POLL_MS);
@@ -434,7 +436,15 @@ export function registerCameraTools(registry: ToolRegistry): void {
                 const fingerprint = JSON.stringify([now.work, now.originOffset]);
                 const stable = fingerprint === previous;
                 previous = fingerprint;
-                if (reportTime > issuedAt && stable && now.isHomed === true && now.machineStatus === 'idle') {
+                if (fingerprint !== initialFingerprint) {
+                    sawChange = true;
+                }
+                // The heartbeat lags ~1s, so two identical post-issue beats can
+                // both predate the motion. Require the position to have moved
+                // off its pre-G28 value at least once - homing always travels -
+                // before accepting stability (or 25s, if it started at home).
+                const changeOk = sawChange || Date.now() - issuedAt > 25000;
+                if (reportTime > issuedAt && stable && changeOk && now.isHomed === true && now.machineStatus === 'idle') {
                     return {
                         homed: true,
                         position: now,

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -120,6 +120,7 @@ export interface BoundedMoveArgs {
     coordinate_system?: string;
     feed_rate?: number;
     operator_confirmed_clearance?: boolean;
+    wait_until_moved?: boolean;
     // Internal (not exposed in any tool schema): lifts the per-call travel
     // limit for fixed, operator-set destinations like the work origin.
     unbounded_travel?: boolean;
@@ -186,6 +187,18 @@ export async function executeBoundedMoveAndCapture(args: BoundedMoveArgs): Promi
     const executed = await sendGcodeVisible(channel, 'move', gcode);
     if (executed.result !== 0) {
         throw new McpToolError(`Move rejected by controller: ${executed.text || executed.result}`);
+    }
+
+    if (args.wait_until_moved === false) {
+        // Fire-and-return: no settle, no capture - the frame would not show
+        // the commanded position. Poll get_position before relying on it.
+        return {
+            commanded: { ...target, coordinate_system: coordinateSystem, feed_rate: feedRate },
+            position: null,
+            position_verified: false,
+            note: 'wait_until_moved was false: move accepted but not awaited, and no frame was '
+                + 'captured (it would not show the commanded position). Poll get_position.',
+        };
     }
 
     // Wait for a post-move heartbeat that reports the target, twice,
@@ -389,8 +402,19 @@ export function registerCameraTools(registry: ToolRegistry): void {
             + 'fitted, G28 also homes B - stock indexed on the rotary WILL rotate (observed -45 to 0 '
             + 'on hardware); warn the operator first. Requires an idle machine with the toolhead '
             + 'off. Waits for the firmware to report homed.',
-        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
-        handler: async () => {
+        inputSchema: {
+            type: 'object',
+            properties: {
+                wait_until_moved: {
+                    type: 'boolean',
+                    description: 'Default true: block ~15-20s until the firmware reports homed and '
+                        + 'settled. false returns right after G28 is accepted - poll get_position '
+                        + 'for isHomed before any motion.',
+                },
+            },
+            additionalProperties: false,
+        },
+        handler: async (args: { wait_until_moved?: boolean }) => {
             const before = getPositionSnapshot();
             if (before.machineStatus !== 'idle') {
                 throw new McpToolError(`Machine is ${before.machineStatus || 'in an unknown state'}, not idle.`);
@@ -414,6 +438,16 @@ export function registerCameraTools(registry: ToolRegistry): void {
             const executed = await sendGcodeVisible(channel, 'home', 'G53;\nG28;\nG54;');
             if (executed.result !== 0) {
                 throw new McpToolError(`Homing rejected by controller: ${executed.text || executed.result}`);
+            }
+
+            if (args.wait_until_moved === false) {
+                return {
+                    homed: null,
+                    position_verified: false,
+                    note: 'wait_until_moved was false: G28 accepted but not awaited (homing takes '
+                        + '~15-20s). Poll get_position until isHomed is true and the position is '
+                        + 'stable before any motion.',
+                };
             }
 
             // Homing on the A350 takes tens of seconds; wait for TWO
@@ -476,10 +510,16 @@ export function registerCameraTools(registry: ToolRegistry): void {
                     description: 'Set true ONLY when the human operator has explicitly confirmed the '
                         + 'current Z and an obstacle-free path at this Z; skips the homed-first requirement.',
                 },
+                wait_until_moved: {
+                    type: 'boolean',
+                    description: 'Default true: settle at the origin and capture there. false returns '
+                        + 'right after the controller accepts the move - no settle, no frame; poll '
+                        + 'get_position afterwards.',
+                },
             },
             additionalProperties: false,
         },
-        handler: async (args: { feed_rate?: number; operator_confirmed_clearance?: boolean }) => {
+        handler: async (args: { feed_rate?: number; operator_confirmed_clearance?: boolean; wait_until_moved?: boolean }) => {
             // The work origin is a fixed, operator-set destination, so the
             // per-call travel limit (meant to bound the blast radius of a
             // wrong coordinate) does not apply; every other guard does.
@@ -489,6 +529,7 @@ export function registerCameraTools(registry: ToolRegistry): void {
                 coordinate_system: 'work',
                 feed_rate: args.feed_rate,
                 operator_confirmed_clearance: args.operator_confirmed_clearance,
+                wait_until_moved: args.wait_until_moved,
                 unbounded_travel: true,
             });
         },
@@ -516,6 +557,12 @@ export function registerCameraTools(registry: ToolRegistry): void {
                     type: 'boolean',
                     description: 'Set true ONLY when the human operator has explicitly confirmed the '
                         + 'current Z and an obstacle-free path at this Z; skips the homed-first requirement.',
+                },
+                wait_until_moved: {
+                    type: 'boolean',
+                    description: 'Default true: settle at the target and capture there. false returns '
+                        + 'right after the controller accepts the move - no settle, NO FRAME, '
+                        + 'position_verified: false; poll get_position afterwards.',
                 },
             },
             additionalProperties: false,

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -121,6 +121,7 @@ export interface BoundedMoveArgs {
     feed_rate?: number;
     operator_confirmed_clearance?: boolean;
     wait_until_moved?: boolean;
+    capture?: boolean;
     // Internal (not exposed in any tool schema): lifts the per-call travel
     // limit for fixed, operator-set destinations like the work origin.
     unbounded_travel?: boolean;
@@ -169,10 +170,14 @@ export async function executeBoundedMoveAndCapture(args: BoundedMoveArgs): Promi
         y: target.y - before.originOffset.y,
     };
     if (size) {
-        if (machineTarget.x < -0.5 || machineTarget.x > size.x + 0.5
-                    || machineTarget.y < -0.5 || machineTarget.y > size.y + 0.5) {
+        // Floors allow real overtravel: the A350 X home switch sits at
+        // machine -19, so "keep the current X while parked at home" must
+        // pass (a target at the machine's own resting position was being
+        // rejected live). Matches the position-sanity bounds.
+        if (machineTarget.x < -25 || machineTarget.x > size.x + 40
+                    || machineTarget.y < -25 || machineTarget.y > size.y + 40) {
             throw new McpToolError(`Target (machine ${machineTarget.x.toFixed(1)}, ${machineTarget.y.toFixed(1)}) `
-                        + `is outside the ${size.x}x${size.y} build area.`);
+                        + `is outside the ${size.x}x${size.y} build area (overtravel allowance -25..+40).`);
         }
     }
 
@@ -238,12 +243,21 @@ export async function executeBoundedMoveAndCapture(args: BoundedMoveArgs): Promi
     }
 
     await sleep(POST_SETTLE_DWELL_MS);
+    if (args.capture === false) {
+        return {
+            commanded: { ...target, coordinate_system: coordinateSystem, feed_rate: feedRate },
+            position: getPositionSnapshot(),
+            position_verified: true,
+            note: 'position is firmware-reported after settling; capture was false so no frame was taken',
+        };
+    }
     const frame = await captureFrame();
     const after = getPositionSnapshot();
 
     return frameContent(frame, {
         commanded: { ...target, coordinate_system: coordinateSystem, feed_rate: feedRate },
         position: after,
+        position_verified: true,
         note: 'position is firmware-reported after settling, not the commanded target',
     });
 }
@@ -563,6 +577,12 @@ export function registerCameraTools(registry: ToolRegistry): void {
                     description: 'Default true: settle at the target and capture there. false returns '
                         + 'right after the controller accepts the move - no settle, NO FRAME, '
                         + 'position_verified: false; poll get_position afterwards.',
+                },
+                capture: {
+                    type: 'boolean',
+                    description: 'Default true. false still settles and verifies the position but '
+                        + 'skips the frame - a plain verified move. (The XY travel cap per call is '
+                        + 'the configstore key mcpMaxJogDistance, default 100mm.)',
                 },
             },
             additionalProperties: false,

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -168,16 +168,38 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 // PERSISTS - the firmware parks back at the work origin when
                 // a file job completes, so a file job cannot hold a Z. The
                 // operator approved exactly this gcode on the confirm page.
+                // For a batch, each call executes ONE approved step; the
+                // token stays valid for the remaining steps (within its TTL).
                 job.state = 'starting';
-                job.startedAt = Date.now();
-                const gcodeText = fs.readFileSync(job.filePath, 'utf8');
+                const issuedAt = Date.now();
+                job.startedAt = job.startedAt || issuedAt;
+                const isBatch = Array.isArray(job.steps) && job.steps.length > 0;
+                const gcodeText = isBatch
+                    ? job.steps[job.nextStep]
+                    : fs.readFileSync(job.filePath, 'utf8');
                 const executed = await sendGcodeVisible(channel as GcodeChannel, `direct:${job.name}`, gcodeText);
                 if (executed.result !== 0) {
                     job.state = 'start_failed';
                     job.error = `Controller rejected the move: ${executed.text || executed.result}`;
                     throw new McpToolError(job.error);
                 }
-                const position = await waitForStableHeartbeat(job.startedAt);
+                const position = await waitForStableHeartbeat(issuedAt);
+                if (isBatch) {
+                    job.nextStep += 1;
+                    if (job.nextStep < job.steps.length) {
+                        // Same operator-approved list; keep the token usable
+                        // for the remaining steps.
+                        job.tokenUsed = false;
+                        job.state = 'started';
+                        return {
+                            job: jobManager.describe(job),
+                            position,
+                            remaining_steps: job.steps.length - job.nextStep,
+                            note: 'Step executed and settled. Call start_gcode_job again with the same '
+                                + 'job_id and code for the next approved step; positions persist.',
+                        };
+                    }
+                }
                 job.state = 'completed';
                 return {
                     job: jobManager.describe(job),
@@ -217,31 +239,54 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
 
     registry.register({
         name: 'move_z',
-        description: 'Request a SINGLE absolute Z move, executed on the direct path so the position '
-            + 'PERSISTS (file jobs park back at the work origin when they complete - firmware '
-            + 'behaviour). Every request goes to the operator confirm page showing current Z, '
-            + 'target, delta and feed; only their one-time code executes it. NOT door-interlocked - '
-            + 'the operator supervises. Spindle must be off; the toolhead always carries a tool.',
+        description: 'Request absolute Z motion, executed on the direct path so positions PERSIST '
+            + '(file jobs park back at the work origin when they complete - firmware behaviour). '
+            + 'Either one target (z) or an ordered list (z_targets, max 20) for a methodical search: '
+            + 'the operator approves the EXACT list once, and each start_gcode_job call then executes '
+            + 'one step, so you can capture between steps and abandon the series at any point. The '
+            + 'confirm page shows current Z, every target, deltas and feed; only the operator one-time '
+            + 'code executes anything. NOT door-interlocked - the operator supervises. Spindle must be '
+            + 'off; the toolhead always carries a tool.',
         inputSchema: {
             type: 'object',
             properties: {
-                z: { type: 'number', description: 'Absolute target Z.' },
+                z: { type: 'number', description: 'Absolute target Z (single move).' },
+                z_targets: {
+                    type: 'array',
+                    items: { type: 'number' },
+                    minItems: 1,
+                    maxItems: 20,
+                    description: 'Ordered absolute Z targets; one approval covers the exact list, '
+                        + 'one start_gcode_job call per step. Mutually exclusive with z.',
+                },
                 coordinate_system: {
                     type: 'string',
                     enum: ['work', 'machine'],
                     description: 'Which frame z is in. Default work.',
                 },
                 feed_rate: { type: 'number', description: 'mm/min, default 300, max 600.' },
-                reason: { type: 'string', description: 'Shown to the operator: why this Z move is needed.' },
+                reason: { type: 'string', description: 'Shown to the operator: why this Z motion is needed.' },
             },
-            required: ['z', 'reason'],
+            required: ['reason'],
             additionalProperties: false,
         },
-        handler: async (args: { z?: number; coordinate_system?: string; feed_rate?: number; reason?: string }) => {
-            const targetZ = Number(args.z);
-            if (!Number.isFinite(targetZ)) {
-                throw new McpToolError('z must be a finite number.');
+        handler: async (args: {
+            z?: number;
+            z_targets?: number[];
+            coordinate_system?: string;
+            feed_rate?: number;
+            reason?: string;
+        }) => {
+            if ((args.z === undefined) === (args.z_targets === undefined)) {
+                throw new McpToolError('Provide exactly one of z or z_targets.');
             }
+            const targets = args.z_targets !== undefined
+                ? args.z_targets.map(Number)
+                : [Number(args.z)];
+            if (!targets.length || targets.length > 20 || targets.some((t) => !Number.isFinite(t))) {
+                throw new McpToolError('Targets must be 1-20 finite numbers.');
+            }
+            const targetZ = targets[targets.length - 1];
             const coordinateSystem = args.coordinate_system || 'work';
             if (!['work', 'machine'].includes(coordinateSystem)) {
                 throw new McpToolError('coordinate_system must be "work" or "machine".');
@@ -265,34 +310,45 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             if (currentZ === null) {
                 throw new McpToolError('Current Z unknown; cannot describe the move to the operator.');
             }
-            const machineTargetZ = coordinateSystem === 'machine' ? targetZ : targetZ - position.originOffset.z;
             const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
-            if (size && (machineTargetZ < -1 || machineTargetZ > size.z + 40)) {
-                throw new McpToolError(`Target (machine Z ${machineTargetZ.toFixed(1)}) is outside the `
-                    + `0..${size.z} travel.`);
+            for (const t of targets) {
+                const machineT = coordinateSystem === 'machine' ? t : t - position.originOffset.z;
+                if (size && (machineT < -1 || machineT > size.z + 40)) {
+                    throw new McpToolError(`Target ${coordinateSystem} Z ${t} (machine Z ${machineT.toFixed(1)}) `
+                        + `is outside the 0..${size.z} travel.`);
+                }
             }
 
-            const move = `G1 Z${targetZ.toFixed(3)} F${feedRate}`;
-            const gcode = coordinateSystem === 'machine'
-                ? `G90\nG53;\n${move};\nG54;`
-                : `G90\n${move}`;
+            const stepGcode = (t: number) => (coordinateSystem === 'machine'
+                ? `G90\nG53;\nG1 Z${t.toFixed(3)} F${feedRate};\nG54;`
+                : `G90\nG1 Z${t.toFixed(3)} F${feedRate}`);
+            const steps = targets.map(stepGcode);
+            const isBatch = targets.length > 1;
+            const reviewText = steps.join('\n; --- next approved step ---\n');
             const delta = targetZ - currentZ;
-            const name = `z-move ${coordinateSystem} Z${targetZ.toFixed(1)} (${delta >= 0 ? '+' : ''}${delta.toFixed(1)}mm) - ${String(args.reason).slice(0, 40)}`;
+            const name = isBatch
+                ? `z-series ${coordinateSystem} [${targets.map((t) => t.toFixed(1)).join(', ')}] - ${String(args.reason).slice(0, 40)}`
+                : `z-move ${coordinateSystem} Z${targetZ.toFixed(1)} (${delta >= 0 ? '+' : ''}${delta.toFixed(1)}mm) - ${String(args.reason).slice(0, 40)}`;
 
-            const validation = validateGcode(gcode);
-            const job = jobManager.submit(gcode, name, 'cnc', validation, 'direct');
+            const validation = validateGcode(reviewText);
+            const job = jobManager.submit(reviewText, name, 'cnc', validation, 'direct', isBatch ? steps : undefined);
 
             return {
                 job: jobManager.describe(job),
                 current_z: currentZ,
-                target_z: targetZ,
-                delta_mm: delta,
+                targets,
+                final_delta_mm: delta,
                 feed_rate: feedRate,
                 coordinate_system: coordinateSystem,
                 confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
-                next_step: 'Ask the operator to open confirm_url, review the DIRECT-move banner '
-                    + '(current Z, target, delta, feed), and approve. Their one-time code passed to '
-                    + 'start_gcode_job executes the move; the position then persists.',
+                next_step: isBatch
+                    ? 'Ask the operator to open confirm_url, review the DIRECT-move banner and the full '
+                        + 'target list, and approve once. Then call start_gcode_job with the code once PER '
+                        + 'STEP - each call executes the next approved target and settles; capture between '
+                        + 'steps as needed. The series can be abandoned at any point.'
+                    : 'Ask the operator to open confirm_url, review the DIRECT-move banner '
+                        + '(current Z, target, delta, feed), and approve. Their one-time code passed to '
+                        + 'start_gcode_job executes the move; the position then persists.',
             };
         },
     });

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -36,12 +36,20 @@ function getJobChannel(): JobChannel {
 }
 
 /**
- * Wait for two consecutive identical heartbeats fresher than issuedAt, so a
- * direct move's returned position is settled firmware truth.
+ * Wait until the heartbeat is settled AND, when the executed gcode names an
+ * absolute Z target, until the reported Z actually matches it. Two identical
+ * post-issue beats alone are not enough: the heartbeat lags the controller
+ * by ~1s, so both can be pre-motion beats showing the old position (observed
+ * live: a -95 move "completed" while still reporting -85). Every returned
+ * position is either verified or flagged as not.
  */
-async function waitForStableHeartbeat(issuedAt: number): Promise<PositionSnapshot | null> {
-    const deadline = issuedAt + 30000;
+async function waitForStableHeartbeat(
+    issuedAt: number,
+    expect?: { frame: 'work' | 'machine'; z: number }
+): Promise<{ position: PositionSnapshot | null; verified: boolean; warning?: string }> {
+    const deadline = issuedAt + 45000;
     let previous: string | null = null;
+    let last: PositionSnapshot | null = null;
     while (Date.now() < deadline) {
         await new Promise((resolve) => {
             setTimeout(resolve, 500);
@@ -52,15 +60,43 @@ async function waitForStableHeartbeat(issuedAt: number): Promise<PositionSnapsho
         } catch (err) {
             continue;
         }
+        last = now;
         const reportTime = Date.now() - now.reportAgeMs;
         const fingerprint = JSON.stringify([now.work, now.originOffset]);
         const stable = fingerprint === previous;
         previous = fingerprint;
-        if (reportTime > issuedAt && stable && now.machineStatus === 'idle') {
-            return now;
+        if (reportTime <= issuedAt || !stable || now.machineStatus !== 'idle') {
+            continue;
         }
+        if (expect) {
+            const reportedZ = expect.frame === 'work' ? now.work.z : now.machine.z;
+            if (reportedZ === null || Math.abs(reportedZ - expect.z) > 0.15) {
+                continue; // settled, but not AT the target yet - keep waiting
+            }
+        }
+        return { position: now, verified: true };
     }
-    return null;
+    return {
+        position: last,
+        verified: false,
+        warning: expect
+            ? `Timed out waiting for the heartbeat to report ${expect.frame} Z ${expect.z}; the position `
+                + 'shown is the last read and may be stale - verify with query_firmware_position.'
+            : 'Timed out waiting for a settled heartbeat; the position shown may be stale - verify with '
+                + 'query_firmware_position.',
+    };
+}
+
+/**
+ * Absolute Z target of a direct-move gcode, for settle verification.
+ * G53-wrapped moves are machine-frame; plain ones are work-frame.
+ */
+function parseZTarget(gcode: string): { frame: 'work' | 'machine'; z: number } | undefined {
+    const match = gcode.match(/G0*1[^;\n]*?Z(-?\d+(?:\.\d+)?)/i);
+    if (!match) {
+        return undefined;
+    }
+    return { frame: gcode.includes('G53') ? 'machine' : 'work', z: Number(match[1]) };
 }
 
 function machineStatus(): string | null {
@@ -183,7 +219,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                     job.error = `Controller rejected the move: ${executed.text || executed.result}`;
                     throw new McpToolError(job.error);
                 }
-                const position = await waitForStableHeartbeat(issuedAt);
+                const settle = await waitForStableHeartbeat(issuedAt, parseZTarget(gcodeText));
                 if (isBatch) {
                     job.nextStep += 1;
                     if (job.nextStep < job.steps.length) {
@@ -193,7 +229,9 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                         job.state = 'started';
                         return {
                             job: jobManager.describe(job),
-                            position,
+                            position: settle.position,
+                            position_verified: settle.verified,
+                            warning: settle.warning,
                             remaining_steps: job.steps.length - job.nextStep,
                             note: 'Step executed and settled. Call start_gcode_job again with the same '
                                 + 'job_id and code for the next approved step; positions persist.',
@@ -203,8 +241,10 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 job.state = 'completed';
                 return {
                     job: jobManager.describe(job),
-                    position,
-                    note: 'Direct move executed and settled; the position persists (no end-of-job park).',
+                    position: settle.position,
+                    position_verified: settle.verified,
+                    warning: settle.warning,
+                    note: 'Direct move executed; the position persists (no end-of-job park).',
                 };
             }
 

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -174,11 +174,17 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             properties: {
                 job_id: { type: 'string' },
                 confirm_token: { type: 'string', description: 'One-time code from the operator.' },
+                wait_until_moved: {
+                    type: 'boolean',
+                    description: 'Direct jobs only. Default true: block until the heartbeat verifiably '
+                        + 'reports the move done. false returns immediately after the controller accepts '
+                        + 'the command, with position_verified: false - poll get_position afterwards.',
+                },
             },
             required: ['job_id', 'confirm_token'],
             additionalProperties: false,
         },
-        handler: async (args: { job_id?: string; confirm_token?: string }) => {
+        handler: async (args: { job_id?: string; confirm_token?: string; wait_until_moved?: boolean }) => {
             const job = jobManager.get(String(args.job_id || ''));
             if (!job) {
                 throw new McpToolError('Unknown job_id.');
@@ -219,7 +225,17 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                     job.error = `Controller rejected the move: ${executed.text || executed.result}`;
                     throw new McpToolError(job.error);
                 }
-                const settle = await waitForStableHeartbeat(issuedAt, parseZTarget(gcodeText));
+                const shouldWait = args.wait_until_moved !== undefined
+                    ? args.wait_until_moved !== false
+                    : job.waitUntilMoved !== false;
+                const settle = !shouldWait
+                    ? {
+                        position: null,
+                        verified: false,
+                        warning: 'wait_until_moved was false: the move was accepted but not awaited - '
+                            + 'poll get_position (or query_firmware_position) before relying on position.',
+                    }
+                    : await waitForStableHeartbeat(issuedAt, parseZTarget(gcodeText));
                 if (isBatch) {
                     job.nextStep += 1;
                     if (job.nextStep < job.steps.length) {
@@ -306,6 +322,13 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 },
                 feed_rate: { type: 'number', description: 'mm/min, default 300, max 600.' },
                 reason: { type: 'string', description: 'Shown to the operator: why this Z motion is needed.' },
+                wait_until_moved: {
+                    type: 'boolean',
+                    description: 'Staged default for execution (start_gcode_job can override per call). '
+                        + 'Default true: each step blocks until the heartbeat verifiably reports the '
+                        + 'target Z. false: steps return on controller accept with '
+                        + 'position_verified: false - poll get_position.',
+                },
             },
             required: ['reason'],
             additionalProperties: false,
@@ -316,6 +339,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             coordinate_system?: string;
             feed_rate?: number;
             reason?: string;
+            wait_until_moved?: boolean;
         }) => {
             if ((args.z === undefined) === (args.z_targets === undefined)) {
                 throw new McpToolError('Provide exactly one of z or z_targets.');
@@ -372,6 +396,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
 
             const validation = validateGcode(reviewText);
             const job = jobManager.submit(reviewText, name, 'cnc', validation, 'direct', isBatch ? steps : undefined);
+            job.waitUntilMoved = args.wait_until_moved !== false;
 
             return {
                 job: jobManager.describe(job),


### PR DESCRIPTION
The remaining five items from the first full calibration session's field report:

- **Built-in sign check**: `set_camera_calibration` accepts the fitted `jacobian` and **rejects** a sign-flipped matrix (M·J ≈ −identity) before it can reach hardware; large identity residuals warn instead.
- **Y-tolerance friction**: `visual_servo` auto-select no longer hard-fails at exactly 2 mm (single steps drift Y 2–6 mm routinely) — nearest entry within 25 mm is used, with the existing scale-may-be-off warning beyond 2 mm.
- **`set_tool_region`**: refine `expectedToolRegion` from live frames by tool call instead of config edits.
- **Camera flakiness**: device choice is sticky (`mcpCameraLastGood` remembered and preferred), one retry on transient open failure, and a vanished device is a **clear error** — never a silent substitution to a different (possibly dead) virtual camera.
- **Batch-scoped Z approval**: `move_z` accepts `z_targets` (max 20). The operator approves the exact ordered list once on one page; each `start_gcode_job` call executes ONE step with settling, captures can happen between steps, and the series can be abandoned at any point — same explicit-approval property, one page instead of fourteen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)