### PR TITLE
Feature: Landmarks, stored-state overview, depth-plane and expectation checks

### DIFF
--- a/.claude/skills/cnc-visual-alignment/SKILL.md
+++ b/.claude/skills/cnc-visual-alignment/SKILL.md
@@ -123,7 +123,8 @@ Never compute a machine coordinate from one frame and drive to it. With the MCP:
    wrong — real parallax, not a bug. Derive on the surface you will servo on, record the
    surface in `notes`, and before trusting any tracked shift, sanity-check it against the
    Jacobian prediction (J·Δmachine ≈ Δpixel); a sharp divergence means wrong plane, wrong
-   match, or both (automatic cross-check planned as fork issue #51).
+   match, or both - visual_servo also performs this cross-check automatically and warns
+   on divergence; tag calibrations with their `surface` so the warning can name it.
 4. Iterate `visual_servo` — each call is one clamped step and returns the frame; two or
    three passes converge. It auto-selects the nearest-Y calibration and warns when a step
    moves Y (self-invalidating) — re-derive or re-select when it does.
@@ -164,8 +165,9 @@ object must not be assigned an identity from what it sits near ("beside jaw-shap
 so chuck-related") — on this machine the gold cylinder at machine Y≈176–340 is the **tool
 height checker**, misidentified twice by analogy before the operator corrected it. If the
 operator has named a landmark, use that; if not, ask — never assert a guess as resolved
-fact. (A named-landmark registry is planned as fork issue #50; until it exists, landmark
-identities live in this paragraph and the operator's word.)
+fact. Landmark identities persist in the registry: call `get_stored_state` first in any
+session, and record new operator-stated identities with `set_landmark` - captures then
+carry `nearbyLandmarks` automatically.
 
 ## Datums: check the landmark is actually in frame
 

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -97,7 +97,7 @@ and tool activity — all timestamped. Events: `mcp:activity`, `mcp:gcode` (whit
 - Fleet: machine named "Snapmaker" @ 192.168.1.173 = the A350 CNC; "F350" @ .130 = the
   3D printer. Same Luban profile identifier — distinguish by NAME/address, never profile.
 
-## Tool surface (21)
+## Tool surface (24)
 
 `get_connection_status` · `get_machine_profile` (kinematics, module offsets) ·
 `get_position` (both frames, warnings on incoherent reporting) ·
@@ -106,9 +106,14 @@ and tool activity — all timestamped. Events: `mcp:activity`, `mcp:gcode` (whit
 `z_targets` batch) · `home` · `goto_work_origin` · `move_and_capture` · `list_cameras` ·
 `capture_frame` (position-stamped, `frameId`, `expectedToolRegion`) · `set_tool_region` ·
 `track_feature` (NCC between cached frames — use instead of eyeballing pixels) ·
-`set_/get_/delete_camera_calibration` (Y/Z-keyed; optional `jacobian` REJECTS sign-flipped
-matrices, M·J ≈ −I) · `visual_servo` (one clamped step per call; trips when the error
-fails to shrink).
+`set_/get_/delete_camera_calibration` (Y/Z-keyed; optional `surface` depth-plane tag;
+optional `jacobian` REJECTS sign-flipped matrices, M·J ≈ −I) · `visual_servo` (one clamped
+step per call; trips when the error fails to shrink OR when the measured response diverges
+from the calibration prediction — the depth-plane parallax signature) ·
+`set_landmark` / `delete_landmark` (named scene features by machine extent; nearby ones are
+surfaced on every capture) · `get_stored_state` (one-call orientation: calibrations,
+landmarks, tool region, limits, camera config, connection — call this first in a fresh
+session).
 
 ## Development workflow (learned the hard way)
 
@@ -133,14 +138,10 @@ fails to shrink).
 
 ## Open threads
 
-- **#50 named-landmark registry** — `expectedToolRegion` for scene landmarks (tool height
-  checker, rotary span), set once, surfaced near their coordinates.
-- **#51 depth-plane calibration tag + Jacobian-mismatch warning** — a calibration from one
-  surface applied to another depth read ~4× wrong (parallax); tools should cross-check the
-  early measured shift against the Jacobian prediction automatically.
-- **#52 expected-shift hint for `track_feature`** — second-peak gap is a soft signal on
-  repetitive patterns; a Jacobian-derived expectation should break ties.
-- **#53 stored-state overview call** — one call returning calibrations + landmarks + tool
-  region so a fresh session orients without motion.
+- **#50–#53 implemented** in `mcp/22-stored-state`: landmark registry (`set_landmark`,
+  surfaced as `nearbyLandmarks` on captures within 120 mm), calibration `surface` tag +
+  automatic Jacobian-prediction divergence warning in `visual_servo`, `expected_shift`
+  tie-breaking in `track_feature` (reports `chosen_by`/`raw_best`), and `get_stored_state`.
+  Seed the landmark registry with the tool height checker (machine Y≈176–340).
 - **#38 startup socket.io gap** — properly belongs in the startup stack; hotfixed here.
 - **#24 measurement systems, #25 collision watcher** — designed but not started.

--- a/src/server/services/mcp/calibration.ts
+++ b/src/server/services/mcp/calibration.ts
@@ -22,6 +22,10 @@ export interface CalibrationEntry {
     validAtY: number; // machine Y the frame was captured at
     z: number; // machine Z the frame was captured at
     matrix: [[number, number], [number, number]];
+    // Physical surface the calibration was derived on (#51): a matrix is only
+    // valid for features on the same depth plane - applying a bracket-derived
+    // matrix to the board surface read ~4x wrong on hardware (parallax).
+    surface: string | null;
     notes: string | null;
     createdAt: number;
 }

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -9,6 +9,7 @@ import { ToolRegistry } from './registry';
 import { registerCalibrationTools } from './tools/calibration';
 import { registerCameraTools } from './tools/camera';
 import { registerGcodeTools } from './tools/gcode';
+import { registerLandmarkTools } from './tools/landmarks';
 import { registerMachineTools } from './tools/machine';
 import { registerStatusTools } from './tools/status';
 
@@ -105,6 +106,7 @@ export function startMcpService(socketServer?: McpBroadcaster): void {
     registerGcodeTools(registry, () => `http://127.0.0.1:${port}`);
     registerCameraTools(registry);
     registerCalibrationTools(registry);
+    registerLandmarkTools(registry);
     registeredToolCount = registry.list().length;
 
     broadcaster = socketServer || null;

--- a/src/server/services/mcp/landmarks.ts
+++ b/src/server/services/mcp/landmarks.ts
@@ -1,0 +1,106 @@
+import crypto from 'crypto';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+import DataStorage from '../../DataStorage';
+import logger from '../../lib/logger';
+
+const log = logger('service:mcp:landmarks');
+
+// Named scene landmarks (#50): expectedToolRegion solved "what is that blurry
+// thing" for the endmill; this does the same for fixed scene features (tool
+// height checker, rotary span, tool post). Set once from operator knowledge,
+// persisted, and surfaced on every capture taken near their machine
+// coordinates - so no agent re-derives an identity the operator already gave.
+
+export interface Landmark {
+    id: string;
+    name: string;
+    description: string;
+    // Machine-coordinate XY extent of the feature on/over the bed.
+    machine: { x0: number; y0: number; x1: number; y1: number };
+    notes: string | null;
+    createdAt: number;
+}
+
+interface LandmarkFile {
+    landmarks: Landmark[];
+}
+
+export class LandmarkStore {
+    private filePath: string | null = null;
+
+    private cache: LandmarkFile | null = null;
+
+    private file(): string {
+        if (!this.filePath) {
+            this.filePath = path.join(DataStorage.userDataDir, 'mcp-landmarks.json');
+        }
+        return this.filePath;
+    }
+
+    private load(): LandmarkFile {
+        if (this.cache) {
+            return this.cache;
+        }
+        try {
+            const raw = fs.readJsonSync(this.file());
+            this.cache = { landmarks: Array.isArray(raw?.landmarks) ? raw.landmarks : [] };
+        } catch (err) {
+            this.cache = { landmarks: [] };
+        }
+        return this.cache;
+    }
+
+    private save(): void {
+        try {
+            fs.writeJsonSync(this.file(), this.cache, { spaces: 2 });
+        } catch (err) {
+            log.error(`Failed to persist landmarks: ${err.message}`);
+        }
+    }
+
+    public add(landmark: Omit<Landmark, 'id' | 'createdAt'>): Landmark {
+        const data = this.load();
+        // Same name replaces: landmarks are identities, not history.
+        data.landmarks = data.landmarks.filter((l) => l.name !== landmark.name);
+        const full: Landmark = {
+            ...landmark,
+            id: crypto.randomBytes(4).toString('hex'),
+            createdAt: Date.now(),
+        };
+        data.landmarks.push(full);
+        this.save();
+        log.info(`Landmark stored: ${full.name} (${full.id})`);
+        return full;
+    }
+
+    public list(): Landmark[] {
+        return this.load().landmarks;
+    }
+
+    public remove(idOrName: string): boolean {
+        const data = this.load();
+        const before = data.landmarks.length;
+        data.landmarks = data.landmarks.filter((l) => l.id !== idOrName && l.name !== idOrName);
+        if (data.landmarks.length !== before) {
+            this.save();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Landmarks whose extent lies within `radius` mm of a machine XY point -
+     * what a toolhead camera at that position could plausibly see.
+     */
+    public near(x: number, y: number, radius: number): Landmark[] {
+        return this.load().landmarks.filter((l) => {
+            const dx = Math.max(l.machine.x0 - x, 0, x - l.machine.x1);
+            const dy = Math.max(l.machine.y0 - y, 0, y - l.machine.y1);
+            return Math.hypot(dx, dy) <= radius;
+        });
+    }
+}
+
+export const landmarkStore = new LandmarkStore();

--- a/src/server/services/mcp/tools/calibration.ts
+++ b/src/server/services/mcp/tools/calibration.ts
@@ -32,7 +32,18 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
     // the error. Remember the last step per calibration+target and warn the
     // moment the error fails to shrink - one wasted step instead of a manual
     // catch several steps later.
-    let lastServoStep: { calibrationId: string; tu: number; tv: number; magnitude: number; at: number } | null = null;
+    let lastServoStep: {
+        calibrationId: string;
+        tu: number;
+        tv: number;
+        magnitude: number;
+        du: number;
+        dv: number;
+        appliedDx: number;
+        appliedDy: number;
+        matrix: [[number, number], [number, number]];
+        at: number;
+    } | null = null;
     registry.register({
         name: 'set_camera_calibration',
         description: 'Persist a pixel-to-machine calibration, keyed by the machine Y it was '
@@ -55,6 +66,12 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
                     maxItems: 2,
                 },
                 notes: { type: 'string', description: 'Free-form provenance: grid used, residuals, tilt.' },
+                surface: {
+                    type: 'string',
+                    description: 'Physical surface the calibration was derived on (e.g. "board", '
+                        + '"bracket"). A matrix is only valid on its own depth plane - cross-plane '
+                        + 'use read ~4x wrong on hardware.',
+                },
                 jacobian: {
                     type: 'array',
                     description: 'Optional 2x2 forward Jacobian J (pixel shift per mm) you fitted. When '
@@ -68,7 +85,7 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
             required: ['valid_at_y', 'z', 'matrix'],
             additionalProperties: false,
         },
-        handler: async (args: { valid_at_y?: number; z?: number; matrix?: unknown; notes?: string; jacobian?: unknown }) => {
+        handler: async (args: { valid_at_y?: number; z?: number; matrix?: unknown; notes?: string; surface?: string; jacobian?: unknown }) => {
             const validAtY = Number(args.valid_at_y);
             const z = Number(args.z);
             if (!Number.isFinite(validAtY) || !Number.isFinite(z)) {
@@ -107,6 +124,7 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
                 validAtY,
                 z,
                 matrix: args.matrix,
+                surface: args.surface ? String(args.surface) : null,
                 notes: args.notes ? String(args.notes) : null,
             });
             return { entry: describeEntry(entry), warnings };
@@ -255,15 +273,41 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
             const errorMagnitude = Math.hypot(du, dv);
             const tu = Number(args.target_pixel?.u);
             const tv = Number(args.target_pixel?.v);
-            if (lastServoStep
+            const sameSeries = lastServoStep
                 && lastServoStep.calibrationId === entry.id
                 && Math.abs(lastServoStep.tu - tu) < 5 && Math.abs(lastServoStep.tv - tv) < 5
-                && Date.now() - lastServoStep.at < 10 * 60 * 1000
-                && errorMagnitude >= lastServoStep.magnitude * 0.95) {
+                && Date.now() - lastServoStep.at < 10 * 60 * 1000;
+            if (sameSeries && errorMagnitude >= lastServoStep.magnitude * 0.95) {
                 warnings.push('Pixel error did not shrink after the previous servo step with this calibration '
                     + `(${lastServoStep.magnitude.toFixed(1)}px -> ${errorMagnitude.toFixed(1)}px). A sign-flipped or `
                     + 'badly scaled matrix drives AWAY from the target: verify J.(M.e) reproduces +e before '
                     + 'iterating further.');
+            }
+            // Depth-plane / wrong-match cross-check (#51): predict this step
+            // error from the last one using J = inverse(M) and the applied
+            // move; sharp divergence means the tracked feature sits on a
+            // different physical surface than the calibration (parallax read
+            // ~4x wrong on hardware) or the match latched onto the wrong spot.
+            if (sameSeries) {
+                const m = lastServoStep.matrix;
+                const det = m[0][0] * m[1][1] - m[0][1] * m[1][0];
+                if (Math.abs(det) > 1e-9) {
+                    const j = [
+                        [m[1][1] / det, -m[0][1] / det],
+                        [-m[1][0] / det, m[0][0] / det],
+                    ];
+                    const predDu = lastServoStep.du - (j[0][0] * lastServoStep.appliedDx + j[0][1] * lastServoStep.appliedDy);
+                    const predDv = lastServoStep.dv - (j[1][0] * lastServoStep.appliedDx + j[1][1] * lastServoStep.appliedDy);
+                    const expectedChange = Math.hypot(lastServoStep.du - predDu, lastServoStep.dv - predDv);
+                    const deviation = Math.hypot(du - predDu, dv - predDv);
+                    if (expectedChange > 3 && deviation > Math.max(0.5 * expectedChange, 5)) {
+                        warnings.push('Measured response diverges from the calibration prediction (expected error near '
+                            + `(${predDu.toFixed(0)}, ${predDv.toFixed(0)})px, measured (${du.toFixed(0)}, ${dv.toFixed(0)})px). `
+                            + 'Likely a depth-plane mismatch - the feature sits on a different surface than the calibration'
+                            + `${entry.surface ? ` (derived on "${entry.surface}")` : ''} - or the tracked match is wrong. `
+                            + 'Re-derive on the working surface before iterating.');
+                    }
+                }
             }
             if (entryDistance !== null && entryDistance > DEFAULT_Y_TOLERANCE_MM) {
                 warnings.push(`Calibration ${entry.id} is ${entryDistance.toFixed(1)} mm from the current Y; scale may be off.`);
@@ -280,7 +324,18 @@ export function registerCalibrationTools(registry: ToolRegistry): void {
                 operator_confirmed_clearance: args.operator_confirmed_clearance,
             }) as { mcpContent: object[] };
 
-            lastServoStep = { calibrationId: entry.id, tu, tv, magnitude: errorMagnitude, at: Date.now() };
+            lastServoStep = {
+                calibrationId: entry.id,
+                tu,
+                tv,
+                magnitude: errorMagnitude,
+                du,
+                dv,
+                appliedDx: dx,
+                appliedDy: dy,
+                matrix: entry.matrix,
+                at: Date.now(),
+            };
 
             // Splice servo metadata into the text part of the frame result.
             const servoMeta = {

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -6,6 +6,7 @@ import { connectionManager } from '../../machine/ConnectionManager';
 import { CapturedFrame, captureFrame, getCachedFrame, getCachedFrameIds, listCameras } from '../camera';
 import { decodeToGray, trackFeature } from '../tracking';
 import { McpToolError, ToolRegistry } from '../registry';
+import { landmarkStore } from '../landmarks';
 import { PositionSnapshot, getMachineSizeByIdentifier, getPositionSnapshot } from './machine';
 
 // Motion policy (#23, refined): the direct move path is for the odd single
@@ -64,6 +65,28 @@ function expectedToolRegion(): object | null {
     }
 }
 
+function positionOrNull(): PositionSnapshot | null {
+    try {
+        return getPositionSnapshot();
+    } catch (err) {
+        return null;
+    }
+}
+
+/**
+ * Landmarks near the current machine XY (#50): identities the operator has
+ * stated once, surfaced on every capture so they are never re-guessed.
+ */
+function nearbyLandmarks(): object[] {
+    const position = positionOrNull();
+    const x = position?.machine.x;
+    const y = position?.machine.y;
+    if (x === null || x === undefined || y === null || y === undefined) {
+        return [];
+    }
+    return landmarkStore.near(x, y, 120);
+}
+
 function frameContent(frame: CapturedFrame, meta: object): object {
     return {
         mcpContent: [
@@ -78,19 +101,12 @@ function frameContent(frame: CapturedFrame, meta: object): object {
                         device: frame.device,
                         capturedAt: frame.capturedAt,
                         expectedToolRegion: expectedToolRegion(),
+                        nearbyLandmarks: nearbyLandmarks(),
                     },
                 }),
             },
         ],
     };
-}
-
-function positionOrNull(): PositionSnapshot | null {
-    try {
-        return getPositionSnapshot();
-    } catch (err) {
-        return null;
-    }
 }
 
 function assertSafeToMove(position: PositionSnapshot, operatorConfirmedClearance: boolean): void {
@@ -342,6 +358,14 @@ export function registerCameraTools(registry: ToolRegistry): void {
                 },
                 patch_size: { type: 'number', description: 'Odd patch edge in px, default 41, max 101.' },
                 search_radius: { type: 'number', description: 'Search half-window in px, default 120, max 250.' },
+                expected_shift: {
+                    type: 'object',
+                    properties: { du: { type: 'number' }, dv: { type: 'number' } },
+                    required: ['du', 'dv'],
+                    description: 'Optional predicted pixel shift (e.g. J x commanded move). Breaks '
+                        + 'ties among near-best candidates on repetitive grids; the response says '
+                        + 'when the expectation, not the raw score, chose the match.',
+                },
             },
             required: ['template_frame_id', 'search_frame_id', 'point'],
             additionalProperties: false,
@@ -352,6 +376,7 @@ export function registerCameraTools(registry: ToolRegistry): void {
             point?: { u?: number; v?: number };
             patch_size?: number;
             search_radius?: number;
+            expected_shift?: { du?: number; dv?: number };
         }) => {
             const templateJpg = getCachedFrame(String(args.template_frame_id || ''));
             const searchJpg = getCachedFrame(String(args.search_frame_id || ''));
@@ -368,7 +393,17 @@ export function registerCameraTools(registry: ToolRegistry): void {
             patch = Math.min(Math.max(patch % 2 === 0 ? patch + 1 : patch, 11), 101);
             const radius = Math.min(Math.max(Math.round(Number(args.search_radius) || 120), 20), 250);
 
-            const result = trackFeature(decodeToGray(templateJpg), decodeToGray(searchJpg), u, v, patch, radius);
+            let expected: { du: number; dv: number } | undefined;
+            if (args.expected_shift) {
+                const edu = Number(args.expected_shift.du);
+                const edv = Number(args.expected_shift.dv);
+                if (!Number.isFinite(edu) || !Number.isFinite(edv)) {
+                    throw new McpToolError('expected_shift.du and .dv must be numbers.');
+                }
+                expected = { du: edu, dv: edv };
+            }
+
+            const result = trackFeature(decodeToGray(templateJpg), decodeToGray(searchJpg), u, v, patch, radius, expected);
             return {
                 template_frame_id: args.template_frame_id,
                 search_frame_id: args.search_frame_id,
@@ -377,6 +412,9 @@ export function registerCameraTools(registry: ToolRegistry): void {
                 pixel_shift: { du: result.du, dv: result.dv },
                 score: result.score,
                 second_peak_gap: result.secondPeakGap,
+                chosen_by: result.chosenBy,
+                distance_from_expected: result.distanceFromExpected,
+                raw_best: result.rawBest,
                 patch_size: patch,
                 search_radius: radius,
                 warnings: result.warnings,

--- a/src/server/services/mcp/tools/landmarks.ts
+++ b/src/server/services/mcp/tools/landmarks.ts
@@ -1,0 +1,118 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention.
+import config from '../../configstore';
+import { connectionManager } from '../../machine/ConnectionManager';
+import { calibrationStore } from '../calibration';
+import { Landmark, landmarkStore } from '../landmarks';
+import { McpToolError, ToolRegistry } from '../registry';
+
+// Named scene landmarks (#50) and the stored-state overview (#53): operator
+// knowledge captured once, surfaced every session, so no agent spends moves
+// re-deriving what the operator already said.
+
+function describeLandmark(landmark: Landmark): object {
+    return landmark;
+}
+
+export function registerLandmarkTools(registry: ToolRegistry): void {
+    registry.register({
+        name: 'set_landmark',
+        description: 'Persist a named scene landmark (tool height checker, rotary span, tool '
+            + 'post...) with its machine-coordinate XY extent and a description. Same name '
+            + 'replaces. Landmarks near the current position are surfaced with every capture, '
+            + 'so identities the operator has stated once are never re-guessed. Record identity '
+            + 'from OPERATOR knowledge, not visual analogy.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'Short unique name, e.g. "tool-height-checker".' },
+                description: { type: 'string', description: 'What it is and how it looks on camera.' },
+                x0: { type: 'number', description: 'Machine-coordinate extent of the feature.' },
+                y0: { type: 'number' },
+                x1: { type: 'number' },
+                y1: { type: 'number' },
+                notes: { type: 'string' },
+            },
+            required: ['name', 'description', 'x0', 'y0', 'x1', 'y1'],
+            additionalProperties: false,
+        },
+        handler: async (args: {
+            name?: string;
+            description?: string;
+            x0?: number;
+            y0?: number;
+            x1?: number;
+            y1?: number;
+            notes?: string;
+        }) => {
+            const name = String(args.name || '').trim();
+            const description = String(args.description || '').trim();
+            if (!name || !description) {
+                throw new McpToolError('name and description are required.');
+            }
+            const box = [args.x0, args.y0, args.x1, args.y1].map(Number);
+            if (box.some((v) => !Number.isFinite(v)) || box[0] >= box[2] || box[1] >= box[3]) {
+                throw new McpToolError('Require finite machine coordinates with x0 < x1 and y0 < y1.');
+            }
+            const landmark = landmarkStore.add({
+                name,
+                description,
+                machine: { x0: box[0], y0: box[1], x1: box[2], y1: box[3] },
+                notes: args.notes ? String(args.notes) : null,
+            });
+            return { landmark: describeLandmark(landmark) };
+        },
+    });
+
+    registry.register({
+        name: 'delete_landmark',
+        description: 'Delete one stored landmark by id or name.',
+        inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'string', description: 'Landmark id or name.' } },
+            required: ['id'],
+            additionalProperties: false,
+        },
+        handler: async (args: { id?: string }) => {
+            if (!landmarkStore.remove(String(args.id || ''))) {
+                throw new McpToolError('Unknown landmark id or name.');
+            }
+            return { removed: true };
+        },
+    });
+
+    registry.register({
+        name: 'get_stored_state',
+        description: 'Everything already known about this machine and bed in one read-only call, '
+            + 'so a fresh session orients WITHOUT moving anything: stored calibrations (with '
+            + 'surface tags), named landmarks, the expected tool region, motion limits, camera '
+            + 'config, and the live connection snapshot. Call this first.',
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => {
+            let toolRegion: object | null = null;
+            const rawRegion = config.get('mcpToolRegion');
+            if (rawRegion) {
+                try {
+                    toolRegion = typeof rawRegion === 'string' ? JSON.parse(rawRegion) : (rawRegion as object);
+                } catch (err) {
+                    toolRegion = null;
+                }
+            }
+            return {
+                connection: connectionManager.getConnectionStatus(),
+                calibrations: calibrationStore.list(),
+                landmarks: landmarkStore.list().map(describeLandmark),
+                expectedToolRegion: toolRegion,
+                limits: {
+                    maxJogDistanceMm: Number(config.get('mcpMaxJogDistance')) || 100,
+                },
+                camera: {
+                    url: config.get('mcpCameraUrl') || null,
+                    device: config.get('mcpCameraDevice') || null,
+                    lastGoodDevice: config.get('mcpCameraLastGood') || null,
+                },
+                installedModules: config.get('mcpInstalledModules') || [],
+            };
+        },
+    });
+}

--- a/src/server/services/mcp/tracking.ts
+++ b/src/server/services/mcp/tracking.ts
@@ -51,6 +51,9 @@ export interface TrackResult {
     dv: number;
     score: number;
     secondPeakGap: number;
+    chosenBy: 'score' | 'expectation';
+    distanceFromExpected: number | null;
+    rawBest: { u: number; v: number; score: number } | null;
     warnings: string[];
 }
 
@@ -67,7 +70,8 @@ export function trackFeature(
     u: number,
     v: number,
     patchSize: number,
-    searchRadius: number
+    searchRadius: number,
+    expected?: { du: number; dv: number }
 ): TrackResult {
     const half = Math.floor(patchSize / 2);
     const warnings: string[] = [];
@@ -147,6 +151,50 @@ export function trackFeature(
         }
     }
 
+    // Expectation tie-breaking (#52): on a repetitive grid several
+    // intersections score within noise of each other and the raw best can be
+    // the wrong one. Given an expected shift (from the running Jacobian),
+    // choose the near-best candidate closest to it instead - and always say
+    // which rule chose.
+    const rawBest = { u: bestU, v: bestV, score: best };
+    let chosenBy: 'score' | 'expectation' = 'score';
+    let distanceFromExpected: number | null = null;
+    if (expected && best > -1) {
+        const eu = u + expected.du;
+        const ev = v + expected.dv;
+        const threshold = best - 0.08;
+        let candU = bestU;
+        let candV = bestV;
+        let candScore = best;
+        let candDist = Math.hypot(bestU - eu, bestV - ev);
+        for (let sv = vMin; sv <= vMax; sv++) {
+            for (let su = uMin; su <= uMax; su++) {
+                const score = scores[sv - vMin][su - uMin];
+                if (score < threshold) {
+                    continue;
+                }
+                const dist = Math.hypot(su - eu, sv - ev);
+                if (dist < candDist) {
+                    candDist = dist;
+                    candU = su;
+                    candV = sv;
+                    candScore = score;
+                }
+            }
+        }
+        distanceFromExpected = candDist;
+        if (candU !== bestU || candV !== bestV) {
+            chosenBy = 'expectation';
+            warnings.push(`Expectation override: the raw best match at (${bestU}, ${bestV}) `
+                + `(NCC ${best.toFixed(2)}) was replaced by a near-best candidate at (${candU}, ${candV}) `
+                + `(NCC ${candScore.toFixed(2)}) closer to the expected shift - typical on repetitive `
+                + 'grids. If the expectation itself is suspect, re-run without expected_shift.');
+            bestU = candU;
+            bestV = candV;
+            best = candScore;
+        }
+    }
+
     if (best < 0.5) {
         warnings.push(`Low match confidence (NCC ${best.toFixed(2)}); the feature may have left the frame `
             + 'or changed appearance (lighting, focus, Z change).');
@@ -163,6 +211,9 @@ export function trackFeature(
         dv: bestV - v,
         score: best,
         secondPeakGap: gap,
+        chosenBy,
+        distanceFromExpected,
+        rawBest: chosenBy === 'expectation' ? rawBest : null,
         warnings,
     };
 }


### PR DESCRIPTION
Closes #50. Closes #51. Closes #52. Closes #53 — the four gaps from the final field report, implemented before compaction.

- **#50** `set_landmark`/`delete_landmark`: named scene features by machine-coordinate extent, persisted in userDataDir; every capture surfaces `nearbyLandmarks` within 120 mm of the current position. Seed with the tool height checker (machine Y≈176–340).
- **#51** calibrations take a `surface` tag, and `visual_servo` now cross-checks each step against the calibration's own prediction (J = M⁻¹ applied to the executed move) — sharp divergence warns of a depth-plane mismatch (the ~4× parallax failure observed live) or a wrong match, naming the calibration's surface when tagged.
- **#52** `track_feature` accepts `expected_shift` and breaks ties among near-best candidates (within 0.08 NCC of the peak) by distance from the expectation, reporting `chosen_by`, `distance_from_expected`, and `raw_best` when overridden.
- **#53** `get_stored_state`: calibrations + landmarks + tool region + limits + camera config + connection snapshot in one read-only call — documented as the first call of any fresh session.

Tool surface is now 24; README and the in-repo skill updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)