### PR TITLE
Feature: Tool change workflows with work-origin offset preservation

### DIFF
--- a/.claude/skills/tool-change/SKILL.md
+++ b/.claude/skills/tool-change/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tool-change
+description: "Change the CNC tool and keep the work origin true — measure the old tool on the tool setter, park for a manual swap, measure the new tool, and shift the work origin Z by the length difference, all through the Luban MCP tool surface. Use whenever the user wants to change bits/tools mid-job-setup without re-touching the stock."
+---
+
+# Tool change without losing the work origin
+
+A tool change replaces the one physical thing the work origin Z was calibrated
+through: the tool tip. The tool setter (fixed switch on the bed, probe feed
+channel `toolsetter`) measures each tool's trigger height, and the difference
+between two measurements IS the length difference — so the work origin can be
+shifted exactly, without ever re-touching the stock.
+
+## Preconditions
+
+- Probe feed connected (`get_probe_feed_status` — this also arms the overtravel
+  tripwire) and the machine homed and idle.
+- Tool setter reference and the tool-change park position stored
+  (`get_tool_setter_config`; the operator sets them once with
+  `set_tool_setter_config` — on this machine the park is Z at the homing
+  height, X at the far end, Y free).
+- Every motion step below stages a job the OPERATOR approves on a confirm page;
+  the one-time code they give you goes to `start_gcode_job`.
+
+## Two flows — ask which one the operator is using
+
+**A. MCP-managed offset** (operator at the computer): measure old → park → swap
+→ measure new → `apply_tool_length_offset` shifts the work origin. Steps below.
+
+**B. Touchscreen manual-swap wizard** (operator at the machine): the FIRMWARE
+matches the tip positions itself, so no origin shift is applied by MCP — the
+agent's job is only to find and HOLD the trigger height for each tool:
+
+1. `run_tool_setter` with `stay_at_trigger: true` — one move up, over to the
+   setter, measure, and hold the tip in contact. Send no other motion.
+2. The operator confirms the position on the touchscreen and swaps the tool by
+   hand; the wizard returns the new tool over the setter near height.
+3. `run_tool_setter` again with `stay_at_trigger: true, start_from_current:
+   true` (skips travel; verified over the centre within 1.5 mm). The operator
+   confirms the matched position on the touchscreen — the firmware applies the
+   offset. Do NOT also call `apply_tool_length_offset` (it would double-apply).
+4. Only after the operator says the wizard is finished may motion resume.
+
+If the new tool reads already-triggered before the second run (a longer tool
+pressed into the setter by the wizard), the run refuses to start - the
+operator raises it slightly from the touchscreen first.
+
+## The sequence (flow A)
+
+1. **Measure the old tool** — `run_tool_setter` with the operator-stated
+   `bit_length_mm`. Skip only if the last stored measurement
+   (`get_tool_setter_config` → `measurements.last`) is from this same tool,
+   this session, and the operator confirms nothing has moved.
+2. **Park** — `goto_tool_change_position`. One approval, two
+   `start_gcode_job` calls: Z rises to the park height first, then X/Y.
+3. **The operator swaps the tool by hand.** Wait for their word; never infer
+   it. Ask them for the new tool's approximate length.
+4. **Measure the new tool** — `run_tool_setter` with the new `bit_length_mm`.
+   The measurement history now holds previous = old tool, last = new tool.
+5. **Shift the work origin** — `apply_tool_length_offset` (defaults to those
+   two measurements). It stages a single `G92` — nothing moves; the work frame
+   shifts by `new − old`. A longer tool makes the current work Z read LOWER.
+6. **Verify** — `get_position`: `originOffset.z` must have changed by the
+   delta, and the operator should sanity-check the displayed work Z against
+   physical reality before any cutting.
+
+## Failure modes to respect
+
+- The spread reported by `run_tool_setter` is the trust metric: passes that
+  disagree by more than one fine step mean feed latency or a loose tool —
+  re-measure before applying any offset.
+- `apply_tool_length_offset` refuses deltas over 50 mm; if it triggers, the
+  stored measurements are not an old/new pair (stale history, wrong bit
+  declared). Pass `old_trigger_z`/`new_trigger_z` explicitly from known-good
+  values instead of loosening anything.
+- If the overtravel alarm latches at any point, everything stops until the
+  operator physically inspects and explicitly clears it
+  (`clear_overtravel_alarm`).

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -102,7 +102,9 @@ and tool activity — all timestamped. Events: `mcp:activity`, `mcp:gcode` (whit
 - Controller has **G53 (machine workspace) and G54+ (numbered workspaces)**; the heartbeat
   `pos` is in the *currently selected* workspace. Convention everywhere:
   `machine = work − originOffset`.
-- **Machine home = (−19, 342, 328)**; homing = `G53;G28;G54` exactly like Luban's button
+- **Machine home = (−19, 342, 328)**; **firmware X limit = 339** (sweep-verified 2026-09-01:
+  tracks requests exactly through 330, clamps a 340 request at 339 — the tool-change park X);
+  homing = `G53;G28;G54` exactly like Luban's button
   (a bare G28 leaves reporting in an unselected workspace → impossible derived coords like
   Y 464/Z 656). Homing takes ~15–20 s and **also homes B — stock on the rotary rotates**.
 - **Work origins are operator-set per workspace and persist across homing.**
@@ -120,7 +122,7 @@ and tool activity — all timestamped. Events: `mcp:activity`, `mcp:gcode` (whit
 - Fleet: machine named "Snapmaker" @ 192.168.1.173 = the A350 CNC; "F350" @ .130 = the
   3D printer. Same Luban profile identifier — distinguish by NAME/address, never profile.
 
-## Tool surface (31)
+## Tool surface (33)
 
 `get_connection_status` · `get_machine_profile` (kinematics, module offsets) ·
 `get_position` (both frames, warnings on incoherent reporting) ·
@@ -144,7 +146,30 @@ measurement: ONE operator approval covers a server-driven envelope-bounded routi
 centre, Z to `triggerZ + (longest−ref) + 50`, 1 mm sensor-gated descent, release, 0.1 mm
 approach, 0.3 mm backoff, ≥2 s/0.1 mm confirm pass, retreat; hard floor at expected
 trigger − margin; requires the probe feed connected and the toolsetter sensor readable
-and untriggered; `store_as_reference` locks the measured Z in as the new reference).
+and untriggered; `store_as_reference` locks the measured Z in as the new reference;
+`stay_at_trigger` / `start_from_current` support the touchscreen swap wizard) ·
+`goto_tool_change_position` (two approved steps: Z up, then X/Y to the operator-set park) ·
+`apply_tool_length_offset` (confirmed G92 shifting work-origin Z by the measured
+new−old tool length difference — flow A only).
+
+## Tool change workflows
+
+**A — MCP-managed offset**: measure old tool (`run_tool_setter`) →
+`goto_tool_change_position` (operator-set park: machine Z at homing height, X at the far
+end, Y free — stored via `set_tool_setter_config` `tool_change_x/y/z`) → operator swaps by
+hand → measure new tool → `apply_tool_length_offset` stages a single
+`G92 Z(current work Z − (new−old))` for confirmation: nothing moves, the work frame shifts
+so work Z 0 stays on the same physical plane. Measurement history (last/previous) persists
+in the config; deltas over 50 mm are refused.
+
+**B — touchscreen manual-swap wizard**: the firmware matches tip positions itself, so MCP
+applies NO offset. `run_tool_setter` with `stay_at_trigger: true` measures and HOLDS the
+tip in contact for the operator to confirm on the touchscreen; after the swap the wizard
+returns the tool over the setter, and the second run adds `start_from_current: true`
+(skips travel, verified over the centre within 1.5 mm). Never combine flow B with
+`apply_tool_length_offset` — it would double-apply.
+
+Full agent guidance in `.claude/skills/tool-change/SKILL.md`.
 
 ## Development workflow (learned the hard way)
 

