### PR TITLE
Feature: Tool height measurement via the tool setter and probe feed

### DIFF
--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -47,7 +47,8 @@ mcp/
   mqtt.ts        minimal MQTT 3.1.1 client over net/tls (hand-rolled, no deps)
   probeFeed.ts   external probe sensor feed: config resolution (env->config),
                  last-reading cache per channel, overtravel tripwire latch
-  tools/         status, machine, gcode, camera, calibration, probe registrations
+  toolSetter.ts  tool height measurement: config, envelope planner, staged runner
+  tools/         status, machine, gcode, camera, calibration, probe, toolsetter
 ```
 
 External probe sensors (tool height setter, overtravel switch, CNC touch probe) report
@@ -113,10 +114,13 @@ and tool activity — all timestamped. Events: `mcp:activity`, `mcp:gcode` (whit
   calibration is keyed by machine Y AND Z. The board-viewing anchor pose is the pre-home
   park (machine X0/Y0), not machine home. The **gold cylinder at machine Y≈176–340 is the
   TOOL HEIGHT CHECKER** (operator-confirmed; was misidentified twice).
+- **Tool setter (operator-stated 2026-08-31): centre at machine (X79, Y293); it triggers at
+  machine Z176 with a 75 mm endmill in the holder** — so expected trigger Z for a bit of
+  length L is `176 + (L − 75)`. Seed `set_tool_setter_config` with these on first run.
 - Fleet: machine named "Snapmaker" @ 192.168.1.173 = the A350 CNC; "F350" @ .130 = the
   3D printer. Same Luban profile identifier — distinguish by NAME/address, never profile.
 
-## Tool surface (28)
+## Tool surface (31)
 
 `get_connection_status` · `get_machine_profile` (kinematics, module offsets) ·
 `get_position` (both frames, warnings on incoherent reporting) ·
@@ -134,7 +138,13 @@ surfaced on every capture) · `get_stored_state` (one-call orientation: calibrat
 landmarks, tool region, limits, camera config, connection, probe feed — call this first in
 a fresh session) · `get_probe_feed_status` · `connect_probe_feed` / `disconnect_probe_feed`
 (MQTT sensor feed; connecting arms the overtravel tripwire) · `clear_overtravel_alarm`
-(operator's explicit word only).
+(operator's explicit word only) · `set_/get_tool_setter_config` (setter centre, trigger Z
+with a reference bit, bit lengths — operator-stated) · `run_tool_setter` (tool height
+measurement: ONE operator approval covers a server-driven envelope-bounded routine — XY to
+centre, Z to `triggerZ + (longest−ref) + 50`, 1 mm sensor-gated descent, release, 0.1 mm
+approach, 0.3 mm backoff, ≥2 s/0.1 mm confirm pass, retreat; hard floor at expected
+trigger − margin; requires the probe feed connected and the toolsetter sensor readable
+and untriggered; `store_as_reference` locks the measured Z in as the new reference).
 
 ## Development workflow (learned the hard way)
 
@@ -166,3 +176,18 @@ a fresh session) · `get_probe_feed_status` · `connect_probe_feed` / `disconnec
   Seed the landmark registry with the tool height checker (machine Y≈176–340).
 - **#38 startup socket.io gap** — properly belongs in the startup stack; hotfixed here.
 - **#24 measurement systems, #25 collision watcher** — designed but not started.
+- **CNC touch probe (next)**: a normally-open touch probe in the spindle, reporting on the
+  probe feed channel (config already carries `mcpMqttFeedProbe`), combined with the camera
+  to measure work from the top and sides in any position including on the rotary axis.
+  Long term: a manual probe/inspection file driving a probing session, and a report
+  exportable to CAD/CAM (Fusion + free tools). The tool setter's staged
+  approach/release/confirm runner in `toolSetter.ts` is the motion template.
+- **Future probe transports (operator-stated 2026-08-31)**: MQTT may be replaced or joined
+  by hardwired USB-GPIO, or an HTTP service (e.g. a Pi running Python with a USB camera
+  plus GPIOs for the contact sensors). The transport contract is the `ProbeFeedService`
+  surface (`connect/disconnect/getReading/waitForReading/assertNoOvertravel/status`) —
+  consumers never see MQTT; a new backend implements that surface and feeds the same
+  reading cache and overtravel latch. Sensor latency is transport-dependent: local GPIO
+  would let `sensor_delay_ms` and the release timeouts collapse to near zero. The Pi's
+  camera half already fits `mcpCameraUrl` (any HTTP snapshot endpoint), so one box could
+  serve both.

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -14,6 +14,7 @@ import { registerLandmarkTools } from './tools/landmarks';
 import { registerMachineTools } from './tools/machine';
 import { registerProbeTools } from './tools/probe';
 import { registerStatusTools } from './tools/status';
+import { registerToolSetterTools } from './tools/toolsetter';
 
 const log = logger('service:mcp');
 
@@ -110,6 +111,7 @@ export function startMcpService(socketServer?: McpBroadcaster): void {
     registerCalibrationTools(registry);
     registerLandmarkTools(registry);
     registerProbeTools(registry);
+    registerToolSetterTools(registry, () => `http://127.0.0.1:${port}`);
     registeredToolCount = registry.list().length;
 
     broadcaster = socketServer || null;

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -32,8 +32,11 @@ export type McpJobState =
  * the firmware parks at the work origin on completion). 'direct' executes
  * over execute_code on approval - it persists position but is NOT subject to
  * the door interlock, so the confirm page says so and the operator supervises.
+ * 'procedure' is a server-driven measurement routine (e.g. the tool setter):
+ * the operator approves a motion ENVELOPE and the runner steps within it
+ * against live sensor feedback - also on the direct path, not interlocked.
  */
