### PR TITLE
Feature: Touch probe point measurement and whole-bed camera survey

### DIFF
--- a/src/server/services/mcp/McpServer.ts
+++ b/src/server/services/mcp/McpServer.ts
@@ -204,12 +204,29 @@ export class McpServer {
             return rpcError(id, JSONRPC_INVALID_PARAMS, `Unknown tool: ${name}`);
         }
 
-        // One line per call, arguments elided (they can carry whole gcode
-        // files); enough to follow agent activity from the server log.
+        // Every call logs its arguments and a result summary (truncated -
+        // args can carry whole gcode files, results whole images), so the
+        // server log alone tells the story of an agent session.
+        const summarize = (value: unknown, limit: number): string => {
+            let text: string;
+            try {
+                text = JSON.stringify(value, (key, v) => {
+                    if (typeof v === 'string' && v.length > 300) {
+                        return `${v.slice(0, 120)}...<${v.length} chars>`;
+                    }
+                    return v;
+                }) || 'undefined';
+            } catch (err) {
+                text = String(value);
+            }
+            return text.length > limit ? `${text.slice(0, limit)}...<truncated>` : text;
+        };
+        const args = ((params && params.arguments) as object) || {};
         const startedAt = Date.now();
+        log.info(`tool ${name} <- ${summarize(args, 600)}`);
         try {
-            const result = await this.registry.call(name, ((params && params.arguments) as object) || {});
-            log.info(`tool ${name} ok in ${Date.now() - startedAt}ms`);
+            const result = await this.registry.call(name, args);
+            log.info(`tool ${name} ok in ${Date.now() - startedAt}ms -> ${summarize(result, 900)}`);
             this.onActivity && this.onActivity({ tool: name, ok: true, durationMs: Date.now() - startedAt });
             // A tool that returns non-text content (e.g. an image) supplies
             // the MCP content array itself via mcpContent.

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -13,6 +13,7 @@ import { registerGcodeTools } from './tools/gcode';
 import { registerLandmarkTools } from './tools/landmarks';
 import { registerMachineTools } from './tools/machine';
 import { registerProbeTools } from './tools/probe';
+import { registerProbingTools } from './tools/probing';
 import { registerStatusTools } from './tools/status';
 import { registerToolSetterTools } from './tools/toolsetter';
 
@@ -112,6 +113,7 @@ export function startMcpService(socketServer?: McpBroadcaster): void {
     registerLandmarkTools(registry);
     registerProbeTools(registry);
     registerToolSetterTools(registry, () => `http://127.0.0.1:${port}`);
+    registerProbingTools(registry, () => `http://127.0.0.1:${port}`);
     registeredToolCount = registry.list().length;
 
     broadcaster = socketServer || null;

--- a/src/server/services/mcp/probeTool.ts
+++ b/src/server/services/mcp/probeTool.ts
@@ -1,0 +1,316 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention (planProbePoint takes the
+// probe_point arguments verbatim).
+import { mcpBroadcast } from './index';
+import { probeFeedService } from './probeFeed';
+import {
+    COARSE_FEED,
+    FINE_FEED,
+    MAX_RETREAT_MM,
+    ProcedureAbort,
+    TRAVEL_FEED,
+    assertChannelReady,
+    assertMachineReadyForProcedure,
+    moveMachineSettled,
+    senseAfter,
+    senseReleaseAfter,
+} from './probing';
+import { McpToolError } from './registry';
+import { getMachineSizeByIdentifier, getPositionSnapshot } from './tools/machine';
+import { connectionManager } from '../machine/ConnectionManager';
+
+// Point probing with the spindle-mounted touch probe (normally-open, probe
+// feed channel, inverted polarity handled by the feed): a single-axis
+// sensor-gated march from the CURRENT position, using the same staged
+// mechanics hardware-proven on the tool setter - coarse steps to contact,
+// retreat to release, fine steps, then quick lift-and-retest confirm cycles;
+// the result is the median contact coordinate with the spread reported.
+//
+// The envelope the operator approves is anchored to the position at staging:
+// the runner re-verifies it before moving, so the page is always truthful.
+
+export type ProbeAxis = 'x' | 'y' | 'z';
+
+export interface ProbePointPlan {
+    axis: ProbeAxis;
+    direction: 1 | -1;
+    start: { x: number; y: number; z: number }; // machine coords at staging
+    maxTravelMm: number;
+    limitCoord: number; // start[axis] + direction * maxTravel, envelope-clamped
+    coarseStepMm: number;
+    fineStepMm: number;
+    backoffMm: number;
+    sensorDelayMs: number;
+    confirmPasses: number;
+}
+
+export function planProbePoint(args: {
+    axis?: string;
+    direction?: number;
+    max_travel_mm?: number;
+    coarse_step_mm?: number;
+    fine_step_mm?: number;
+    backoff_mm?: number;
+    sensor_delay_ms?: number;
+    confirm_passes?: number;
+}): ProbePointPlan {
+    const axis = String(args.axis || '').toLowerCase() as ProbeAxis;
+    if (!['x', 'y', 'z'].includes(axis)) {
+        throw new McpToolError('axis must be "x", "y" or "z".');
+    }
+    const direction = Number(args.direction);
+    if (direction !== 1 && direction !== -1) {
+        throw new McpToolError('direction must be 1 or -1 (the sign of travel along the axis).');
+    }
+    if (axis === 'z' && direction === 1) {
+        throw new McpToolError('Z probing is downward only (direction -1).');
+    }
+    const maxTravelMm = Number(args.max_travel_mm);
+    if (!Number.isFinite(maxTravelMm) || maxTravelMm < 1 || maxTravelMm > 150) {
+        throw new McpToolError('max_travel_mm is required: how far the probe may march before aborting (1-150).');
+    }
+
+    const position = getPositionSnapshot();
+    const { x, y, z } = position.machine;
+    if (x === null || y === null || z === null) {
+        throw new McpToolError('Current machine position unknown; cannot anchor the probe envelope.');
+    }
+
+    let limitCoord = { x, y, z }[axis] + direction * maxTravelMm;
+    // Clamp to the same envelope the direct-move guards use (machine
+    // -25..size+40 for X/Y; Z never below 0).
+    const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+    if (axis === 'z') {
+        limitCoord = Math.max(limitCoord, 0);
+    } else if (size) {
+        limitCoord = Math.min(Math.max(limitCoord, -25), size[axis] + 40);
+    }
+    if (Math.abs(limitCoord - { x, y, z }[axis]) < 0.5) {
+        throw new McpToolError('The clamped probe travel is under 0.5 mm - already at the envelope edge.');
+    }
+
+    return {
+        axis,
+        direction: direction as 1 | -1,
+        start: { x, y, z },
+        maxTravelMm,
+        limitCoord: Number(limitCoord.toFixed(3)),
+        coarseStepMm: Math.min(Math.max(Number(args.coarse_step_mm) || 1, 0.2), 2),
+        fineStepMm: Math.min(Math.max(Number(args.fine_step_mm) || 0.1, 0.02), 0.5),
+        backoffMm: Math.min(Math.max(Number(args.backoff_mm) || 0.5, Number(args.fine_step_mm) || 0.1), 3),
+        sensorDelayMs: Math.min(Math.max(Number(args.sensor_delay_ms) || 200, 100), 10000),
+        confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 3), 1), 10),
+    };
+}
+
+/** Confirm-page gcode: every stepped command as it would execute. */
+export function describeProbePlanAsGcode(plan: ProbePointPlan): string {
+    const word = plan.axis.toUpperCase();
+    const lines = [
+        '; TOUCH PROBE POINT MEASUREMENT (server-driven, sensor-gated on the probe channel)',
+        '; EVERY LINE IS SENT INDIVIDUALLY: after each move settles, the probe feed is checked',
+        '; before the next line. The march stops at first contact; running the full ladder',
+        `; without contact ABORTS at the travel limit ${word} ${plan.limitCoord.toFixed(3)}.`,
+        `; anchored at machine (${plan.start.x.toFixed(2)}, ${plan.start.y.toFixed(2)}, ${plan.start.z.toFixed(2)})`
+            + ' - re-verified before any motion',
+        '; overtravel feed trips -> job stop + connection close + latched alarm',
+        'G90',
+        'G53;',
+    ];
+    let coord = plan.start[plan.axis];
+    let step = 0;
+    const towards = (value: number) => (plan.direction === 1
+        ? Math.min(value, plan.limitCoord) : Math.max(value, plan.limitCoord));
+    while (Math.abs(coord - plan.limitCoord) > 1e-9) {
+        coord = towards(coord + plan.direction * plan.coarseStepMm);
+        step += 1;
+        lines.push(`G1 ${word}${coord.toFixed(3)} F${COARSE_FEED}; coarse step ${step} - settle, check probe, stop at contact`);
+    }
+    lines.push(
+        `; ...on contact: retreat ${plan.coarseStepMm} mm steps until released, approach in ${plan.fineStepMm} mm`,
+        `; steps to contact, then ${plan.confirmPasses} quick confirm cycles (lift ${plan.backoffMm} mm, wait for release,`,
+        `; re-approach). Result = median contact ${word} (spread reported).`,
+        `G1 ${word}${plan.start[plan.axis].toFixed(3)} F${TRAVEL_FEED}; retreat to the start ${word} when done (also on any abort)`,
+        'G54;',
+    );
+    return lines.join('\n');
+}
+
+export interface ProbePointResult {
+    axis: ProbeAxis;
+    direction: number;
+    contactMachine: { x: number; y: number; z: number };
+    contactWorkOffsetApplied: string;
+    confirmPassContacts: number[];
+    spreadMm: number;
+    phases: { phase: string; coord: number; note?: string }[];
+    note: string;
+    warning?: string;
+}
+
+export async function runProbePointProcedure(plan: ProbePointPlan): Promise<object> {
+    assertChannelReady('probe', 'touch probe');
+    assertMachineReadyForProcedure();
+
+    const position = getPositionSnapshot();
+    const here = position.machine;
+    if (here.x === null || here.y === null || here.z === null
+        || Math.abs(here.x - plan.start.x) > 0.5
+        || Math.abs(here.y - plan.start.y) > 0.5
+        || Math.abs(here.z - plan.start.z) > 0.5) {
+        throw new McpToolError('The machine is not at the position this probe envelope was staged from '
+            + `(staged (${plan.start.x}, ${plan.start.y}, ${plan.start.z}), now `
+            + `(${here.x}, ${here.y}, ${here.z})). Stage probe_point again from the current position.`);
+    }
+
+    const word = plan.axis.toUpperCase();
+    const phases: { phase: string; coord: number; note?: string }[] = [];
+    const announce = (phase: string, coord: number, note?: string) => {
+        phases.push({ phase, coord: Number(coord.toFixed(3)), note });
+        mcpBroadcast('mcp:activity', { tool: 'probe_point', phase, axis: plan.axis, coord: Number(coord.toFixed(3)), note });
+    };
+    const releaseTimeoutMs = Math.max(plan.sensorDelayMs * 4, 2500);
+    const startCoord = plan.start[plan.axis];
+    const towards = (value: number) => (plan.direction === 1
+        ? Math.min(value, plan.limitCoord) : Math.max(value, plan.limitCoord));
+    const move = async (tool: string, coord: number, feed: number) => {
+        await moveMachineSettled(tool, { [plan.axis]: coord } as { x?: number; y?: number; z?: number }, feed);
+    };
+
+    let current = startCoord;
+    try {
+        // Coarse march to first contact.
+        let coarseContact: number | null = null;
+        while (Math.abs(current - plan.limitCoord) > 1e-9) {
+            const stepStart = Date.now();
+            current = towards(current + plan.direction * plan.coarseStepMm);
+            await move('probe:coarse', current, COARSE_FEED);
+            const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+            if (sensed.contact) {
+                coarseContact = current;
+                announce('coarse-contact', current, `probe "${sensed.reading?.value}"`);
+                break;
+            }
+        }
+        if (coarseContact === null) {
+            throw new ProcedureAbort(`Reached the travel limit ${word} ${plan.limitCoord.toFixed(3)} without `
+                + 'contact - nothing to probe within max_travel_mm, or the probe is not reporting.');
+        }
+
+        // Retreat until released.
+        let released = false;
+        while (Math.abs(current - startCoord) > 1e-9 && Math.abs(current - coarseContact) < MAX_RETREAT_MM + 1e-9) {
+            const stepStart = Date.now();
+            current = plan.direction === 1
+                ? Math.max(current - plan.coarseStepMm, startCoord)
+                : Math.min(current + plan.coarseStepMm, startCoord);
+            await move('probe:release', current, COARSE_FEED);
+            const sensed = await senseReleaseAfter('probe', stepStart, releaseTimeoutMs);
+            if (!sensed.contact) {
+                released = true;
+                announce('released', current);
+                break;
+            }
+        }
+        if (!released) {
+            throw new ProcedureAbort(`Probe still reads triggered ${MAX_RETREAT_MM} mm back from first `
+                + 'contact - stuck probe or feed fault.');
+        }
+
+        // Fine approach.
+        let fineContact: number | null = null;
+        while (Math.abs(current - plan.limitCoord) > 1e-9) {
+            const stepStart = Date.now();
+            current = towards(current + plan.direction * plan.fineStepMm);
+            await move('probe:fine', current, FINE_FEED);
+            const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+            if (sensed.contact) {
+                fineContact = current;
+                announce('fine-contact', current, `probe "${sensed.reading?.value}"`);
+                break;
+            }
+        }
+        if (fineContact === null) {
+            throw new ProcedureAbort('Fine approach reached the travel limit without re-contact after a '
+                + 'coarse contact - inconsistent probe.');
+        }
+
+        // Quick lift-and-retest confirm cycles; median wins, spread reported.
+        const passContacts: number[] = [];
+        const cycleLimit = towards(fineContact + plan.direction * 0.5);
+        let reference = fineContact;
+        for (let pass = 1; pass <= plan.confirmPasses; pass++) {
+            const liftIssuedAt = Date.now();
+            current = reference - plan.direction * plan.backoffMm;
+            await move('probe:backoff', current, FINE_FEED);
+            const liftSense = await senseReleaseAfter('probe', liftIssuedAt, releaseTimeoutMs);
+            if (liftSense.contact) {
+                throw new ProcedureAbort(`Probe still triggered ${releaseTimeoutMs} ms after backing off `
+                    + `${plan.backoffMm} mm - hysteresis exceeds the backoff. Rerun with a larger backoff_mm.`);
+            }
+            let passContact: number | null = null;
+            while (Math.abs(current - cycleLimit) > 1e-9) {
+                const stepStart = Date.now();
+                current = plan.direction === 1
+                    ? Math.min(current + plan.fineStepMm, cycleLimit)
+                    : Math.max(current - plan.fineStepMm, cycleLimit);
+                await move('probe:confirm', current, FINE_FEED);
+                const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+                if (sensed.contact) {
+                    passContact = current;
+                    break;
+                }
+            }
+            if (passContact === null) {
+                throw new ProcedureAbort(`Confirm pass ${pass} went 0.5 mm past the first contact without `
+                    + 're-contact - inconsistent probe.');
+            }
+            passContacts.push(Number(passContact.toFixed(3)));
+            announce(`confirm-${pass}`, passContact, `of ${plan.confirmPasses}`);
+            reference = passContact;
+        }
+        const sorted = [...passContacts].sort((a, b) => a - b);
+        const measured = sorted[Math.floor((sorted.length - 1) / 2)];
+        const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
+        announce('measured', measured, `median of [${passContacts.join(', ')}], spread ${spreadMm} mm`);
+
+        // Retreat along the probed axis to the start coordinate.
+        await move('probe:retreat', startCoord, TRAVEL_FEED);
+        announce('retreated', startCoord);
+
+        const contactMachine = { ...plan.start, [plan.axis]: measured };
+        const after = getPositionSnapshot();
+        const result: ProbePointResult = {
+            axis: plan.axis,
+            direction: plan.direction,
+            contactMachine,
+            contactWorkOffsetApplied: `work = machine + originOffset (${JSON.stringify(after.originOffset)})`,
+            confirmPassContacts: passContacts,
+            spreadMm,
+            phases,
+            note: `Probe contact at machine ${word} ${measured.toFixed(3)} - median of ${plan.confirmPasses} `
+                + `passes [${passContacts.join(', ')}], spread ${spreadMm} mm (+/- ${plan.fineStepMm} mm step `
+                + 'resolution, minus the probe tip radius on side probes - the tip touches before its centre).',
+            warning: spreadMm > plan.fineStepMm + 1e-9
+                ? `Confirm passes spread ${spreadMm} mm exceeds one fine step - feed timing was unstable; `
+                    + 'consider more confirm_passes or a longer sensor_delay_ms.'
+                : undefined,
+        };
+        return result as unknown as object;
+    } catch (err) {
+        const isTrip = !!probeFeedService.getTrip();
+        if (!isTrip) {
+            try {
+                await move('probe:abort-retreat', startCoord, TRAVEL_FEED);
+                announce('abort-retreated', startCoord);
+            } catch (retreatErr) {
+                // The abort itself already reports; retreat failure is logged
+                // by the activity stream.
+            }
+        }
+        if (err instanceof ProcedureAbort) {
+            throw new McpToolError(`Probe run aborted: ${err.message} Phases completed: ${JSON.stringify(phases)}`);
+        }
+        throw err;
+    }
+}

