### PR TITLE
Improvement: Bundle server dependencies into the production build

### DIFF
--- a/webpack.config.server.production.js
+++ b/webpack.config.server.production.js
@@ -1,5 +1,4 @@
 const crypto = require('crypto');
-const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
@@ -8,15 +7,36 @@ const pkg = require('./package.json');
 
 const NODE_MODULES = path.resolve(__dirname, 'node_modules');
 
-// http://jlongster.com/Backend-Apps-with-Webpack--Part-I
-const externals = {};
-fs.readdirSync(NODE_MODULES)
-    .filter((x) => {
-        return ['.bin'].indexOf(x) === -1;
-    })
-    .forEach((mod) => {
-        externals[mod] = `commonjs ${mod}`;
-    });
+// Bundle dependencies into the server bundle instead of externalizing all of
+// node_modules: a cold start used to crawl thousands of small files (each
+// scanned by antivirus on first open, ~10s+ after a rebuild or reboot before
+// the backend answered), whereas one bundle is a single read. Only packages
+// that cannot live inside a bundle stay external: native addons, packages
+// that spawn or load sibling binaries/assets out of their own package
+// directory, and template engines resolved by name at runtime.
+const KEEP_EXTERNAL = [
+    'serialport', // native (@serialport/bindings-cpp)
+    'font-scanner', // native
+    'lzma-native', // native
+    '@snapmaker/snapmaker-lunar', // spawns LunarTPP binaries from its package dir
+    'snapmaker-luban-engine', // spawns CuraEngine binaries from its package dir
+    'opencv-wasm', // loads .wasm from its package dir
+    'consolidate', // requires template engines by name at runtime
+    'hogan.js', // loaded dynamically by consolidate
+    'formidable', // constructor requires its plugin files from its package dir
+    'errorhandler', // reads its stylesheet from its package dir
+    'socket.io', // serveClient reads the client bundle from its package dir
+];
+const externals = [
+    (context, request, callback) => {
+        const external = request.startsWith('@serialport/')
+            || KEEP_EXTERNAL.some((mod) => request === mod || request.startsWith(`${mod}/`));
+        if (external) {
+            return callback(null, `commonjs ${request}`);
+        }
+        return callback();
+    },
+];
 
 // Use publicPath for production
 // const payload = pkg.version;


### PR DESCRIPTION
Cold starts (first launch after a rebuild or reboot) took 10–15s to reach services-ready because `webpack.config.server.production.js` externalized **all** of node_modules, so the server's `require()` graph crawled thousands of small files at startup — each paying first-open antivirus scanning. It was never disk speed: after a RAMMap standby-list purge (cold file cache, cached AV verdicts) the same startup took 2.0s on NVMe.

Bundle the pure-JS dependencies into the server bundle instead (1.1MB → 5.1MB, single read, single AV scan). Only packages that cannot live inside a bundle stay external:

- **native addons**: `serialport` (+ `@serialport/*`), `font-scanner`, `lzma-native`
- **packages that spawn or load sibling binaries/assets from their own package directory**: `@snapmaker/snapmaker-lunar`, `snapmaker-luban-engine`, `opencv-wasm`, `errorhandler` (stylesheet), `formidable` (plugin files in its constructor), `socket.io` (serveClient)
- **template engines resolved by name at runtime**: `consolidate`, `hogan.js`

node_modules holds 99,599 files; the keep-external packages total 748 on disk.

## Measurements (same machine: 4GHz 8-core, DDR5, 7GB/s NVMe, Defender on)

| Scenario | Unbundled | Bundled |
|---|---|---|
| First launch after rebuild (new dist files) | 9.8s | 0.7s |
| First launch after reboot | 13.3s (original report) | **6.0s** |
| Warm relaunch | 0.7s | 0.7s |

Post-reboot breakdown of the remaining 6.0s (bundled):

| Phase | Time | What it is |
|---|---|---|
| Electron child spawn | 0.7s | fixed cost |
| Bundle require | 1.4s | cold read + first-open AV scan of the 5MB bundle |
| Port bind + config | 0.4s | |
| `require('./app')` | **3.7s** | the remaining *external* packages loading cold (socket.io tree, serialport tree, lunar, consolidate…) plus boot-time disk/AV contention |
| DataStorage + services | 0.1s | |

Follow-up candidates for the remaining 3.7s: bundle `socket.io` with `serveClient: false` (the app ships its own client), and audit whether `consolidate`/`hogan.js` are reachable at all (the only render calls in app.js are commented out).

Verified working against the bundled build: HTTP API, JWT signin, multipart upload through connect-multiparty, socket.io handshake + workspace page, and the full 24-tool MCP surface (`tools/list`, `get_stored_state`). Two webpack warnings remain, both verified benign: `express/lib/view.js` (engines are pre-registered via consolidate, the dynamic path never runs) and `i18next-node-fs-backend` (dynamic require only for .js/.ts locale files; ours are .json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)