-export type McpJobKind = 'file' | 'direct';
+export type McpJobKind = 'file' | 'direct' | 'procedure';
 
 export interface McpJob {
     id: string;
@@ -57,6 +60,9 @@ export interface McpJob {
     // Staged default for direct execution: whether start_gcode_job should
     // block until the move verifiably settles (call-time arg overrides).
     waitUntilMoved?: boolean;
+    // Procedure jobs: the server-side runner start_gcode_job invokes after
+    // the operator's token is consumed. Never serialised or described.
+    runner?: () => Promise<object>;
 }
 
 function escapeHtml(text: string): string {
@@ -234,15 +240,23 @@ export class JobManager {
             ? `<ul>${v.warnings.map((w) => `<li>${escapeHtml(w)}</li>`).join('')}</ul>`
             : '<p>None.</p>';
 
-        const directBanner = job.kind === 'direct'
-            ? `<p style="background:#fff3cd;border:1px solid #b8860b;padding:10px">
+        let directBanner = '';
+        if (job.kind === 'direct') {
+            directBanner = `<p style="background:#fff3cd;border:1px solid #b8860b;padding:10px">
                    <strong>DIRECT MOVE</strong>: on start this executes over the realtime path so the
                    position <em>persists</em> - but it does NOT run as a job, so the enclosure door
-                   interlock does not apply. Supervise it.</p>`
-            : '';
+                   interlock does not apply. Supervise it.</p>`;
+        } else if (job.kind === 'procedure') {
+            directBanner = `<p style="background:#fff3cd;border:1px solid #b8860b;padding:10px">
+                   <strong>SERVER-DRIVEN PROCEDURE</strong>: on start the server steps the machine
+                   within the envelope below, gated by live probe-sensor feedback - it stops early on
+                   contact and can never exceed the extents shown. It runs on the realtime path, so
+                   the enclosure door interlock does NOT apply, and the overtravel tripwire must be
+                   armed. Supervise it.</p>`;
+        }
 
         return `
-            <h2>Confirm ${job.kind === 'direct' ? 'DIRECT move' : 'G-code job'}: ${escapeHtml(job.name)}</h2>
+            <h2>Confirm ${{ direct: 'DIRECT move', procedure: 'SERVER-DRIVEN procedure', file: 'G-code job' }[job.kind]}: ${escapeHtml(job.name)}</h2>
             <p>Submitted by an agent over MCP. Review before approving - approval mints a
                one-time code the agent needs to start it.</p>
             ${directBanner}

--- a/src/server/services/mcp/toolSetter.ts
+++ b/src/server/services/mcp/toolSetter.ts
@@ -1,0 +1,615 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention (planToolSetterRun takes
+// the run_tool_setter arguments verbatim).
+import logger from '../../lib/logger';
+import config from '../configstore';
+import { connectionManager } from '../machine/ConnectionManager';
+import { mcpBroadcast } from './index';
+import { probeFeedService } from './probeFeed';
+import { McpToolError } from './registry';
+import { GcodeChannel, sendGcodeVisible } from './tools/camera';
+import { getPositionSnapshot } from './tools/machine';
+
+const log = logger('service:mcp:tool-setter');
+
+// Tool height measurement against the fixed tool setter (the gold cylinder
+// on the A350 bed; a normally-open switch that reports over the probe feed).
+// The whole procedure is ONE operator approval: the confirm page shows the
+// motion envelope (XY centre, start Z, hard floor Z, increments, feeds) and
+// the server-side runner drives the steps deterministically against live
+// sensor feedback - the model never chooses a Z during the run.
+//
+// Staged approach (operator-specified):
+//   1. travel: XY to the centre at the current (post-home) Z, then Z down to
+//      startZ = reference trigger Z + (longest bit - reference bit) + 50 mm
+//   2. coarse: descend in 1 mm steps, checking the toolsetter feed after
+//      each settled step, until contact
+//   3. release: retreat in 1 mm steps until the feed reports released
+//   4. fine: descend in 0.1 mm steps until contact
+//   5. confirm: back off 0.3 mm, then descend 0.1 mm per >=2 s until contact
+//   6. retreat to startZ and report
+// A hard floor (expected trigger Z for the declared bit minus a margin)
+// aborts the descent; the overtravel tripwire aborts everything at any time.
+
+const CONFIG_KEY = 'mcpToolSetter';
+
+const TRAVEL_FEED = 600; // mm/min, matches the move_z cap
+const COARSE_FEED = 100;
+const FINE_FEED = 60;
+const SETTLE_TIMEOUT_MS = 30000;
+const SETTLE_POLL_MS = 250;
+const SETTLE_TOLERANCE_MM = 0.15;
+const MAX_RETREAT_MM = 5; // still triggered after this much retreat = stuck sensor
+
+export interface ToolSetterConfig {
+    centerX: number; // machine coords of the setter's centre
+    centerY: number;
+    triggerZ: number; // machine Z at trigger with the reference bit fitted
+    referenceBitLengthMm: number;
+    longestBitLengthMm: number;
+    floorMarginMm: number; // how far below the expected trigger Z to allow
+    notes: string | null;
+}
+
+export function getToolSetterConfig(): ToolSetterConfig | null {
+    const raw = config.get(CONFIG_KEY);
+    if (!raw || typeof raw !== 'object') {
+        return null;
+    }
+    const cfg = raw as { [key: string]: unknown };
+    const numbers = ['centerX', 'centerY', 'triggerZ', 'referenceBitLengthMm', 'longestBitLengthMm'];
+    if (numbers.some((key) => !Number.isFinite(Number(cfg[key])))) {
+        return null;
+    }
+    return {
+        centerX: Number(cfg.centerX),
+        centerY: Number(cfg.centerY),
+        triggerZ: Number(cfg.triggerZ),
+        referenceBitLengthMm: Number(cfg.referenceBitLengthMm),
+        longestBitLengthMm: Number(cfg.longestBitLengthMm),
+        floorMarginMm: Number.isFinite(Number(cfg.floorMarginMm)) ? Number(cfg.floorMarginMm) : 3,
+        notes: cfg.notes ? String(cfg.notes) : null,
+    };
+}
+
+export function setToolSetterConfig(cfg: ToolSetterConfig): void {
+    config.set(CONFIG_KEY, cfg);
+    log.info(`Tool setter config stored: centre (${cfg.centerX}, ${cfg.centerY}), `
+        + `trigger Z ${cfg.triggerZ} with ${cfg.referenceBitLengthMm} mm reference bit`);
+}
+
+export interface ToolSetterPlan {
+    config: ToolSetterConfig;
+    bitLengthMm: number;
+    expectedTriggerZ: number;
+    startZ: number;
+    floorZ: number;
+    // Bottom of the coarse ladder: coarse steps stop this far ABOVE the
+    // expected trigger and the descent continues in fine steps, so a
+    // correctly-declared bit presses at most one fine step into the setter
+    // (a full coarse step can overrun by up to its own size - observed
+    // 0.5 mm on the first live run).
+    coarseFloorZ: number;
+    slowZoneMm: number;
+    coarseStepMm: number;
+    fineStepMm: number;
+    backoffMm: number;
+    sensorDelayMs: number;
+    confirmPasses: number;
+    storeAsReference: boolean;
+}
+
+/**
+ * Derive the motion envelope for a declared bit length. Throws McpToolError
+ * with operator guidance when configuration or physics rule the run out.
+ */
+export function planToolSetterRun(args: {
+    bit_length_mm?: number;
+    coarse_step_mm?: number;
+    fine_step_mm?: number;
+    backoff_mm?: number;
+    sensor_delay_ms?: number;
+    confirm_passes?: number;
+    start_clearance_mm?: number;
+    slow_zone_mm?: number;
+    store_as_reference?: boolean;
+}): ToolSetterPlan {
+    const cfg = getToolSetterConfig();
+    if (!cfg) {
+        throw new McpToolError('Tool setter is not configured. Ask the operator for the setter centre '
+            + '(machine XY), the machine Z at trigger with a known bit, that bit\'s length, and the '
+            + 'longest bit in use, then store them with set_tool_setter_config.');
+    }
+    const bitLengthMm = Number(args.bit_length_mm);
+    if (!Number.isFinite(bitLengthMm) || bitLengthMm <= 0 || bitLengthMm > 300) {
+        throw new McpToolError('bit_length_mm must be the approximate protrusion of the fitted bit in mm '
+            + '(0-300), as stated by the operator.');
+    }
+    const coarseStepMm = Math.min(Math.max(Number(args.coarse_step_mm) || 1, 0.2), 2);
+    const fineStepMm = Math.min(Math.max(Number(args.fine_step_mm) || 0.1, 0.02), 0.5);
+    const backoffMm = Math.min(Math.max(Number(args.backoff_mm) || 0.3, fineStepMm), 2);
+    // 200ms default is tuned to the operator's local-broker latency; the
+    // hard floor and the overtravel tripwire backstop a missed message.
+    const sensorDelayMs = Math.min(Math.max(Number(args.sensor_delay_ms) || 200, 100), 10000);
+    const confirmPasses = Math.min(Math.max(Math.round(Number(args.confirm_passes) || 3), 1), 10);
+    const startClearanceMm = Math.min(Math.max(Number(args.start_clearance_mm) || 30, 10), 150);
+    const slowZoneMm = Math.min(Math.max(Number(args.slow_zone_mm) || 1, fineStepMm), 10);
+
+    const expectedTriggerZ = cfg.triggerZ + (bitLengthMm - cfg.referenceBitLengthMm);
+    const startZ = cfg.triggerZ + (cfg.longestBitLengthMm - cfg.referenceBitLengthMm) + startClearanceMm;
+    const floorZ = expectedTriggerZ - cfg.floorMarginMm;
+    if (floorZ < 0) {
+        throw new McpToolError(`Computed floor Z ${floorZ.toFixed(1)} is below machine Z 0 - the declared `
+            + 'bit length or stored trigger reference must be wrong. Re-check with the operator.');
+    }
+    if (startZ <= expectedTriggerZ) {
+        throw new McpToolError('Computed start Z is at or below the expected trigger Z; check '
+            + 'longestBitLengthMm and the clearance.');
+    }
+
+    return {
+        config: cfg,
+        bitLengthMm,
+        expectedTriggerZ,
+        startZ,
+        floorZ,
+        coarseFloorZ: Math.min(Math.max(expectedTriggerZ + slowZoneMm, floorZ), startZ),
+        slowZoneMm,
+        coarseStepMm,
+        fineStepMm,
+        backoffMm,
+        sensorDelayMs,
+        confirmPasses,
+        storeAsReference: args.store_as_reference === true,
+    };
+}
+
+/**
+ * The gcode shown on the confirm page. Every line is sent INDIVIDUALLY: the
+ * runner waits for each move to verifiably settle, then checks the sensor
+ * feed, before issuing the next line - so the coarse descent is enumerated
+ * step by step exactly as it would execute against a silent sensor. It stops
+ * at the first contact, after which the fine/backoff/confirm steps repeat
+ * the same one-command-per-check pattern in fine increments around the
+ * contact Z (their exact targets depend on where contact happens, and all of
+ * them lie between the contact Z plus backoff and the hard floor).
+ */
+export function describePlanAsGcode(plan: ToolSetterPlan): string {
+    const c = plan.config;
+    const lines = [
+        '; TOOL SETTER MEASUREMENT PROCEDURE (server-driven, sensor-gated)',
+        '; EVERY LINE IS SENT INDIVIDUALLY: after each move settles, the toolsetter',
+        '; feed is checked before the next line is issued. Descent stops at first',
+        '; contact - the full ladder below only executes if the sensor stays silent,',
+        `; and then the run ABORTS at the hard floor Z ${plan.floorZ.toFixed(2)}.`,
+        `; centre: machine X${c.centerX} Y${c.centerY}; declared bit ${plan.bitLengthMm} mm; expected trigger Z ${plan.expectedTriggerZ.toFixed(2)}`,
+        '; overtravel feed trips -> job stop + connection close + latched alarm',
+        'G90',
+        'G53;',
+        `G0 X${c.centerX.toFixed(3)} Y${c.centerY.toFixed(3)}; XY to setter centre at current (post-home) Z`,
+        `G1 Z${plan.startZ.toFixed(3)} F${TRAVEL_FEED}; travel to start height`,
+    ];
+    let z = plan.startZ;
+    let step = 0;
+    while (z - plan.coarseStepMm >= plan.coarseFloorZ - 1e-9) {
+        z = Math.max(z - plan.coarseStepMm, plan.coarseFloorZ);
+        step += 1;
+        lines.push(`G1 Z${z.toFixed(3)} F${COARSE_FEED}; coarse step ${step} - settle, check sensor, stop at contact`);
+    }
+    lines.push(
+        `; coarse ladder ends ${plan.slowZoneMm} mm ABOVE the expected trigger; contact above this`,
+        `; line means the bit is longer than declared (retreat ${plan.coarseStepMm} mm steps until released).`,
+        `; SLOW ZONE - fine ${plan.fineStepMm} mm steps, max press into the setter = one step:`,
+    );
+    step = 0;
+    while (z - plan.fineStepMm >= plan.floorZ - 1e-9) {
+        z -= plan.fineStepMm;
+        step += 1;
+        lines.push(`G1 Z${z.toFixed(3)} F${FINE_FEED}; fine step ${step} - settle, check sensor, stop at contact`);
+    }
+    lines.push(
+        `; ...on contact: ${plan.confirmPasses} quick confirm cycles, each = lift ${plan.backoffMm} mm, wait for the`,
+        `; sensor to release, re-approach in ${plan.fineStepMm} mm steps to contact. Result = median of the`,
+        '; cycle contacts (spread reported); a cycle never descends more than 0.5 mm below first contact.',
+        `G1 Z${plan.startZ.toFixed(3)} F${TRAVEL_FEED}; retreat to start height when done (also on any abort)`,
+        'G54;',
+    );
+    return lines.join('\n');
+}
+
+interface StepResult {
+    contact: boolean;
+    reading: { value: string; receivedAt: number } | null;
+}
+
+class ProcedureAbort extends Error {}
+
+function getDirectChannel(): GcodeChannel {
+    const channel = connectionManager.getCurrentChannel() as unknown as GcodeChannel;
+    if (!channel || typeof channel.executeGcode !== 'function') {
+        throw new ProcedureAbort('No machine channel with direct command support.');
+    }
+    return channel;
+}
+
+async function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+/**
+ * Issue one absolute machine-frame move and block until the heartbeat
+ * verifiably reports it (same contract as move_z): report newer than issue,
+ * two identical consecutive beats, machine idle, and axes at target.
+ */
+async function moveMachineSettled(
+    tool: string,
+    target: { x?: number; y?: number; z?: number },
+    feed: number
+): Promise<void> {
+    probeFeedService.assertNoOvertravel();
+    const channel = getDirectChannel();
+    const words = [
+        target.x !== undefined ? `X${target.x.toFixed(3)}` : '',
+        target.y !== undefined ? `Y${target.y.toFixed(3)}` : '',
+        target.z !== undefined ? `Z${target.z.toFixed(3)}` : '',
+    ].filter(Boolean).join(' ');
+    const gcode = `G90\nG53;\nG1 ${words} F${feed};\nG54;`;
+
+    // When every commanded axis moves by well over the tolerance, a stale
+    // pre-move heartbeat cannot sit within tolerance of the target, so the
+    // FIRST post-issue beat at the target is already proof of arrival - no
+    // need to wait out a second identical beat (~1-1.5s/step saved on the
+    // coarse ladder). Small steps (fine/confirm, at or under the tolerance)
+    // keep the strict stable-double-beat rule. Judged from the position
+    // BEFORE the move is issued.
+    const before = getPositionSnapshot();
+    const bigMove = (['x', 'y', 'z'] as const).every((axis) => {
+        const want = target[axis];
+        if (want === undefined) {
+            return true;
+        }
+        const from = before.machine[axis];
+        return from !== null && Math.abs(want - from) > SETTLE_TOLERANCE_MM * 3;
+    });
+
+    const issuedAt = Date.now();
+    const executed = await sendGcodeVisible(channel, tool, gcode);
+    if (executed.result !== 0) {
+        throw new ProcedureAbort(`Controller rejected the move: ${executed.text || executed.result}`);
+    }
+
+    // Fast path: the HTTP channel executes gcode synchronously and its reply
+    // echoes the position after completion ("X:.. Y:.. Z:.." in WORK
+    // coordinates, hardware-observed to always match the exact target). An
+    // exact echo match (0.02 mm, tighter than one fine step) is proof of
+    // arrival with no heartbeat wait (~2s/step saved - the heartbeat only
+    // ticks ~2s on the wifi channel). Anything less falls through to the
+    // strict heartbeat settle below.
+    const echo = String(executed.text || '').match(/X:(-?\d+(?:\.\d+)?)\s+Y:(-?\d+(?:\.\d+)?)\s+Z:(-?\d+(?:\.\d+)?)/);
+    if (echo) {
+        const offset = before.originOffset;
+        const echoMachine = {
+            x: Number(echo[1]) - offset.x,
+            y: Number(echo[2]) - offset.y,
+            z: Number(echo[3]) - offset.z,
+        };
+        const exact = (['x', 'y', 'z'] as const).every((axis) => {
+            const want = target[axis];
+            return want === undefined || Math.abs(echoMachine[axis] - want) <= 0.02;
+        });
+        if (exact) {
+            return;
+        }
+    }
+
+    const deadline = issuedAt + SETTLE_TIMEOUT_MS;
+    let previous: string | null = null;
+    while (Date.now() < deadline) {
+        await sleep(SETTLE_POLL_MS);
+        probeFeedService.assertNoOvertravel();
+        let now;
+        try {
+            now = getPositionSnapshot();
+        } catch (err) {
+            continue;
+        }
+        const reportTime = Date.now() - now.reportAgeMs;
+        const fingerprint = JSON.stringify([now.work, now.originOffset]);
+        const stable = fingerprint === previous;
+        previous = fingerprint;
+        if (reportTime <= issuedAt || now.machineStatus !== 'idle') {
+            continue;
+        }
+        if (!bigMove && !stable) {
+            continue;
+        }
+        const atTarget = (['x', 'y', 'z'] as const).every((axis) => {
+            const want = target[axis];
+            const have = now.machine[axis];
+            return want === undefined || (have !== null && Math.abs(have - want) <= SETTLE_TOLERANCE_MM);
+        });
+        if (atTarget) {
+            return;
+        }
+    }
+    throw new ProcedureAbort(`Timed out waiting for the heartbeat to verify the move to ${words}.`);
+}
+
+/**
+ * After a settled step, give the sensor's report time to arrive (early-exits
+ * when a fresh reading lands), then judge contact from the LAST KNOWN state -
+ * the sensor publishes on change, so silence means unchanged.
+ *
+ * This short window is for CONTACT detection while descending, where a late
+ * message merely costs one extra step before detection (self-correcting).
+ */
+async function senseAfter(stepIssuedAt: number, delayMs: number): Promise<StepResult> {
+    const fresh = await probeFeedService.waitForReading('toolsetter', stepIssuedAt, delayMs);
+    const state = fresh || probeFeedService.getReading('toolsetter');
+    return {
+        contact: !!(state && state.triggered),
+        reading: state ? { value: state.value, receivedAt: state.receivedAt } : null,
+    };
+}
+
+/**
+ * RELEASE detection needs different patience: a stale "triggered" here is a
+ * false abort (live-hit on run 2: the cloud round-trip of the release
+ * message exceeded the 200 ms contact window). Wait until the last known
+ * state reads untriggered, early-exiting on fresh readings, up to timeoutMs;
+ * only then is "still triggered" believed.
+ */
+async function senseReleaseAfter(stepIssuedAt: number, timeoutMs: number): Promise<StepResult> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        const state = probeFeedService.getReading('toolsetter');
+        if (state && !state.triggered) {
+            return { contact: false, reading: { value: state.value, receivedAt: state.receivedAt } };
+        }
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+            return {
+                contact: !!(state && state.triggered),
+                reading: state ? { value: state.value, receivedAt: state.receivedAt } : null,
+            };
+        }
+        await probeFeedService.waitForReading(
+            'toolsetter',
+            state ? state.receivedAt : stepIssuedAt,
+            Math.min(remaining, 250)
+        );
+    }
+}
+
+function assertFeedReady(): void {
+    probeFeedService.assertNoOvertravel();
+    if (!probeFeedService.isConnected()) {
+        throw new McpToolError('Probe feed is not connected - connect_probe_feed first. The overtravel '
+            + 'tripwire MUST be armed for a tool setter run.');
+    }
+    const setter = probeFeedService.getReading('toolsetter');
+    if (!setter) {
+        throw new McpToolError('No reading has ever arrived on the toolsetter feed - cannot trust the '
+            + 'sensor. Ask the operator to trigger the setter by hand and watch get_probe_feed_status '
+            + 'until the touch shows up.');
+    }
+    if (setter.triggered) {
+        throw new McpToolError(`The toolsetter feed already reads triggered ("${setter.value}") before `
+            + 'any approach - the sensor is stuck or something is resting on it. Resolve physically first.');
+    }
+}
+
+export interface ToolSetterResult {
+    measuredTriggerZ: number;
+    confirmPassContacts: number[];
+    spreadMm: number;
+    expectedTriggerZ: number;
+    deltaMm: number;
+    derivedBitLengthMm: number;
+    phases: { phase: string; z: number; note?: string }[];
+    storedAsReference: boolean;
+    note: string;
+    warning?: string;
+}
+
+/**
+ * The operator-approved run. Every motion re-checks the overtravel latch;
+ * any abort retreats to the start height when the machine still answers.
+ */
+export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<object> {
+    assertFeedReady();
+    const position = getPositionSnapshot();
+    if (position.machineStatus !== 'idle') {
+        throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);
+    }
+    if (position.isHomed !== true) {
+        throw new McpToolError('Machine does not report homed; the tool setter centre is only valid '
+            + 'after homing. Call home first.');
+    }
+    const state = connectionManager.getLatestMachineState() as { headStatus?: unknown; headPower?: unknown } | null;
+    const headPower = Number(state && state.headPower);
+    if ((Number.isFinite(headPower) && headPower > 0) || (state && (state.headStatus === true || state.headStatus === 'on'))) {
+        throw new McpToolError('Toolhead appears to be on; refusing to run the tool setter.');
+    }
+
+    const phases: { phase: string; z: number; note?: string }[] = [];
+    const c = plan.config;
+    const announce = (phase: string, z: number, note?: string) => {
+        phases.push({ phase, z: Number(z.toFixed(3)), note });
+        mcpBroadcast('mcp:activity', { tool: 'run_tool_setter', phase, z: Number(z.toFixed(3)), note });
+    };
+
+    let currentZ = plan.startZ;
+    try {
+        // Phase 1: position over the centre, then travel down to start height.
+        // XY first at the current (post-home, high) Z, so the bit never sweeps
+        // across the bed at approach height.
+        announce('travel-xy', position.machine.z ?? plan.startZ, `XY to (${c.centerX}, ${c.centerY})`);
+        await moveMachineSettled('toolsetter:travel', { x: c.centerX, y: c.centerY }, TRAVEL_FEED);
+        announce('travel-z', plan.startZ);
+        await moveMachineSettled('toolsetter:travel', { z: plan.startZ }, TRAVEL_FEED);
+
+        // Phase 2: coarse descent, sensor-checked after every settled step,
+        // ONLY down to the slow zone above the expected trigger. Contact in
+        // this phase means the bit is longer than declared (a coarse step can
+        // press up to its own size into the setter - the slow zone keeps a
+        // correctly-declared bit out of that regime).
+        let coarseContactZ: number | null = null;
+        while (currentZ - plan.coarseStepMm >= plan.coarseFloorZ - 1e-9) {
+            const stepStart = Date.now();
+            currentZ = Math.max(currentZ - plan.coarseStepMm, plan.coarseFloorZ);
+            await moveMachineSettled('toolsetter:coarse', { z: currentZ }, COARSE_FEED);
+            const sensed = await senseAfter(stepStart, plan.sensorDelayMs);
+            if (sensed.contact) {
+                coarseContactZ = currentZ;
+                announce('coarse-contact', currentZ,
+                    `sensor "${sensed.reading?.value}" ABOVE the slow zone - bit longer than declared`);
+                break;
+            }
+        }
+
+        // Release-type checks wait out the feed's real-world latency (the
+        // release message has been observed arriving ~1s after the motion);
+        // a short window here caused a false "hysteresis" abort on run 2.
+        const releaseTimeoutMs = Math.max(plan.sensorDelayMs * 4, 2500);
+
+        // Phase 3: only after a coarse contact - retreat until released, so
+        // the fine approach starts from a clear sensor.
+        if (coarseContactZ !== null) {
+            let releasedZ: number | null = null;
+            while (currentZ < coarseContactZ + MAX_RETREAT_MM) {
+                const stepStart = Date.now();
+                currentZ += plan.coarseStepMm;
+                await moveMachineSettled('toolsetter:release', { z: currentZ }, COARSE_FEED);
+                const sensed = await senseReleaseAfter(stepStart, releaseTimeoutMs);
+                if (!sensed.contact) {
+                    releasedZ = currentZ;
+                    announce('released', currentZ);
+                    break;
+                }
+            }
+            if (releasedZ === null) {
+                throw new ProcedureAbort(`Sensor still reads triggered ${MAX_RETREAT_MM} mm above first contact - `
+                    + 'stuck switch or feed fault.');
+            }
+        } else {
+            announce('slow-zone', currentZ, 'coarse ladder done, no contact; continuing in fine steps');
+        }
+
+        // Phase 4: fine approach - the primary contact phase when the
+        // declared bit length is right (max press = one fine step).
+        let fineContactZ: number | null = null;
+        while (currentZ - plan.fineStepMm >= plan.floorZ - 1e-9) {
+            const stepStart = Date.now();
+            currentZ -= plan.fineStepMm;
+            await moveMachineSettled('toolsetter:fine', { z: currentZ }, FINE_FEED);
+            const sensed = await senseAfter(stepStart, plan.sensorDelayMs);
+            if (sensed.contact) {
+                fineContactZ = currentZ;
+                announce('fine-contact', currentZ, `sensor "${sensed.reading?.value}"`);
+                break;
+            }
+        }
+        if (fineContactZ === null) {
+            throw new ProcedureAbort(`Reached the hard floor Z ${plan.floorZ.toFixed(2)} without contact. `
+                + 'The declared bit length, the stored trigger reference, or the sensor is wrong.');
+        }
+
+        // Phase 5: repeated quick lift-and-retest cycles (operator-specified
+        // protocol): each pass lifts by the backoff, waits for the sensor to
+        // actually release (patient - correctness gates on it), then
+        // re-approaches in fine steps with the SHORT contact window. A pass
+        // risks only a couple of fine steps, so a feed timing aberration
+        // shows up as spread between passes instead of biasing the result;
+        // the reported trigger Z is the median.
+        const passContacts: number[] = [];
+        const cycleFloor = Math.max(plan.floorZ, fineContactZ - 0.5);
+        let referenceContactZ = fineContactZ;
+        for (let pass = 1; pass <= plan.confirmPasses; pass++) {
+            const liftIssuedAt = Date.now();
+            currentZ = referenceContactZ + plan.backoffMm;
+            await moveMachineSettled('toolsetter:backoff', { z: currentZ }, FINE_FEED);
+            const liftSense = await senseReleaseAfter(liftIssuedAt, releaseTimeoutMs);
+            if (liftSense.contact) {
+                throw new ProcedureAbort(`Sensor still triggered ${releaseTimeoutMs} ms after backing off `
+                    + `${plan.backoffMm} mm - trigger hysteresis exceeds the backoff. Rerun with a larger backoff_mm.`);
+            }
+            let passContact: number | null = null;
+            while (currentZ - plan.fineStepMm >= cycleFloor - 1e-9) {
+                const stepStart = Date.now();
+                currentZ -= plan.fineStepMm;
+                await moveMachineSettled('toolsetter:confirm', { z: currentZ }, FINE_FEED);
+                const sensed = await senseAfter(stepStart, plan.sensorDelayMs);
+                if (sensed.contact) {
+                    passContact = currentZ;
+                    break;
+                }
+            }
+            if (passContact === null) {
+                throw new ProcedureAbort(`Confirm pass ${pass} descended to ${cycleFloor.toFixed(2)} `
+                    + '(0.5 mm below the first fine contact) without re-contact - inconsistent sensor.');
+            }
+            passContacts.push(Number(passContact.toFixed(3)));
+            announce(`confirm-${pass}`, passContact, `of ${plan.confirmPasses}`);
+            referenceContactZ = passContact;
+        }
+        const sorted = [...passContacts].sort((a, b) => a - b);
+        const measuredZ = sorted[Math.floor((sorted.length - 1) / 2)];
+        const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
+        announce('measured', measuredZ, `median of [${passContacts.join(', ')}], spread ${spreadMm} mm`);
+
+        // Phase 6: retreat to the start height and report.
+        await moveMachineSettled('toolsetter:retreat', { z: plan.startZ }, TRAVEL_FEED);
+        announce('retreated', plan.startZ);
+
+        const derivedBitLengthMm = c.referenceBitLengthMm + (measuredZ - c.triggerZ);
+        let storedAsReference = false;
+        if (plan.storeAsReference) {
+            setToolSetterConfig({
+                ...c,
+                triggerZ: measuredZ,
+                referenceBitLengthMm: plan.bitLengthMm,
+            });
+            storedAsReference = true;
+        }
+
+        const result: ToolSetterResult = {
+            measuredTriggerZ: measuredZ,
+            confirmPassContacts: passContacts,
+            spreadMm,
+            expectedTriggerZ: plan.expectedTriggerZ,
+            deltaMm: Number((measuredZ - plan.expectedTriggerZ).toFixed(3)),
+            derivedBitLengthMm: Number(derivedBitLengthMm.toFixed(3)),
+            phases,
+            storedAsReference,
+            note: `Trigger at machine Z ${measuredZ.toFixed(3)} - median of ${plan.confirmPasses} confirm `
+                + `passes [${passContacts.join(', ')}], spread ${spreadMm} mm (+/- ${plan.fineStepMm} mm step `
+                + 'resolution). The derived bit length assumes the stored reference is exact; report it '
+                + 'with that uncertainty.',
+            warning: spreadMm > plan.fineStepMm + 1e-9
+                ? `Confirm passes spread ${spreadMm} mm exceeds one fine step - feed timing was unstable; `
+                    + 'consider more confirm_passes or a longer sensor_delay_ms.'
+                : undefined,
+        };
+        return result as unknown as object;
+    } catch (err) {
+        // Best-effort retreat to the safe start height, unless the failure is
+        // the overtravel latch itself (the connection is being force-closed).
+        const isTrip = !!probeFeedService.getTrip();
+        if (!isTrip) {
+            try {
+                await moveMachineSettled('toolsetter:abort-retreat', { z: plan.startZ }, TRAVEL_FEED);
+                announce('abort-retreated', plan.startZ);
+            } catch (retreatErr) {
+                log.error(`Tool setter abort retreat failed: ${retreatErr.message}`);
+            }
+        }
+        if (err instanceof ProcedureAbort) {
+            throw new McpToolError(`Tool setter run aborted: ${err.message} `
+                + `Phases completed: ${JSON.stringify(phases)}`);
+        }
+        throw err;
+    }
+}

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -207,6 +207,30 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 throw new McpToolError(verdict.reason || 'Confirmation failed.');
             }
 
+            if (job.kind === 'procedure') {
+                // Server-driven measurement routine (e.g. run_tool_setter):
+                // the operator approved the envelope; the runner steps within
+                // it against live sensor feedback and returns the result.
+                if (typeof job.runner !== 'function') {
+                    throw new McpToolError('Procedure job has no runner (was the server restarted since '
+                        + 'submission?). Submit it again.');
+                }
+                job.state = 'started';
+                job.startedAt = Date.now();
+                try {
+                    const outcome = await job.runner();
+                    job.state = 'completed';
+                    return {
+                        job: jobManager.describe(job),
+                        result: outcome,
+                    };
+                } catch (err) {
+                    job.state = 'start_failed';
+                    job.error = err.message;
+                    throw err;
+                }
+            }
+
             if (job.kind === 'direct') {
                 // Direct moves execute over the realtime path so position
                 // PERSISTS - the firmware parks back at the work origin when

--- a/src/server/services/mcp/tools/landmarks.ts
+++ b/src/server/services/mcp/tools/landmarks.ts
@@ -6,6 +6,7 @@ import { calibrationStore } from '../calibration';
 import { Landmark, landmarkStore } from '../landmarks';
 import { probeFeedService } from '../probeFeed';
 import { McpToolError, ToolRegistry } from '../registry';
+import { getToolSetterConfig } from '../toolSetter';
 
 // Named scene landmarks (#50) and the stored-state overview (#53): operator
 // knowledge captured once, surfaced every session, so no agent spends moves
@@ -114,6 +115,7 @@ export function registerLandmarkTools(registry: ToolRegistry): void {
                 },
                 installedModules: config.get('mcpInstalledModules') || [],
                 probeFeed: probeFeedService.status(),
+                toolSetter: getToolSetterConfig(),
             };
         },
     });

--- a/src/server/services/mcp/tools/toolsetter.ts
+++ b/src/server/services/mcp/tools/toolsetter.ts
@@ -1,0 +1,161 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention.
+import { jobManager } from '../jobs';
+import { McpToolError, ToolRegistry } from '../registry';
+import {
+    describePlanAsGcode,
+    getToolSetterConfig,
+    planToolSetterRun,
+    runToolSetterProcedure,
+    setToolSetterConfig,
+} from '../toolSetter';
+import { validateGcode } from '../validator';
+
+export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUrl: () => string): void {
+    registry.register({
+        name: 'set_tool_setter_config',
+        description: 'Store the tool setter reference: its centre in MACHINE coordinates, the machine '
+            + 'Z at which a known bit triggers it, that bit\'s length, and the longest bit in use. All '
+            + 'values come from the OPERATOR (or a store_as_reference run) - never from visual '
+            + 'estimation. The expected trigger Z for any bit follows as '
+            + 'triggerZ + (bit length - reference length).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                center_x: { type: 'number', description: 'Machine X of the setter centre.' },
+                center_y: { type: 'number', description: 'Machine Y of the setter centre.' },
+                trigger_z: { type: 'number', description: 'Machine Z at trigger with the reference bit.' },
+                reference_bit_length_mm: { type: 'number', description: 'Protrusion of the reference bit, mm.' },
+                longest_bit_length_mm: { type: 'number', description: 'Longest bit in use, mm - sets the safe start height.' },
+                floor_margin_mm: { type: 'number', description: 'Allowed descent below the expected trigger Z, default 3.' },
+                notes: { type: 'string' },
+            },
+            required: ['center_x', 'center_y', 'trigger_z', 'reference_bit_length_mm', 'longest_bit_length_mm'],
+            additionalProperties: false,
+        },
+        handler: async (args: {
+            center_x?: number;
+            center_y?: number;
+            trigger_z?: number;
+            reference_bit_length_mm?: number;
+            longest_bit_length_mm?: number;
+            floor_margin_mm?: number;
+            notes?: string;
+        }) => {
+            const numbers = {
+                centerX: Number(args.center_x),
+                centerY: Number(args.center_y),
+                triggerZ: Number(args.trigger_z),
+                referenceBitLengthMm: Number(args.reference_bit_length_mm),
+                longestBitLengthMm: Number(args.longest_bit_length_mm),
+            };
+            if (Object.values(numbers).some((v) => !Number.isFinite(v))) {
+                throw new McpToolError('All coordinates and lengths must be finite numbers.');
+            }
+            if (numbers.referenceBitLengthMm <= 0 || numbers.longestBitLengthMm < numbers.referenceBitLengthMm - 0.001) {
+                throw new McpToolError('Bit lengths must be positive and longest >= reference.');
+            }
+            const floorMarginMm = args.floor_margin_mm !== undefined ? Number(args.floor_margin_mm) : 3;
+            if (!Number.isFinite(floorMarginMm) || floorMarginMm < 0.5 || floorMarginMm > 20) {
+                throw new McpToolError('floor_margin_mm must be 0.5-20.');
+            }
+            setToolSetterConfig({
+                ...numbers,
+                floorMarginMm,
+                notes: args.notes ? String(args.notes) : null,
+            });
+            return { config: getToolSetterConfig() };
+        },
+    });
+
+    registry.register({
+        name: 'get_tool_setter_config',
+        description: 'The stored tool setter reference (centre, trigger Z, bit lengths). Read-only.',
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => ({ config: getToolSetterConfig() }),
+    });
+
+    registry.register({
+        name: 'run_tool_setter',
+        description: 'Stage a tool height measurement against the tool setter for human confirmation. '
+            + 'The declared bit_length_mm comes from the OPERATOR. Preconditions: machine homed and '
+            + 'idle, probe feed connected (overtravel tripwire armed), toolsetter sensor readable and '
+            + 'not triggered. The confirm page shows the full motion envelope; after approval one '
+            + 'start_gcode_job call runs the whole server-driven routine: XY to the centre, Z travel '
+            + 'to the safe start height, 1 mm sensor-gated descent to a slow zone, 0.1 mm approach to '
+            + 'contact, then repeated quick lift-and-retest confirm cycles - retreats and reports the '
+            + 'median trigger Z, the per-pass contacts and spread, and the derived bit length. '
+            + 'A hard floor and the overtravel tripwire bound it (~1-2 minutes).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                bit_length_mm: {
+                    type: 'number',
+                    description: 'Approximate protrusion of the FITTED bit in mm, as stated by the operator.',
+                },
+                coarse_step_mm: { type: 'number', description: 'Coarse descent step, default 1 (0.2-2).' },
+                fine_step_mm: { type: 'number', description: 'Fine step, default 0.1 (0.02-0.5).' },
+                backoff_mm: { type: 'number', description: 'Backoff before the confirm pass, default 0.3.' },
+                sensor_delay_ms: { type: 'number', description: 'Wait for the sensor report after each step, default 200.' },
+                confirm_passes: {
+                    type: 'number',
+                    description: 'Quick lift-and-retest cycles after first fine contact; the result is '
+                        + 'their median and the spread is reported. Default 3 (1-10).',
+                },
+                start_clearance_mm: { type: 'number', description: 'Clearance above the longest-bit trigger height, default 30 (10-150).' },
+                slow_zone_mm: {
+                    type: 'number',
+                    description: 'The coarse ladder stops this far above the expected trigger and fine '
+                        + 'steps take over, capping the press into the setter at one fine step. Default 1.',
+                },
+                store_as_reference: {
+                    type: 'boolean',
+                    description: 'After a successful run, store the measured trigger Z and this bit '
+                        + 'length as the new reference (locks in the setter height).',
+                },
+                reason: { type: 'string', description: 'Shown to the operator: why this measurement is needed.' },
+            },
+            required: ['bit_length_mm', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { bit_length_mm?: number; reason?: string; [key: string]: unknown }) => {
+            if (!String(args.reason || '').trim()) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            const plan = planToolSetterRun(args);
+            const envelope = describePlanAsGcode(plan);
+            const validation = validateGcode(envelope);
+            const job = jobManager.submit(
+                envelope,
+                `tool-setter bit ${plan.bitLengthMm}mm - ${String(args.reason).slice(0, 40)}`,
+                'cnc',
+                validation,
+                'procedure'
+            );
+            job.runner = async () => runToolSetterProcedure(plan);
+
+            return {
+                job: jobManager.describe(job),
+                plan: {
+                    center: { x: plan.config.centerX, y: plan.config.centerY },
+                    expected_trigger_z: plan.expectedTriggerZ,
+                    start_z: plan.startZ,
+                    floor_z: plan.floorZ,
+                    coarse_floor_z: plan.coarseFloorZ,
+                    slow_zone_mm: plan.slowZoneMm,
+                    coarse_step_mm: plan.coarseStepMm,
+                    fine_step_mm: plan.fineStepMm,
+                    backoff_mm: plan.backoffMm,
+                    sensor_delay_ms: plan.sensorDelayMs,
+                    confirm_passes: plan.confirmPasses,
+                    store_as_reference: plan.storeAsReference,
+                },
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url, review the SERVER-DRIVEN PROCEDURE '
+                    + 'banner and the motion envelope, and approve. Their one-time code passed to '
+                    + 'start_gcode_job runs the whole routine; it returns the measurement when done '
+                    + '(several minutes - the confirm pass is deliberately slow).',
+            };
+        },
+    });
+}


### PR DESCRIPTION
Stacked on #61. Adds the tool height detector routine on top of the probe feed transport.

## What's here

- **`run_tool_setter`** — a new `'procedure'` job kind: the operator approves a **motion envelope** once (the confirm page shows a SERVER-DRIVEN PROCEDURE banner, the exact travel moves, the descent envelope through the validator's extents table, and the hard floor), and one `start_gcode_job` call then runs the whole server-driven routine against live sensor feedback. The model never chooses a Z during the run.
- **The staged routine** (as operator-specified): XY to the setter centre at the post-home Z → Z travel to `triggerZ + (longest bit − reference bit) + 50 mm` → 1 mm sensor-gated descent to first contact → 1 mm retreat until release → 0.1 mm fine approach → 0.3 mm backoff (aborts if the sensor stays triggered: hysteresis exceeds the backoff) → confirm pass at 0.1 mm per ≥2 s → retreat to start height and report: measured trigger Z, delta from expectation, derived bit length (with step-resolution uncertainty stated).
- **Bounded everywhere**: hard floor at `expected trigger Z − margin` (default 3 mm); every step verifies settle via the heartbeat (same contract as `move_z`) and re-checks the overtravel latch; retreat caps at 5 mm (stuck-switch detection); any abort retreats to the start height (skipped when the abort IS the overtravel trip, since the connection is being force-closed). Preconditions: homed, idle, toolhead off, probe feed connected (tripwire armed), toolsetter sensor readable and not already triggered.
- **`set_tool_setter_config` / `get_tool_setter_config`** — the operator-stated reference: centre machine XY, trigger Z with a known bit, bit lengths, floor margin. `store_as_reference: true` on a run locks the measured Z in as the new reference. Hardware facts recorded in the README: **centre (X79, Y293), trigger at machine Z176 with a 75 mm endmill** → expected trigger Z = `176 + (L − 75)`.
- 31 tools total.

## Verified (built app, live broker, no machine attached)

- Unconfigured `run_tool_setter` returns operator guidance; config stored and echoed back
- Plan math with the real hardware values: expected trigger Z 176, start Z 226, floor Z 173
- Confirm page renders the procedure banner with extents X 79..79 / Z 173..226 and the floor
- Approve mints the one-time code; `start_gcode_job` invokes the runner, which failed cleanly at its first precondition (`No machine connected.`) — correct guard order
- tsc + eslint clean

Hardware run pending (camera reconnect + a machine session). The runner in `toolSetter.ts` is the motion template for the CNC touch probe tool (next: spindle-mounted probe on the `probe` channel + camera, measuring work from top and sides including on the rotary; long-term manual inspection files + CAD/CAM reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)