--- a/src/server/services/mcp/probing.ts
+++ b/src/server/services/mcp/probing.ts
@@ -1,0 +1,245 @@
+import { connectionManager } from '../machine/ConnectionManager';
+import { ProbeChannel, probeFeedService } from './probeFeed';
+import { McpToolError } from './registry';
+import { GcodeChannel, sendGcodeVisible } from './tools/camera';
+import { getPositionSnapshot } from './tools/machine';
+
+// The shared sensor-gated motion engine: settled single moves on the direct
+// path, contact/release sensing against a probe feed channel, and the
+// readiness guard. Extracted from the tool setter (where every piece was
+// hardware-proven 2026-08-31/09-01) so the CNC touch probe reuses the exact
+// same verified mechanics against its own feed channel.
+
+export const TRAVEL_FEED = 600; // mm/min, matches the move_z cap
+export const COARSE_FEED = 100;
+export const FINE_FEED = 60;
+const SETTLE_TIMEOUT_MS = 30000;
+const SETTLE_POLL_MS = 250;
+export const SETTLE_TOLERANCE_MM = 0.15;
+export const MAX_RETREAT_MM = 5; // still triggered after this much retreat = stuck sensor
+
+export class ProcedureAbort extends Error {}
+
+export interface StepResult {
+    contact: boolean;
+    reading: { value: string; receivedAt: number } | null;
+    // Which channel fired, when sensing across several (e.g. measuring the
+    // spindle touch probe on the tool setter accepts either).
+    channel?: ProbeChannel;
+}
+
+export function getDirectChannel(): GcodeChannel {
+    const channel = connectionManager.getCurrentChannel() as unknown as GcodeChannel;
+    if (!channel || typeof channel.executeGcode !== 'function') {
+        throw new ProcedureAbort('No machine channel with direct command support.');
+    }
+    return channel;
+}
+
+export async function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+/**
+ * Issue one absolute machine-frame move and block until it verifiably
+ * completed. Fast path: the HTTP channel executes gcode synchronously and its
+ * reply echoes the completed position in WORK coordinates - an exact match
+ * (0.02 mm) is proof of arrival with no heartbeat wait. Fallback: heartbeat
+ * settle (report newer than issue, machine idle, axes at target; moves larger
+ * than 3x the tolerance accept the first at-target beat, smaller ones require
+ * a stable double-beat since a stale beat could pass). The overtravel latch
+ * is re-checked before the move and on every poll.
+ */
+export async function moveMachineSettled(
+    tool: string,
+    target: { x?: number; y?: number; z?: number },
+    feed: number
+): Promise<void> {
+    probeFeedService.assertNoOvertravel();
+    const channel = getDirectChannel();
+    const words = [
+        target.x !== undefined ? `X${target.x.toFixed(3)}` : '',
+        target.y !== undefined ? `Y${target.y.toFixed(3)}` : '',
+        target.z !== undefined ? `Z${target.z.toFixed(3)}` : '',
+    ].filter(Boolean).join(' ');
+    const gcode = `G90\nG53;\nG1 ${words} F${feed};\nG54;`;
+
+    const before = getPositionSnapshot();
+    const bigMove = (['x', 'y', 'z'] as const).every((axis) => {
+        const want = target[axis];
+        if (want === undefined) {
+            return true;
+        }
+        const from = before.machine[axis];
+        return from !== null && Math.abs(want - from) > SETTLE_TOLERANCE_MM * 3;
+    });
+
+    const issuedAt = Date.now();
+    const executed = await sendGcodeVisible(channel, tool, gcode);
+    if (executed.result !== 0) {
+        throw new ProcedureAbort(`Controller rejected the move: ${executed.text || executed.result}`);
+    }
+
+    const echo = String(executed.text || '').match(/X:(-?\d+(?:\.\d+)?)\s+Y:(-?\d+(?:\.\d+)?)\s+Z:(-?\d+(?:\.\d+)?)/);
+    if (echo) {
+        const offset = before.originOffset;
+        const echoMachine = {
+            x: Number(echo[1]) - offset.x,
+            y: Number(echo[2]) - offset.y,
+            z: Number(echo[3]) - offset.z,
+        };
+        const exact = (['x', 'y', 'z'] as const).every((axis) => {
+            const want = target[axis];
+            return want === undefined || Math.abs(echoMachine[axis] - want) <= 0.02;
+        });
+        if (exact) {
+            return;
+        }
+    }
+
+    const deadline = issuedAt + SETTLE_TIMEOUT_MS;
+    let previous: string | null = null;
+    while (Date.now() < deadline) {
+        await sleep(SETTLE_POLL_MS);
+        probeFeedService.assertNoOvertravel();
+        let now;
+        try {
+            now = getPositionSnapshot();
+        } catch (err) {
+            continue;
+        }
+        const reportTime = Date.now() - now.reportAgeMs;
+        const fingerprint = JSON.stringify([now.work, now.originOffset]);
+        const stable = fingerprint === previous;
+        previous = fingerprint;
+        if (reportTime <= issuedAt || now.machineStatus !== 'idle') {
+            continue;
+        }
+        if (!bigMove && !stable) {
+            continue;
+        }
+        const atTarget = (['x', 'y', 'z'] as const).every((axis) => {
+            const want = target[axis];
+            const have = now.machine[axis];
+            return want === undefined || (have !== null && Math.abs(have - want) <= SETTLE_TOLERANCE_MM);
+        });
+        if (atTarget) {
+            return;
+        }
+    }
+    throw new ProcedureAbort(`Timed out waiting for the heartbeat to verify the move to ${words}.`);
+}
+
+/**
+ * CONTACT detection after a settled step: give the sensor's report a short
+ * window to arrive (early-exit on a fresh reading), then judge from the LAST
+ * KNOWN state - the sensor publishes on change, so silence means unchanged.
+ * A late contact message merely costs one extra step (self-correcting).
+ */
+export async function senseAfter(
+    channels: ProbeChannel | ProbeChannel[],
+    stepIssuedAt: number,
+    delayMs: number
+): Promise<StepResult> {
+    const list = Array.isArray(channels) ? channels : [channels];
+    const deadline = Date.now() + delayMs;
+    for (;;) {
+        for (const channel of list) {
+            const state = probeFeedService.getReading(channel);
+            if (state && state.triggered) {
+                return {
+                    contact: true,
+                    reading: { value: state.value, receivedAt: state.receivedAt },
+                    channel,
+                };
+            }
+        }
+        if (Date.now() >= deadline) {
+            const state = probeFeedService.getReading(list[0]);
+            return {
+                contact: false,
+                reading: state ? { value: state.value, receivedAt: state.receivedAt } : null,
+                channel: list[0],
+            };
+        }
+        await sleep(Math.min(50, Math.max(1, deadline - Date.now())));
+    }
+}
+
+/**
+ * RELEASE detection needs different patience: a stale "triggered" here is a
+ * false abort (live-hit on the tool setter: the cloud round-trip of the
+ * release message exceeded the contact window). Wait until the last known
+ * state reads untriggered, early-exiting on fresh readings, up to timeoutMs;
+ * only then is "still triggered" believed.
+ */
+export async function senseReleaseAfter(
+    channels: ProbeChannel | ProbeChannel[],
+    stepIssuedAt: number,
+    timeoutMs: number
+): Promise<StepResult> {
+    const list = Array.isArray(channels) ? channels : [channels];
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        const states = list.map((channel) => ({ channel, state: probeFeedService.getReading(channel) }));
+        const stillTriggered = states.find((s) => s.state && s.state.triggered);
+        if (!stillTriggered) {
+            const first = states[0].state;
+            return {
+                contact: false,
+                reading: first ? { value: first.value, receivedAt: first.receivedAt } : null,
+                channel: states[0].channel,
+            };
+        }
+        if (Date.now() >= deadline) {
+            return {
+                contact: true,
+                reading: stillTriggered.state
+                    ? { value: stillTriggered.state.value, receivedAt: stillTriggered.state.receivedAt }
+                    : null,
+                channel: stillTriggered.channel,
+            };
+        }
+        await sleep(Math.min(100, Math.max(1, deadline - Date.now())));
+    }
+}
+
+/**
+ * The sensor must be connected, have reported at least once, and read
+ * untriggered before any sensor-gated approach may start.
+ */
+export function assertChannelReady(channel: ProbeChannel, what: string): void {
+    probeFeedService.assertNoOvertravel();
+    if (!probeFeedService.isConnected()) {
+        throw new McpToolError('Probe feed is not connected - connect_probe_feed first. The overtravel '
+            + `tripwire MUST be armed for a ${what} run.`);
+    }
+    const reading = probeFeedService.getReading(channel);
+    if (!reading) {
+        throw new McpToolError(`No reading has ever arrived on the ${channel} feed - cannot trust the `
+            + 'sensor. Ask the operator to trigger it by hand and watch get_probe_feed_status until '
+            + 'the touch shows up.');
+    }
+    if (reading.triggered) {
+        throw new McpToolError(`The ${channel} feed already reads triggered ("${reading.value}") before `
+            + 'any approach - the sensor is stuck or already in contact. Resolve physically first.');
+    }
+}
+
+/** Machine idle, homed, toolhead off - the common motion preconditions. */
+export function assertMachineReadyForProcedure(): void {
+    const position = getPositionSnapshot();
+    if (position.machineStatus !== 'idle') {
+        throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);
+    }
+    if (position.isHomed !== true) {
+        throw new McpToolError('Machine does not report homed; home first.');
+    }
+    const state = connectionManager.getLatestMachineState() as { headStatus?: unknown; headPower?: unknown } | null;
+    const headPower = Number(state && state.headPower);
+    if ((Number.isFinite(headPower) && headPower > 0) || (state && (state.headStatus === true || state.headStatus === 'on'))) {
+        throw new McpToolError('Toolhead appears to be on; refusing to run the procedure.');
+    }
+}