--- a/src/server/services/mcp/toolSetter.ts
+++ b/src/server/services/mcp/toolSetter.ts
@@ -48,15 +48,51 @@ export interface ToolSetterConfig {
     referenceBitLengthMm: number;
     longestBitLengthMm: number;
     floorMarginMm: number; // how far below the expected trigger Z to allow
+    // Tool-change park position (machine coords), operator preference: on
+    // this setup Z = the homing height and X = the far end; Y is free (null
+    // = leave the current Y alone).
+    changeX: number | null;
+    changeY: number | null;
+    changeZ: number | null;
     notes: string | null;
 }
 
-export function getToolSetterConfig(): ToolSetterConfig | null {
+/** One completed tool setter measurement, kept for tool-change offsets. */
+export interface ToolMeasurement {
+    measuredTriggerZ: number;
+    bitLengthMm: number;
+    spreadMm: number;
+    at: number;
+}
+
+function rawConfig(): { [key: string]: unknown } {
     const raw = config.get(CONFIG_KEY);
+    return raw && typeof raw === 'object' ? (raw as { [key: string]: unknown }) : {};
+}
+
+function numberOrNull(value: unknown): number | null {
+    return Number.isFinite(Number(value)) && value !== null && value !== '' && value !== undefined
+        ? Number(value) : null;
+}
+
+function parseMeasurement(raw: unknown): ToolMeasurement | null {
     if (!raw || typeof raw !== 'object') {
         return null;
     }
-    const cfg = raw as { [key: string]: unknown };
+    const m = raw as { [key: string]: unknown };
+    if (!Number.isFinite(Number(m.measuredTriggerZ)) || !Number.isFinite(Number(m.at))) {
+        return null;
+    }
+    return {
+        measuredTriggerZ: Number(m.measuredTriggerZ),
+        bitLengthMm: Number(m.bitLengthMm),
+        spreadMm: Number(m.spreadMm) || 0,
+        at: Number(m.at),
+    };
+}
+
+export function getToolSetterConfig(): ToolSetterConfig | null {
+    const cfg = rawConfig();
     const numbers = ['centerX', 'centerY', 'triggerZ', 'referenceBitLengthMm', 'longestBitLengthMm'];
     if (numbers.some((key) => !Number.isFinite(Number(cfg[key])))) {
         return null;
@@ -68,14 +104,36 @@ export function getToolSetterConfig(): ToolSetterConfig | null {
         referenceBitLengthMm: Number(cfg.referenceBitLengthMm),
         longestBitLengthMm: Number(cfg.longestBitLengthMm),
         floorMarginMm: Number.isFinite(Number(cfg.floorMarginMm)) ? Number(cfg.floorMarginMm) : 3,
+        changeX: numberOrNull(cfg.changeX),
+        changeY: numberOrNull(cfg.changeY),
+        changeZ: numberOrNull(cfg.changeZ),
         notes: cfg.notes ? String(cfg.notes) : null,
     };
 }
 
+/** Merge-write: measurement history and unknown fields survive config edits. */
 export function setToolSetterConfig(cfg: ToolSetterConfig): void {
-    config.set(CONFIG_KEY, cfg);
+    config.set(CONFIG_KEY, { ...rawConfig(), ...cfg });
     log.info(`Tool setter config stored: centre (${cfg.centerX}, ${cfg.centerY}), `
         + `trigger Z ${cfg.triggerZ} with ${cfg.referenceBitLengthMm} mm reference bit`);
+}
+
+export function getMeasurements(): { last: ToolMeasurement | null; previous: ToolMeasurement | null } {
+    const cfg = rawConfig();
+    return {
+        last: parseMeasurement(cfg.lastMeasurement),
+        previous: parseMeasurement(cfg.previousMeasurement),
+    };
+}
+
+/** Record a completed measurement, shifting the old one down a slot. */
+export function recordMeasurement(measurement: ToolMeasurement): void {
+    const cfg = rawConfig();
+    config.set(CONFIG_KEY, {
+        ...cfg,
+        previousMeasurement: cfg.lastMeasurement || null,
+        lastMeasurement: measurement,
+    });
 }
 
 export interface ToolSetterPlan {
@@ -97,6 +155,11 @@ export interface ToolSetterPlan {
     sensorDelayMs: number;
     confirmPasses: number;
     storeAsReference: boolean;
+    // Touchscreen manual-swap wizard support: hold at the measured trigger
+    // (in contact) instead of retreating, and/or start the descent from the
+    // current position (wizard returns the new tool over the setter).
+    stayAtTrigger: boolean;
+    startFromCurrent: boolean;
 }
 
 /**
@@ -113,6 +176,8 @@ export function planToolSetterRun(args: {
     start_clearance_mm?: number;
     slow_zone_mm?: number;
     store_as_reference?: boolean;
+    stay_at_trigger?: boolean;
+    start_from_current?: boolean;
 }): ToolSetterPlan {
     const cfg = getToolSetterConfig();
     if (!cfg) {
@@ -161,6 +226,8 @@ export function planToolSetterRun(args: {
         sensorDelayMs,
         confirmPasses,
         storeAsReference: args.store_as_reference === true,
+        stayAtTrigger: args.stay_at_trigger === true,
+        startFromCurrent: args.start_from_current === true,
     };
 }
 
@@ -186,9 +253,16 @@ export function describePlanAsGcode(plan: ToolSetterPlan): string {
         '; overtravel feed trips -> job stop + connection close + latched alarm',
         'G90',
         'G53;',
-        `G0 X${c.centerX.toFixed(3)} Y${c.centerY.toFixed(3)}; XY to setter centre at current (post-home) Z`,
-        `G1 Z${plan.startZ.toFixed(3)} F${TRAVEL_FEED}; travel to start height`,
     ];
+    if (plan.startFromCurrent) {
+        lines.push('; START FROM CURRENT POSITION (verified over the setter centre within 1.5 mm);',
+            '; no travel moves - the descent below begins at the current Z (capped at the start height).');
+    } else {
+        lines.push(
+            `G0 X${c.centerX.toFixed(3)} Y${c.centerY.toFixed(3)}; XY to setter centre at current (post-home) Z`,
+            `G1 Z${plan.startZ.toFixed(3)} F${TRAVEL_FEED}; travel to start height`,
+        );
+    }
     let z = plan.startZ;
     let step = 0;
     while (z - plan.coarseStepMm >= plan.coarseFloorZ - 1e-9) {
@@ -211,9 +285,14 @@ export function describePlanAsGcode(plan: ToolSetterPlan): string {
         `; ...on contact: ${plan.confirmPasses} quick confirm cycles, each = lift ${plan.backoffMm} mm, wait for the`,
         `; sensor to release, re-approach in ${plan.fineStepMm} mm steps to contact. Result = median of the`,
         '; cycle contacts (spread reported); a cycle never descends more than 0.5 mm below first contact.',
-        `G1 Z${plan.startZ.toFixed(3)} F${TRAVEL_FEED}; retreat to start height when done (also on any abort)`,
-        'G54;',
     );
+    if (plan.stayAtTrigger) {
+        lines.push('; HOLD AT TRIGGER when done: the tip stays in contact for the touchscreen manual-swap',
+            `; wizard - NO final retreat. (Any ABORT still retreats to Z ${plan.startZ.toFixed(3)}.)`);
+    } else {
+        lines.push(`G1 Z${plan.startZ.toFixed(3)} F${TRAVEL_FEED}; retreat to start height when done (also on any abort)`);
+    }
+    lines.push('G54;');
     return lines.join('\n');
 }
 
@@ -443,13 +522,33 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
 
     let currentZ = plan.startZ;
     try {
-        // Phase 1: position over the centre, then travel down to start height.
-        // XY first at the current (post-home, high) Z, so the bit never sweeps
-        // across the bed at approach height.
-        announce('travel-xy', position.machine.z ?? plan.startZ, `XY to (${c.centerX}, ${c.centerY})`);
-        await moveMachineSettled('toolsetter:travel', { x: c.centerX, y: c.centerY }, TRAVEL_FEED);
-        announce('travel-z', plan.startZ);
-        await moveMachineSettled('toolsetter:travel', { z: plan.startZ }, TRAVEL_FEED);
+        if (plan.startFromCurrent) {
+            // Touchscreen-wizard flow: the machine is already positioned over
+            // the setter (the wizard returns it there after the swap). Verify
+            // rather than trust, then descend from where we are.
+            const { x, y, z } = position.machine;
+            if (x === null || y === null || z === null) {
+                throw new ProcedureAbort('start_from_current: current machine position unknown.');
+            }
+            if (Math.abs(x - c.centerX) > 1.5 || Math.abs(y - c.centerY) > 1.5) {
+                throw new ProcedureAbort(`start_from_current: machine XY (${x.toFixed(1)}, ${y.toFixed(1)}) `
+                    + `is not over the setter centre (${c.centerX}, ${c.centerY}) within 1.5 mm.`);
+            }
+            if (z <= plan.floorZ) {
+                throw new ProcedureAbort(`start_from_current: machine Z ${z.toFixed(2)} is at or below the `
+                    + `hard floor ${plan.floorZ.toFixed(2)}.`);
+            }
+            currentZ = Math.min(z, plan.startZ);
+            announce('start-from-current', currentZ, 'skipping travel; descending from the current position');
+        } else {
+            // Phase 1: position over the centre, then travel down to start
+            // height. XY first at the current (post-home, high) Z, so the bit
+            // never sweeps across the bed at approach height.
+            announce('travel-xy', position.machine.z ?? plan.startZ, `XY to (${c.centerX}, ${c.centerY})`);
+            await moveMachineSettled('toolsetter:travel', { x: c.centerX, y: c.centerY }, TRAVEL_FEED);
+            announce('travel-z', plan.startZ);
+            await moveMachineSettled('toolsetter:travel', { z: plan.startZ }, TRAVEL_FEED);
+        }
 
         // Phase 2: coarse descent, sensor-checked after every settled step,
         // ONLY down to the slow zone above the expected trigger. Contact in
@@ -560,11 +659,27 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
         const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
         announce('measured', measuredZ, `median of [${passContacts.join(', ')}], spread ${spreadMm} mm`);
 
-        // Phase 6: retreat to the start height and report.
-        await moveMachineSettled('toolsetter:retreat', { z: plan.startZ }, TRAVEL_FEED);
-        announce('retreated', plan.startZ);
+        // Phase 6: retreat to the start height - unless the touchscreen
+        // manual-swap wizard needs the tip HELD at the trigger so the
+        // operator can confirm the matched position there.
+        if (plan.stayAtTrigger) {
+            const holdIssuedAt = Date.now();
+            currentZ = measuredZ;
+            await moveMachineSettled('toolsetter:hold', { z: currentZ }, FINE_FEED);
+            await probeFeedService.waitForReading('toolsetter', holdIssuedAt, plan.sensorDelayMs);
+            announce('holding-at-trigger', measuredZ, 'NOT retreating - touchscreen wizard takes over');
+        } else {
+            await moveMachineSettled('toolsetter:retreat', { z: plan.startZ }, TRAVEL_FEED);
+            announce('retreated', plan.startZ);
+        }
 
         const derivedBitLengthMm = c.referenceBitLengthMm + (measuredZ - c.triggerZ);
+        recordMeasurement({
+            measuredTriggerZ: measuredZ,
+            bitLengthMm: plan.bitLengthMm,
+            spreadMm,
+            at: Date.now(),
+        });
         let storedAsReference = false;
         if (plan.storeAsReference) {
             setToolSetterConfig({
@@ -587,7 +702,10 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
             note: `Trigger at machine Z ${measuredZ.toFixed(3)} - median of ${plan.confirmPasses} confirm `
                 + `passes [${passContacts.join(', ')}], spread ${spreadMm} mm (+/- ${plan.fineStepMm} mm step `
                 + 'resolution). The derived bit length assumes the stored reference is exact; report it '
-                + 'with that uncertainty.',
+                + `with that uncertainty.${plan.stayAtTrigger
+                    ? ' HOLDING AT THE TRIGGER (in contact, no retreat): the operator confirms on the '
+                        + 'touchscreen wizard from here - send no other motion until they say the swap flow is done.'
+                    : ''}`,
             warning: spreadMm > plan.fineStepMm + 1e-9
                 ? `Confirm passes spread ${spreadMm} mm exceeds one fine step - feed timing was unstable; `
                     + 'consider more confirm_passes or a longer sensor_delay_ms.'

--- a/src/server/services/mcp/tools/toolsetter.ts
+++ b/src/server/services/mcp/tools/toolsetter.ts
@@ -1,15 +1,19 @@
 /* eslint-disable camelcase */
 // MCP tool arguments are snake_case by convention.
+import { connectionManager } from '../../machine/ConnectionManager';
 import { jobManager } from '../jobs';
+import { probeFeedService } from '../probeFeed';
 import { McpToolError, ToolRegistry } from '../registry';
 import {
     describePlanAsGcode,
+    getMeasurements,
     getToolSetterConfig,
     planToolSetterRun,
     runToolSetterProcedure,
     setToolSetterConfig,
 } from '../toolSetter';
 import { validateGcode } from '../validator';
+import { getPositionSnapshot } from './machine';
 
 export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUrl: () => string): void {
     registry.register({
@@ -28,6 +32,9 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
                 reference_bit_length_mm: { type: 'number', description: 'Protrusion of the reference bit, mm.' },
                 longest_bit_length_mm: { type: 'number', description: 'Longest bit in use, mm - sets the safe start height.' },
                 floor_margin_mm: { type: 'number', description: 'Allowed descent below the expected trigger Z, default 3.' },
+                tool_change_x: { type: 'number', description: 'Machine X of the tool-change park position (operator preference).' },
+                tool_change_y: { type: 'number', description: 'Machine Y of the park position; omit if Y does not matter.' },
+                tool_change_z: { type: 'number', description: 'Machine Z of the park position, typically the homing height.' },
                 notes: { type: 'string' },
             },
             required: ['center_x', 'center_y', 'trigger_z', 'reference_bit_length_mm', 'longest_bit_length_mm'],
@@ -40,6 +47,9 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
             reference_bit_length_mm?: number;
             longest_bit_length_mm?: number;
             floor_margin_mm?: number;
+            tool_change_x?: number;
+            tool_change_y?: number;
+            tool_change_z?: number;
             notes?: string;
         }) => {
             const numbers = {
@@ -59,9 +69,22 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
             if (!Number.isFinite(floorMarginMm) || floorMarginMm < 0.5 || floorMarginMm > 20) {
                 throw new McpToolError('floor_margin_mm must be 0.5-20.');
             }
+            const existing = getToolSetterConfig();
+            const changeCoord = (value: number | undefined, previous: number | null): number | null => {
+                if (value === undefined) {
+                    return previous;
+                }
+                if (!Number.isFinite(Number(value))) {
+                    throw new McpToolError('Tool change coordinates must be finite numbers.');
+                }
+                return Number(value);
+            };
             setToolSetterConfig({
                 ...numbers,
                 floorMarginMm,
+                changeX: changeCoord(args.tool_change_x, existing ? existing.changeX : null),
+                changeY: changeCoord(args.tool_change_y, existing ? existing.changeY : null),
+                changeZ: changeCoord(args.tool_change_z, existing ? existing.changeZ : null),
                 notes: args.notes ? String(args.notes) : null,
             });
             return { config: getToolSetterConfig() };
@@ -70,9 +93,10 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
 
     registry.register({
         name: 'get_tool_setter_config',
-        description: 'The stored tool setter reference (centre, trigger Z, bit lengths). Read-only.',
+        description: 'The stored tool setter reference (centre, trigger Z, bit lengths, tool-change '
+            + 'park position) and the last two measurements. Read-only.',
         inputSchema: { type: 'object', properties: {}, additionalProperties: false },
-        handler: async () => ({ config: getToolSetterConfig() }),
+        handler: async () => ({ config: getToolSetterConfig(), measurements: getMeasurements() }),
     });
 
     registry.register({
@@ -113,6 +137,18 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
                     description: 'After a successful run, store the measured trigger Z and this bit '
                         + 'length as the new reference (locks in the setter height).',
                 },
+                stay_at_trigger: {
+                    type: 'boolean',
+                    description: 'HOLD the tip at the measured trigger (in contact) instead of '
+                        + 'retreating - for the touchscreen manual-swap wizard, where the operator '
+                        + 'confirms the matched position there. Send no other motion until they finish.',
+                },
+                start_from_current: {
+                    type: 'boolean',
+                    description: 'Skip the XY move and Z travel; descend from the CURRENT position '
+                        + '(verified over the setter centre within 1.5 mm) - for when the touchscreen '
+                        + 'wizard has already returned the new tool over the setter.',
+                },
                 reason: { type: 'string', description: 'Shown to the operator: why this measurement is needed.' },
             },
             required: ['bit_length_mm', 'reason'],
@@ -149,12 +185,151 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
                     sensor_delay_ms: plan.sensorDelayMs,
                     confirm_passes: plan.confirmPasses,
                     store_as_reference: plan.storeAsReference,
+                    stay_at_trigger: plan.stayAtTrigger,
+                    start_from_current: plan.startFromCurrent,
                 },
                 confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
                 next_step: 'Ask the operator to open confirm_url, review the SERVER-DRIVEN PROCEDURE '
                     + 'banner and the motion envelope, and approve. Their one-time code passed to '
                     + 'start_gcode_job runs the whole routine; it returns the measurement when done '
                     + '(several minutes - the confirm pass is deliberately slow).',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'goto_tool_change_position',
+        description: 'Stage the move to the operator-set tool-change park position (machine coords '
+            + 'from set_tool_setter_config: typically Z at the homing height and X at the far end; '
+            + 'Y only if configured). Two approved steps: Z up first, then X/Y. The operator then '
+            + 'swaps the tool BY HAND; afterwards run_tool_setter measures the new tool and '
+            + 'apply_tool_length_offset shifts the work origin by the length difference.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                reason: { type: 'string', description: 'Shown to the operator.' },
+            },
+            required: ['reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { reason?: string }) => {
+            probeFeedService.assertNoOvertravel();
+            const cfg = getToolSetterConfig();
+            if (!cfg || cfg.changeZ === null || cfg.changeX === null) {
+                throw new McpToolError('No tool-change position stored. Ask the operator for it and set '
+                    + 'tool_change_x / tool_change_z (and optionally _y) via set_tool_setter_config.');
+            }
+            const position = getPositionSnapshot();
+            if (position.machineStatus !== 'idle') {
+                throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);
+            }
+            if (position.isHomed !== true) {
+                throw new McpToolError('Machine does not report homed; home before the tool-change move.');
+            }
+            const state = connectionManager.getLatestMachineState() as { headStatus?: unknown; headPower?: unknown } | null;
+            const headPower = Number(state && state.headPower);
+            if ((Number.isFinite(headPower) && headPower > 0) || (state && (state.headStatus === true || state.headStatus === 'on'))) {
+                throw new McpToolError('Toolhead appears to be on; refusing the tool-change move.');
+            }
+
+            // Z clears first, at the move_z feed cap; XY travels as a rapid
+            // only once at height. One approval covers both exact steps.
+            const steps = [
+                `G90\nG53;\nG1 Z${cfg.changeZ.toFixed(3)} F600;\nG54;`,
+                `G90\nG53;\nG0 X${cfg.changeX.toFixed(3)}${cfg.changeY !== null ? ` Y${cfg.changeY.toFixed(3)}` : ''};\nG54;`,
+            ];
+            const reviewText = steps.join('\n; --- next approved step ---\n');
+            const validation = validateGcode(reviewText);
+            const job = jobManager.submit(
+                reviewText,
+                `tool-change park Z${cfg.changeZ} X${cfg.changeX} - ${String(args.reason).slice(0, 40)}`,
+                'cnc',
+                validation,
+                'direct',
+                steps
+            );
+            return {
+                job: jobManager.describe(job),
+                park: { x: cfg.changeX, y: cfg.changeY, z: cfg.changeZ },
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Operator approves once; call start_gcode_job with the code TWICE (Z step, '
+                    + 'then XY step). Then the operator swaps the tool by hand; measure it with '
+                    + 'run_tool_setter and finish with apply_tool_length_offset.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'apply_tool_length_offset',
+        description: 'After a tool change: shift the CURRENT work origin Z by the measured length '
+            + 'difference between the last two tool setter measurements (new - previous; overridable '
+            + 'via explicit old/new trigger Zs), so work Z keeps meaning the same physical plane with '
+            + 'the new tool. Stages a single G92 for operator confirmation - nothing moves; the work '
+            + 'coordinate frame shifts. Verify with get_position afterwards.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                old_trigger_z: { type: 'number', description: 'Machine trigger Z of the OLD tool. Default: the previous measurement.' },
+                new_trigger_z: { type: 'number', description: 'Machine trigger Z of the NEW tool. Default: the last measurement.' },
+                reason: { type: 'string', description: 'Shown to the operator.' },
+            },
+            required: ['reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { old_trigger_z?: number; new_trigger_z?: number; reason?: string }) => {
+            probeFeedService.assertNoOvertravel();
+            const measurements = getMeasurements();
+            const oldZ = args.old_trigger_z !== undefined ? Number(args.old_trigger_z)
+                : measurements.previous?.measuredTriggerZ;
+            const newZ = args.new_trigger_z !== undefined ? Number(args.new_trigger_z)
+                : measurements.last?.measuredTriggerZ;
+            if (oldZ === undefined || newZ === undefined || !Number.isFinite(oldZ) || !Number.isFinite(newZ)) {
+                throw new McpToolError('Need two measurements: previous (old tool) and last (new tool). '
+                    + 'Either run run_tool_setter before and after the change, or pass old_trigger_z / '
+                    + `new_trigger_z explicitly. Stored: ${JSON.stringify(measurements)}`);
+            }
+            const deltaMm = Number((newZ - oldZ).toFixed(3));
+            if (Math.abs(deltaMm) > 50) {
+                throw new McpToolError(`Computed length difference ${deltaMm} mm exceeds the 50 mm sanity `
+                    + 'limit - the two measurements are probably not an old/new pair of the same setup.');
+            }
+
+            const position = getPositionSnapshot();
+            if (position.machineStatus !== 'idle') {
+                throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);
+            }
+            if (position.work.z === null) {
+                throw new McpToolError('Current work Z unknown; cannot compute the G92.');
+            }
+            // A tool longer by delta puts the tip delta lower at the same
+            // toolhead height, so the SAME position must now read delta LESS
+            // work Z: G92 Z(current work Z - delta). Nothing moves.
+            const newWorkZ = Number((position.work.z - deltaMm).toFixed(3));
+            const gcode = [
+                `; tool length offset: new tool trigger Z ${newZ} vs old ${oldZ} -> ${deltaMm >= 0 ? '+' : ''}${deltaMm} mm ${deltaMm >= 0 ? 'longer' : 'shorter'}`,
+                `; current work Z reads ${position.work.z}; after this G92 it reads ${newWorkZ} (no motion)`,
+                '; work origin Z shifts so work Z 0 stays on the same physical plane with the new tool',
+                `G92 Z${newWorkZ.toFixed(3)}`,
+            ].join('\n');
+            const validation = validateGcode(gcode);
+            const job = jobManager.submit(
+                gcode,
+                `tool-offset ${deltaMm >= 0 ? '+' : ''}${deltaMm}mm - ${String(args.reason).slice(0, 40)}`,
+                'cnc',
+                validation,
+                'direct'
+            );
+            return {
+                job: jobManager.describe(job),
+                old_trigger_z: oldZ,
+                new_trigger_z: newZ,
+                delta_mm: deltaMm,
+                current_work_z: position.work.z,
+                work_z_after: newWorkZ,
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Operator reviews the G92 (no motion - the work frame shifts by the tool '
+                    + 'length difference) and approves; start_gcode_job executes it. Verify with '
+                    + 'get_position that originOffset.z changed by the delta.',
             };
         },
     });


### PR DESCRIPTION
Stacked on #63. Changing the tool replaces the one physical thing the work origin Z was calibrated through: the tool tip. The tool setter measures each tool's trigger height, and the difference between two measurements IS the length difference — so the origin can be corrected exactly, without re-touching the stock. Two operator flows:

## Flow A — MCP-managed offset
1. `run_tool_setter` (old tool) — measurement lands in a persisted last/previous history.
2. `goto_tool_change_position` — operator-set park (`tool_change_x/y/z` on the setter config; this machine: Z at the homing height, X at the far end, Y free). One approval, two `start_gcode_job` steps: **Z clears first**, then X/Y.
3. Operator swaps the tool by hand.
4. `run_tool_setter` (new tool).
5. `apply_tool_length_offset` — stages a single confirmed `G92 Z(current work Z − (new−old))`: nothing moves, the work frame shifts so work Z 0 stays on the same physical plane. Deltas over 50 mm are refused as a mismatched measurement pair; the confirm page shows the before/after work Z and the sign reasoning.

## Flow B — touchscreen manual-swap wizard
The firmware matches tip positions itself, so MCP applies **no** offset. `run_tool_setter` gains:
- `stay_at_trigger` — measure, then **hold the tip in contact** (no retreat) so the operator confirms the matched position on the touchscreen; any abort still retreats to the start height.
- `start_from_current` — skip the XY move and Z travel when the wizard has already returned the tool over the setter (verified within 1.5 mm of the centre and above the hard floor before being trusted).

The skill file `.claude/skills/tool-change/SKILL.md` documents both flows, when to use which, and the failure modes (spread as the trust metric, the already-triggered refusal when a longer tool comes back pressed into the setter, never combining flow B with `apply_tool_length_offset`).

33 tools total. Hardware test pending (needs a second bit on hand); the G92 path is the same one Luban's own set-work-origin uses on the HTTP channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)