--- a/src/server/services/mcp/toolSetter.ts
+++ b/src/server/services/mcp/toolSetter.ts
@@ -3,11 +3,21 @@
 // the run_tool_setter arguments verbatim).
 import logger from '../../lib/logger';
 import config from '../configstore';
-import { connectionManager } from '../machine/ConnectionManager';
 import { mcpBroadcast } from './index';
-import { probeFeedService } from './probeFeed';
+import { ProbeChannel, probeFeedService } from './probeFeed';
+import {
+    COARSE_FEED,
+    FINE_FEED,
+    MAX_RETREAT_MM,
+    ProcedureAbort,
+    TRAVEL_FEED,
+    assertChannelReady,
+    assertMachineReadyForProcedure,
+    moveMachineSettled,
+    senseAfter,
+    senseReleaseAfter,
+} from './probing';
 import { McpToolError } from './registry';
-import { GcodeChannel, sendGcodeVisible } from './tools/camera';
 import { getPositionSnapshot } from './tools/machine';
 
 const log = logger('service:mcp:tool-setter');
@@ -33,13 +43,7 @@ const log = logger('service:mcp:tool-setter');
 
 const CONFIG_KEY = 'mcpToolSetter';
 
-const TRAVEL_FEED = 600; // mm/min, matches the move_z cap
-const COARSE_FEED = 100;
-const FINE_FEED = 60;
-const SETTLE_TIMEOUT_MS = 30000;
-const SETTLE_POLL_MS = 250;
-const SETTLE_TOLERANCE_MM = 0.15;
-const MAX_RETREAT_MM = 5; // still triggered after this much retreat = stuck sensor
+// Motion/sensing engine shared with the CNC touch probe: probing.ts.
 
 export interface ToolSetterConfig {
     centerX: number; // machine coords of the setter's centre
@@ -160,6 +164,10 @@ export interface ToolSetterPlan {
     // current position (wizard returns the new tool over the setter).
     stayAtTrigger: boolean;
     startFromCurrent: boolean;
+    // Measuring the spindle TOUCH PROBE on the setter: the probe's own
+    // channel fires before the setter's switch, and pressing on would bend
+    // the probe - accept EITHER channel as the height confirmation.
+    acceptProbeContact: boolean;
 }
 
 /**
@@ -178,6 +186,7 @@ export function planToolSetterRun(args: {
     store_as_reference?: boolean;
     stay_at_trigger?: boolean;
     start_from_current?: boolean;
+    accept_probe_contact?: boolean;
 }): ToolSetterPlan {
     const cfg = getToolSetterConfig();
     if (!cfg) {
@@ -228,6 +237,7 @@ export function planToolSetterRun(args: {
         storeAsReference: args.store_as_reference === true,
         stayAtTrigger: args.stay_at_trigger === true,
         startFromCurrent: args.start_from_current === true,
+        acceptProbeContact: args.accept_probe_contact === true,
     };
 }
 
@@ -296,189 +306,6 @@ export function describePlanAsGcode(plan: ToolSetterPlan): string {
     return lines.join('\n');
 }
 
-interface StepResult {
-    contact: boolean;
-    reading: { value: string; receivedAt: number } | null;
-}
-
-class ProcedureAbort extends Error {}
-
-function getDirectChannel(): GcodeChannel {
-    const channel = connectionManager.getCurrentChannel() as unknown as GcodeChannel;
-    if (!channel || typeof channel.executeGcode !== 'function') {
-        throw new ProcedureAbort('No machine channel with direct command support.');
-    }
-    return channel;
-}
-
-async function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
-
-/**
- * Issue one absolute machine-frame move and block until the heartbeat
- * verifiably reports it (same contract as move_z): report newer than issue,
- * two identical consecutive beats, machine idle, and axes at target.
- */
-async function moveMachineSettled(
-    tool: string,
-    target: { x?: number; y?: number; z?: number },
-    feed: number
-): Promise<void> {
-    probeFeedService.assertNoOvertravel();
-    const channel = getDirectChannel();
-    const words = [
-        target.x !== undefined ? `X${target.x.toFixed(3)}` : '',
-        target.y !== undefined ? `Y${target.y.toFixed(3)}` : '',
-        target.z !== undefined ? `Z${target.z.toFixed(3)}` : '',
-    ].filter(Boolean).join(' ');
-    const gcode = `G90\nG53;\nG1 ${words} F${feed};\nG54;`;
-
-    // When every commanded axis moves by well over the tolerance, a stale
-    // pre-move heartbeat cannot sit within tolerance of the target, so the
-    // FIRST post-issue beat at the target is already proof of arrival - no
-    // need to wait out a second identical beat (~1-1.5s/step saved on the
-    // coarse ladder). Small steps (fine/confirm, at or under the tolerance)
-    // keep the strict stable-double-beat rule. Judged from the position
-    // BEFORE the move is issued.
-    const before = getPositionSnapshot();
-    const bigMove = (['x', 'y', 'z'] as const).every((axis) => {
-        const want = target[axis];
-        if (want === undefined) {
-            return true;
-        }
-        const from = before.machine[axis];
-        return from !== null && Math.abs(want - from) > SETTLE_TOLERANCE_MM * 3;
-    });
-
-    const issuedAt = Date.now();
-    const executed = await sendGcodeVisible(channel, tool, gcode);
-    if (executed.result !== 0) {
-        throw new ProcedureAbort(`Controller rejected the move: ${executed.text || executed.result}`);
-    }
-
-    // Fast path: the HTTP channel executes gcode synchronously and its reply
-    // echoes the position after completion ("X:.. Y:.. Z:.." in WORK
-    // coordinates, hardware-observed to always match the exact target). An
-    // exact echo match (0.02 mm, tighter than one fine step) is proof of
-    // arrival with no heartbeat wait (~2s/step saved - the heartbeat only
-    // ticks ~2s on the wifi channel). Anything less falls through to the
-    // strict heartbeat settle below.
-    const echo = String(executed.text || '').match(/X:(-?\d+(?:\.\d+)?)\s+Y:(-?\d+(?:\.\d+)?)\s+Z:(-?\d+(?:\.\d+)?)/);
-    if (echo) {
-        const offset = before.originOffset;
-        const echoMachine = {
-            x: Number(echo[1]) - offset.x,
-            y: Number(echo[2]) - offset.y,
-            z: Number(echo[3]) - offset.z,
-        };
-        const exact = (['x', 'y', 'z'] as const).every((axis) => {
-            const want = target[axis];
-            return want === undefined || Math.abs(echoMachine[axis] - want) <= 0.02;
-        });
-        if (exact) {
-            return;
-        }
-    }
-
-    const deadline = issuedAt + SETTLE_TIMEOUT_MS;
-    let previous: string | null = null;
-    while (Date.now() < deadline) {
-        await sleep(SETTLE_POLL_MS);
-        probeFeedService.assertNoOvertravel();
-        let now;
-        try {
-            now = getPositionSnapshot();
-        } catch (err) {
-            continue;
-        }
-        const reportTime = Date.now() - now.reportAgeMs;
-        const fingerprint = JSON.stringify([now.work, now.originOffset]);
-        const stable = fingerprint === previous;
-        previous = fingerprint;
-        if (reportTime <= issuedAt || now.machineStatus !== 'idle') {
-            continue;
-        }
-        if (!bigMove && !stable) {
-            continue;
-        }
-        const atTarget = (['x', 'y', 'z'] as const).every((axis) => {
-            const want = target[axis];
-            const have = now.machine[axis];
-            return want === undefined || (have !== null && Math.abs(have - want) <= SETTLE_TOLERANCE_MM);
-        });
-        if (atTarget) {
-            return;
-        }
-    }
-    throw new ProcedureAbort(`Timed out waiting for the heartbeat to verify the move to ${words}.`);
-}
-
-/**
- * After a settled step, give the sensor's report time to arrive (early-exits
- * when a fresh reading lands), then judge contact from the LAST KNOWN state -
- * the sensor publishes on change, so silence means unchanged.
- *
- * This short window is for CONTACT detection while descending, where a late
- * message merely costs one extra step before detection (self-correcting).
- */
-async function senseAfter(stepIssuedAt: number, delayMs: number): Promise<StepResult> {
-    const fresh = await probeFeedService.waitForReading('toolsetter', stepIssuedAt, delayMs);
-    const state = fresh || probeFeedService.getReading('toolsetter');
-    return {
-        contact: !!(state && state.triggered),
-        reading: state ? { value: state.value, receivedAt: state.receivedAt } : null,
-    };
-}
-
-/**
- * RELEASE detection needs different patience: a stale "triggered" here is a
- * false abort (live-hit on run 2: the cloud round-trip of the release
- * message exceeded the 200 ms contact window). Wait until the last known
- * state reads untriggered, early-exiting on fresh readings, up to timeoutMs;
- * only then is "still triggered" believed.
- */
-async function senseReleaseAfter(stepIssuedAt: number, timeoutMs: number): Promise<StepResult> {
-    const deadline = Date.now() + timeoutMs;
-    for (;;) {
-        const state = probeFeedService.getReading('toolsetter');
-        if (state && !state.triggered) {
-            return { contact: false, reading: { value: state.value, receivedAt: state.receivedAt } };
-        }
-        const remaining = deadline - Date.now();
-        if (remaining <= 0) {
-            return {
-                contact: !!(state && state.triggered),
-                reading: state ? { value: state.value, receivedAt: state.receivedAt } : null,
-            };
-        }
-        await probeFeedService.waitForReading(
-            'toolsetter',
-            state ? state.receivedAt : stepIssuedAt,
-            Math.min(remaining, 250)
-        );
-    }
-}
-
-function assertFeedReady(): void {
-    probeFeedService.assertNoOvertravel();
-    if (!probeFeedService.isConnected()) {
-        throw new McpToolError('Probe feed is not connected - connect_probe_feed first. The overtravel '
-            + 'tripwire MUST be armed for a tool setter run.');
-    }
-    const setter = probeFeedService.getReading('toolsetter');
-    if (!setter) {
-        throw new McpToolError('No reading has ever arrived on the toolsetter feed - cannot trust the '
-            + 'sensor. Ask the operator to trigger the setter by hand and watch get_probe_feed_status '
-            + 'until the touch shows up.');
-    }
-    if (setter.triggered) {
-        throw new McpToolError(`The toolsetter feed already reads triggered ("${setter.value}") before `
-            + 'any approach - the sensor is stuck or something is resting on it. Resolve physically first.');
-    }
-}
 
 export interface ToolSetterResult {
     measuredTriggerZ: number;
@@ -498,20 +325,12 @@ export interface ToolSetterResult {
  * any abort retreats to the start height when the machine still answers.
  */
 export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<object> {
-    assertFeedReady();
+    const contactChannels: ProbeChannel[] = plan.acceptProbeContact ? ['toolsetter', 'probe'] : ['toolsetter'];
+    for (const channel of contactChannels) {
+        assertChannelReady(channel, 'tool setter');
+    }
+    assertMachineReadyForProcedure();
     const position = getPositionSnapshot();
-    if (position.machineStatus !== 'idle') {
-        throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);
-    }
-    if (position.isHomed !== true) {
-        throw new McpToolError('Machine does not report homed; the tool setter centre is only valid '
-            + 'after homing. Call home first.');
-    }
-    const state = connectionManager.getLatestMachineState() as { headStatus?: unknown; headPower?: unknown } | null;
-    const headPower = Number(state && state.headPower);
-    if ((Number.isFinite(headPower) && headPower > 0) || (state && (state.headStatus === true || state.headStatus === 'on'))) {
-        throw new McpToolError('Toolhead appears to be on; refusing to run the tool setter.');
-    }
 
     const phases: { phase: string; z: number; note?: string }[] = [];
     const c = plan.config;
@@ -560,7 +379,7 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
             const stepStart = Date.now();
             currentZ = Math.max(currentZ - plan.coarseStepMm, plan.coarseFloorZ);
             await moveMachineSettled('toolsetter:coarse', { z: currentZ }, COARSE_FEED);
-            const sensed = await senseAfter(stepStart, plan.sensorDelayMs);
+            const sensed = await senseAfter(contactChannels, stepStart, plan.sensorDelayMs);
             if (sensed.contact) {
                 coarseContactZ = currentZ;
                 announce('coarse-contact', currentZ,
@@ -582,7 +401,7 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
                 const stepStart = Date.now();
                 currentZ += plan.coarseStepMm;
                 await moveMachineSettled('toolsetter:release', { z: currentZ }, COARSE_FEED);
-                const sensed = await senseReleaseAfter(stepStart, releaseTimeoutMs);
+                const sensed = await senseReleaseAfter(contactChannels, stepStart, releaseTimeoutMs);
                 if (!sensed.contact) {
                     releasedZ = currentZ;
                     announce('released', currentZ);
@@ -604,10 +423,10 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
             const stepStart = Date.now();
             currentZ -= plan.fineStepMm;
             await moveMachineSettled('toolsetter:fine', { z: currentZ }, FINE_FEED);
-            const sensed = await senseAfter(stepStart, plan.sensorDelayMs);
+            const sensed = await senseAfter(contactChannels, stepStart, plan.sensorDelayMs);
             if (sensed.contact) {
                 fineContactZ = currentZ;
-                announce('fine-contact', currentZ, `sensor "${sensed.reading?.value}"`);
+                announce('fine-contact', currentZ, `${sensed.channel} sensor "${sensed.reading?.value}"`);
                 break;
             }
         }
@@ -630,7 +449,7 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
             const liftIssuedAt = Date.now();
             currentZ = referenceContactZ + plan.backoffMm;
             await moveMachineSettled('toolsetter:backoff', { z: currentZ }, FINE_FEED);
-            const liftSense = await senseReleaseAfter(liftIssuedAt, releaseTimeoutMs);
+            const liftSense = await senseReleaseAfter(contactChannels, liftIssuedAt, releaseTimeoutMs);
             if (liftSense.contact) {
                 throw new ProcedureAbort(`Sensor still triggered ${releaseTimeoutMs} ms after backing off `
                     + `${plan.backoffMm} mm - trigger hysteresis exceeds the backoff. Rerun with a larger backoff_mm.`);
@@ -640,7 +459,7 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
                 const stepStart = Date.now();
                 currentZ -= plan.fineStepMm;
                 await moveMachineSettled('toolsetter:confirm', { z: currentZ }, FINE_FEED);
-                const sensed = await senseAfter(stepStart, plan.sensorDelayMs);
+                const sensed = await senseAfter(contactChannels, stepStart, plan.sensorDelayMs);
                 if (sensed.contact) {
                     passContact = currentZ;
                     break;
@@ -666,7 +485,7 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
             const holdIssuedAt = Date.now();
             currentZ = measuredZ;
             await moveMachineSettled('toolsetter:hold', { z: currentZ }, FINE_FEED);
-            await probeFeedService.waitForReading('toolsetter', holdIssuedAt, plan.sensorDelayMs);
+            await senseAfter(contactChannels, holdIssuedAt, plan.sensorDelayMs);
             announce('holding-at-trigger', measuredZ, 'NOT retreating - touchscreen wizard takes over');
         } else {
             await moveMachineSettled('toolsetter:retreat', { z: plan.startZ }, TRAVEL_FEED);

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 // MCP tool arguments are snake_case by convention.
+import logger from '../../../lib/logger';
 import config from '../../configstore';
 import { mcpBroadcast } from '../index';
 import { connectionManager } from '../../machine/ConnectionManager';
@@ -29,15 +30,21 @@ export interface GcodeChannel {
     executeGcode?: (gcode: string) => Promise<{ result: number; text?: string }>;
 }
 
+const gcodeLog = logger('service:mcp:gcode');
+
 /**
  * Send gcode on the direct path AND mirror exactly what was sent (plus the
- * controller's reply) to the UI console, so the operator can see which
- * coordinate frame every MCP-issued command ran in.
+ * controller's reply) to the UI console AND the server log - the console
+ * broadcast is invisible to anyone reading the process log, and a headless
+ * session debugging "controller said ok but nothing moved" needs the reply.
  */
 export async function sendGcodeVisible(channel: GcodeChannel, tool: string, gcode: string): Promise<{ result: number; text?: string }> {
     mcpBroadcast('mcp:gcode', { tool, gcode });
+    gcodeLog.info(`[${tool}] > ${gcode.replace(/\r?\n/g, ' | ')}`);
     const executed = await channel.executeGcode(gcode);
-    mcpBroadcast('mcp:gcode', { tool, response: executed.text || (executed.result === 0 ? 'ok' : `result=${executed.result}`) });
+    const response = executed.text || (executed.result === 0 ? 'ok' : `result=${executed.result}`);
+    mcpBroadcast('mcp:gcode', { tool, response });
+    gcodeLog.info(`[${tool}] < ${String(response).replace(/\r?\n/g, ' | ')}`);
     return executed;
 }
 

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -1,0 +1,232 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention.
+import crypto from 'crypto';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+import DataStorage from '../../../DataStorage';
+import { connectionManager } from '../../machine/ConnectionManager';
+import { captureFrame } from '../camera';
+import { jobManager } from '../jobs';
+import { describeProbePlanAsGcode, planProbePoint, runProbePointProcedure } from '../probeTool';
+import { probeFeedService } from '../probeFeed';
+import { TRAVEL_FEED, assertMachineReadyForProcedure, moveMachineSettled } from '../probing';
+import { McpToolError, ToolRegistry } from '../registry';
+import { getMachineSizeByIdentifier, getPositionSnapshot } from './machine';
+import { validateGcode } from '../validator';
+
+// The spindle touch probe (probe feed channel) and the whole-bed camera
+// survey: the survey gives the agent visual context ("measure the stock on
+// the rotary axis"), the probe turns that context into millimetres.
+
+const SURVEY_MIN_MACHINE_Z = 250;
+
+export function registerProbingTools(registry: ToolRegistry, getConfirmBaseUrl: () => string): void {
+    registry.register({
+        name: 'probe_point',
+        description: 'Stage a touch-probe point measurement for human confirmation: a single-axis '
+            + 'sensor-gated march FROM THE CURRENT POSITION along +/-X, +/-Y or -Z, using the '
+            + 'spindle touch probe (probe feed channel). Same staged mechanics as the tool setter: '
+            + 'coarse steps to contact, retreat to release, fine steps, quick lift-and-retest '
+            + 'confirm cycles - returns the median contact coordinate in machine coords with '
+            + 'spread. Position first (move_and_capture / move_z), then stage; the envelope is '
+            + 'anchored to the staging position and re-verified before motion. Remember the tip '
+            + 'radius on side probes: the surface is one tip-radius beyond the contact centre.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                axis: { type: 'string', enum: ['x', 'y', 'z'], description: 'Axis to march along.' },
+                direction: { type: 'number', enum: [1, -1], description: 'Sign of travel; Z is -1 only.' },
+                max_travel_mm: {
+                    type: 'number',
+                    description: 'REQUIRED hard travel limit (1-150): the march aborts here without contact.',
+                },
+                coarse_step_mm: { type: 'number', description: 'Coarse step, default 1 (0.2-2).' },
+                fine_step_mm: { type: 'number', description: 'Fine step, default 0.1 (0.02-0.5).' },
+                backoff_mm: { type: 'number', description: 'Confirm-cycle lift, default 0.5.' },
+                sensor_delay_ms: { type: 'number', description: 'Contact-check window per step, default 200.' },
+                confirm_passes: { type: 'number', description: 'Lift-and-retest cycles, default 3 (1-10).' },
+                reason: { type: 'string', description: 'Shown to the operator: what is being measured and why.' },
+            },
+            required: ['axis', 'direction', 'max_travel_mm', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            if (!String(args.reason || '').trim()) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            probeFeedService.assertNoOvertravel();
+            const plan = planProbePoint(args as Parameters<typeof planProbePoint>[0]);
+            const envelope = describeProbePlanAsGcode(plan);
+            const validation = validateGcode(envelope);
+            const job = jobManager.submit(
+                envelope,
+                `probe ${plan.direction === 1 ? '+' : '-'}${plan.axis.toUpperCase()} `
+                    + `${plan.maxTravelMm}mm - ${String(args.reason).slice(0, 40)}`,
+                'cnc',
+                validation,
+                'procedure'
+            );
+            job.runner = async () => runProbePointProcedure(plan);
+            return {
+                job: jobManager.describe(job),
+                plan,
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url, review the envelope (anchored to the '
+                    + 'current position), and approve. Their one-time code passed to start_gcode_job '
+                    + 'runs the march and returns the contact coordinate.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'survey_bed',
+        description: 'Stage a whole-bed camera survey for human confirmation: a serpentine XY grid at '
+            + 'the CURRENT Z (which must be high - machine Z >= 250 unless the operator has confirmed '
+            + 'clearance), capturing a frame at every waypoint. Frames are saved to disk with a '
+            + 'machine-position index so the scene can be reviewed as a whole (read the files '
+            + 'directly); they do NOT go through the 12-frame cache. Requires a working camera '
+            + '(mcpCameraUrl or ffmpeg).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                pitch_mm: { type: 'number', description: 'Grid spacing, default 80 (40-160).' },
+                margin_mm: { type: 'number', description: 'Inset from the default bounds, default 10.' },
+                x_min: { type: 'number', description: 'Machine-coord grid bounds. Defaults: margin..(size-margin).' },
+                x_max: { type: 'number', description: 'Set beyond the nominal size to cover reachable overtravel (e.g. the far-X column the camera angle otherwise misses - setup-specific, so state it explicitly).' },
+                y_min: { type: 'number' },
+                y_max: { type: 'number' },
+                operator_confirmed_clearance: {
+                    type: 'boolean',
+                    description: 'Set true ONLY on the operator\'s explicit word that the current Z '
+                        + 'clears everything on the bed; required when machine Z < 250.',
+                },
+                reason: { type: 'string', description: 'Shown to the operator.' },
+            },
+            required: ['reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: {
+            pitch_mm?: number;
+            margin_mm?: number;
+            x_min?: number;
+            x_max?: number;
+            y_min?: number;
+            y_max?: number;
+            operator_confirmed_clearance?: boolean;
+            reason?: string;
+        }) => {
+            probeFeedService.assertNoOvertravel();
+            const position = getPositionSnapshot();
+            const { x, y, z } = position.machine;
+            if (x === null || y === null || z === null) {
+                throw new McpToolError('Current machine position unknown.');
+            }
+            if (z < SURVEY_MIN_MACHINE_Z && args.operator_confirmed_clearance !== true) {
+                throw new McpToolError(`Machine Z ${z.toFixed(1)} is below the survey height floor `
+                    + `${SURVEY_MIN_MACHINE_Z} - raise Z (move_z), or pass operator_confirmed_clearance: `
+                    + 'true only on the operator\'s explicit word that this Z clears everything on the bed.');
+            }
+            const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+            if (!size) {
+                throw new McpToolError('Unknown machine size; cannot plan the grid.');
+            }
+            const pitch = Math.min(Math.max(Number(args.pitch_mm) || 80, 40), 160);
+            const margin = Math.min(Math.max(Number(args.margin_mm) || 10, 0), 50);
+
+            // Serpentine at the current Z. Bounds are explicit (clamped to the
+            // direct-move envelope) and BOTH endpoints are always covered - a
+            // pitch that undershoots gets a final row/column at the far edge,
+            // because what the camera sees at the extremes is setup-specific
+            // and the far reach is often the only view of its region.
+            const clampAxis = (value: number, max: number) => Math.min(Math.max(value, -25), max + 40);
+            const bounds = {
+                xMin: clampAxis(args.x_min !== undefined ? Number(args.x_min) : margin, size.x),
+                xMax: clampAxis(args.x_max !== undefined ? Number(args.x_max) : size.x - margin, size.x),
+                yMin: clampAxis(args.y_min !== undefined ? Number(args.y_min) : margin, size.y),
+                yMax: clampAxis(args.y_max !== undefined ? Number(args.y_max) : size.y - margin, size.y),
+            };
+            if (!(bounds.xMax > bounds.xMin) || !(bounds.yMax > bounds.yMin)) {
+                throw new McpToolError('Survey bounds are empty after clamping; check x/y min/max.');
+            }
+            const axisPoints = (min: number, max: number): number[] => {
+                const points: number[] = [];
+                for (let value = min; value <= max + 1e-9; value += pitch) {
+                    points.push(Number(value.toFixed(1)));
+                }
+                if (points[points.length - 1] < max - 1) {
+                    points.push(Number(max.toFixed(1)));
+                }
+                return points;
+            };
+            const xs = axisPoints(bounds.xMin, bounds.xMax);
+            const ys = axisPoints(bounds.yMin, bounds.yMax);
+            const waypoints: { x: number; y: number }[] = [];
+            ys.forEach((wy, row) => {
+                const ordered = row % 2 === 0 ? xs : [...xs].reverse();
+                ordered.forEach((wx) => waypoints.push({ x: wx, y: wy }));
+            });
+
+            const envelope = [
+                `; BED SURVEY: ${waypoints.length} waypoints on a ${pitch} mm serpentine grid at CURRENT machine Z ${z.toFixed(1)}`,
+                '; one frame captured per waypoint after the move settles; frames saved to disk with a',
+                '; machine-position index. Each line is sent individually. Aborts on the first capture failure.',
+                'G90',
+                'G53;',
+                ...waypoints.map((w, i) => `G0 X${w.x.toFixed(1)} Y${w.y.toFixed(1)}; waypoint ${i + 1} + capture`),
+                'G54;',
+            ].join('\n');
+            const validation = validateGcode(envelope);
+            const job = jobManager.submit(
+                envelope,
+                `bed-survey ${waypoints.length}pts pitch${pitch} - ${String(args.reason).slice(0, 40)}`,
+                'cnc',
+                validation,
+                'procedure'
+            );
+            job.runner = async () => {
+                assertMachineReadyForProcedure();
+                const surveyId = crypto.randomBytes(4).toString('hex');
+                const dir = path.join(DataStorage.userDataDir, 'mcp-surveys', surveyId);
+                fs.ensureDirSync(dir);
+                const frames: object[] = [];
+                for (let i = 0; i < waypoints.length; i++) {
+                    const w = waypoints[i];
+                    await moveMachineSettled('survey:move', { x: w.x, y: w.y }, TRAVEL_FEED * 4);
+                    let frame;
+                    try {
+                        frame = await captureFrame();
+                    } catch (err) {
+                        throw new McpToolError(`Capture failed at waypoint ${i + 1}/${waypoints.length} `
+                            + `(machine ${w.x}, ${w.y}): ${err.message}. Survey aborted; `
+                            + `${frames.length} frames saved in ${dir}.`);
+                    }
+                    const file = path.join(dir, `wp${String(i + 1).padStart(3, '0')}_x${w.x}_y${w.y}.jpg`);
+                    fs.writeFileSync(file, Buffer.from(frame.imageBase64, 'base64'));
+                    frames.push({ file, machine: { x: w.x, y: w.y, z }, capturedAt: frame.capturedAt });
+                }
+                const index = { surveyId, machineZ: z, pitchMm: pitch, frames };
+                fs.writeJsonSync(path.join(dir, 'index.json'), index, { spaces: 2 });
+                return {
+                    surveyId,
+                    directory: dir,
+                    frameCount: frames.length,
+                    index_file: path.join(dir, 'index.json'),
+                    frames,
+                    note: 'Frames are position-stamped files on disk - read them directly to view the '
+                        + 'bed. The camera is toolhead-mounted: each frame is centred near the waypoint '
+                        + 'plus the fixed camera-to-spindle offset.',
+                };
+            };
+            return {
+                job: jobManager.describe(job),
+                waypoints: waypoints.length,
+                grid: { pitch_mm: pitch, machine_z: z, columns: xs.length, rows: ys.length },
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url, check the Z clears everything on the '
+                    + 'bed (rotary included), and approve. start_gcode_job then drives the whole grid '
+                    + 'and returns the frame index.',
+            };
+        },
+    });
+}

--- a/src/server/services/mcp/tools/toolsetter.ts
+++ b/src/server/services/mcp/tools/toolsetter.ts
@@ -149,6 +149,12 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
                         + '(verified over the setter centre within 1.5 mm) - for when the touchscreen '
                         + 'wizard has already returned the new tool over the setter.',
                 },
+                accept_probe_contact: {
+                    type: 'boolean',
+                    description: 'REQUIRED when the fitted tool is the spindle TOUCH PROBE: its own '
+                        + 'channel fires before the setter switch and pressing on would bend it, so '
+                        + 'EITHER channel counts as the height confirmation (the result notes which).',
+                },
                 reason: { type: 'string', description: 'Shown to the operator: why this measurement is needed.' },
             },
             required: ['bit_length_mm', 'reason'],
@@ -187,6 +193,7 @@ export function registerToolSetterTools(registry: ToolRegistry, getConfirmBaseUr
                     store_as_reference: plan.storeAsReference,
                     stay_at_trigger: plan.stayAtTrigger,
                     start_from_current: plan.startFromCurrent,
+                    accept_probe_contact: plan.acceptProbeContact,
                 },
                 confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
                 next_step: 'Ask the operator to open confirm_url, review the SERVER-DRIVEN PROCEDURE '


### PR DESCRIPTION
Stacked on #64. The CNC touch probe workstream begins: the spindle probe (normally-open, `probe` feed channel, inverted polarity) plus the camera survey that gives the agent visual context for requests like "measure the stock on the rotary axis".

## What's here

- **`probing.ts`** — the sensor-gated motion engine extracted from the tool setter (echo-verified settled moves, short contact windows, patient release detection, readiness guards), now **multi-channel**: contact = any watched channel triggered, and results say which fired.
- **`run_tool_setter` gains `accept_probe_contact`** — measuring the touch probe *itself* on the tool setter would bend it if the march pressed on to the setter's switch (the probe's own channel fires first — operator-stated). With the flag, either channel confirms the height.
- **`probe_point`** — single-axis sensor-gated march (±X, ±Y, −Z) from the current position, with a REQUIRED hard travel limit. The confirm page enumerates every stepped command and is anchored to the staging position (re-verified before motion — a moved machine voids the approval). Coarse → release → fine → lift-and-retest confirm cycles; median contact coordinate + spread; retreat to start on completion or abort. Tip-radius caveat noted for side probes.
- **`survey_bed`** — one approval drives a serpentine XY grid at the current Z (floor: machine Z ≥ 250 unless the operator explicitly confirms clearance), capturing a frame per settled waypoint. Frames are **saved to disk with a machine-position index** (bypassing the 12-frame cache) so the whole bed can be reviewed file-by-file; aborts on the first capture failure.

35 tools total. tsc/eslint clean. Hardware validation next (probe just fitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)