### PR TITLE
Fix: Motion laws after the probe crash - traverse height, obstacles, crash guard

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cnc-probing
+description: "Measure work with the spindle touch probe and the whole-bed camera survey via the Luban MCP tools (probe_point, survey_bed, run_tool_setter with accept_probe_contact) — including the motion laws written in the aftermath of a probe-destroying crash. Use whenever the user wants to probe stock, find surfaces/edges, survey the bed, or calibrate the touch probe."
+---
+
+# CNC probing: the probe, the survey, and the motion laws
+
+The spindle touch probe turns contact into coordinates; the bed survey turns
+the camera into context. Between them sit the motion laws — written after a
+real crash (2026-09-01) in which an XY traverse at a fabricated "clearance"
+height drove the probe into the rotary stock and destroyed it.
+
+## The motion laws (operator law — never overridden on model judgment)
+
+1. **One motion per instruction.** When the operator enumerates steps,
+   execute exactly the step they name and stop. NEVER chain motion calls in
+   a single command (`&&`, one script, one turn) — each motion needs a
+   decision point in front of it. The crash happened because step 2 fired
+   117 ms after step 1 succeeded, with no chance to intervene.
+2. **X/Y traverses happen at top gantry height.** Retreat Z (operator-
+   confirmed `move_z`) to the safe traverse height FIRST, traverse, then
+   descend at the destination. Enforced: direct XY moves below
+   `mcpSafeTraverseZ` (default 320) are refused without
+   `operator_confirmed_clearance` — which only the operator's explicit words
+   authorise.
+3. **Never fabricate clearance.** Only measured numbers or operator-stated
+   numbers count for heights. Visual inference from survey frames is for
+   FINDING things, not for clearing them — the crash analysis misread the
+   same stock's orientation twice from photos. If a height is unknown, ask,
+   or measure from a proven-safe height with `probe_point`.
+4. **Landmarks are obstacles.** Give bed fixtures a `clearance_z` in
+   `set_landmark`; XY paths crossing their box below it are refused.
+5. **Contact sensors are crash sensors.** During any motion, a trigger on a
+   probe channel that no procedure declared as expected trips a CRASH alarm:
+   job stopped, connection closed, motion latched until the operator clears
+   it. Do not disconnect the probe feed while anything might move.
+
+## Probe calibration (do once per probe fitting)
+
+`run_tool_setter` with `accept_probe_contact: true` and a conservative
+`bit_length_mm` (declare LOW: the floor sits only floor_margin below the
+declared expectation, and coarse contact presses at most one coarse step —
+fine for a sprung probe). On this rig the setter's switch is softer than the
+probe's axial spring, so the setter fires first; either channel confirms.
+
+- Setter surface = machine Z 100.5 (trigger 175.5 with the 75 mm reference).
+- Probe effective length = measured trigger Z − 100.5 (measured 71.1 mm,
+  2026-09-01, spread 0 across three passes).
+- **Any probed surface height = probe contact toolhead Z − probe length.**
+
+## Point probing
+
+`probe_point` marches one axis (±X, ±Y, −Z) from the CURRENT position with a
+required `max_travel_mm`; the envelope is anchored to the staging position
+and re-verified before motion. Position first (top-height traverse, then
+operator-confirmed descent), stage, operator approves, run. Results: median
+of lift-and-retest passes, spread as the trust metric. Side probes touch one
+tip-radius before the tip centre — correct for it.
+
+Feed latency (hardware-measured, Adafruit IO): trigger message ~120–150 ms
+after physical contact; 200 ms contact windows are right. Release messages
+lag ~1 s — release checks are patient by design; never shorten them.
+
+## Bed survey
+
+`survey_bed` at top gantry height: serpentine grid, one settled frame per
+waypoint, saved to disk with a machine-position index. Cover the FULL
+reachable envelope (`x_max` etc. beyond nominal size when reachable — the
+camera on this rig looks ~90–150 mm in −X of the toolhead, so the far-X
+column is the only view of the bed centre-right). Read the frames from disk;
+landmarks near each position are the identities the operator already stated.

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -71,6 +71,28 @@ every MCP-sent gcode line and controller reply (`[mcp:home] > G28` / `< X:-19.00
 and tool activity — all timestamped. Events: `mcp:activity`, `mcp:gcode` (whitelisted in
 `socket-communication.ts`).
 
+## Motion laws (operator law after the 2026-09-01 probe crash)
+
+An XY traverse at a fabricated "clearance" height (Z200, derived from assumptions about
+the rotary stock's geometry — wrong twice over) destroyed the fitted touch probe. The
+step had also been chained onto an approved Z move in one command, executing 117 ms after
+it with no decision point, when the operator had authorised "step 1" only. Laws:
+
+1. **One motion per instruction** — never chain motion tool calls in a single command or
+   turn; each motion gets its own decision point. Enumerated steps run one at a time.
+2. **X/Y traverses at top gantry height** — direct XY moves below `mcpSafeTraverseZ`
+   (default 320) are refused without `operator_confirmed_clearance`. Retreat, traverse,
+   descend — in that order.
+3. **No fabricated clearances** — only measured or operator-stated heights count. Visual
+   inference finds things; it never clears them.
+4. **Landmarks are obstacles** — `clearance_z` on a landmark refuses XY paths crossing its
+   box below that height.
+5. **Contact sensors are crash sensors** — a probe/toolsetter trigger during motion that no
+   procedure declared as expected trips a CRASH alarm (stop + force-close + latch), the
+   same machinery as overtravel; `clear_overtravel_alarm` clears either kind on the
+   operator's explicit word. Feed readings and all gcode traffic are logged server-side.
+6. The approved-code page re-shows the exact gcode next to the one-time code.
+
 ## Safety model (operator-defined, non-negotiable)
 
 - **Compound motion and all cutting goes out as gcode FILES** through the same
@@ -116,9 +138,29 @@ and tool activity — all timestamped. Events: `mcp:activity`, `mcp:gcode` (whit
   calibration is keyed by machine Y AND Z. The board-viewing anchor pose is the pre-home
   park (machine X0/Y0), not machine home. The **gold cylinder at machine Y≈176–340 is the
   TOOL HEIGHT CHECKER** (operator-confirmed; was misidentified twice).
-- **Tool setter (operator-stated 2026-08-31): centre at machine (X79, Y293); it triggers at
-  machine Z176 with a 75 mm endmill in the holder** — so expected trigger Z for a bit of
-  length L is `176 + (L − 75)`. Seed `set_tool_setter_config` with these on first run.
+- **Tool setter: centre at machine (X79, Y293), top-left of bed. MEASURED trigger Z 175.500
+  with the 75 mm reference endmill (three confirm passes agreed, spread 0)** — so the setter
+  SURFACE is machine Z 100.5, and expected trigger Z for a bit of length L is
+  `175.5 + (L − 75)`. Config + measurement history live in `mcpToolSetter`.
+- **Touch probe (measured 2026-09-01): effective length 71.1 mm** (trigger on the setter at
+  machine Z 171.6 ⇒ any surface = probe contact toolhead Z − 71.1). The probe's AXIAL
+  spring is stiffer than the setter's switch, so on the setter the SETTER fires first —
+  measuring the probe there is safe with `accept_probe_contact: true` (either channel
+  confirms). Probe feed latency, hardware-measured: **~120–150 ms** sensor→feed on a local
+  bump test (trigger message 452 ms after move issue incl. ~330 ms motion) — the 200 ms
+  contact windows are correctly sized.
+- **Camera offset**: the toolhead camera looks roughly **90–150 mm in −X** of the toolhead
+  (setup-specific — verify per rig): features at machine X appear in frames taken from
+  toolhead X+90..150. The far-X column of a bed survey is therefore the only view of the
+  bed centre-right.
+- **Bed map (operator-stated + survey 25c4f87a, 2026-09-01)**: rotary module along the bed
+  centre at **machine X≈170**, axis along Y, chuck at the back (~Y250–320), yellow tailstock
+  at the front; tool setter top-left. Both stored as landmarks (`rotary-axis`,
+  `tool-setter`).
+- **Silent non-motion signature**: the controller can reply `ok` to a direct move and not
+  move at all (settle times out with position unchanged; observed once 2026-09-01, suspected
+  enclosure door open — unconfirmed). The verified-settle contract catches it; do not trust
+  an `ok` alone.
 - Fleet: machine named "Snapmaker" @ 192.168.1.173 = the A350 CNC; "F350" @ .130 = the
   3D printer. Same Luban profile identifier — distinguish by NAME/address, never profile.
 

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -210,11 +210,21 @@ export class JobManager {
             job.approvedAt = Date.now();
             job.state = 'approved';
             log.info(`MCP job ${job.id} approved by operator`);
+            // The gcode is shown AGAIN next to the code (operator request
+            // after the 2026-09-01 probe crash): the last thing seen before
+            // handing over the code is exactly what the code will run.
+            const approvedGcode = fs.readFileSync(job.filePath, 'utf8');
+            const approvedLines = approvedGcode.split(/\r?\n/);
+            const approvedPreview = approvedLines.length > 80
+                ? [...approvedLines.slice(0, 40), `... ${approvedLines.length - 80} lines elided ...`, ...approvedLines.slice(-40)].join('\n')
+                : approvedGcode;
             this.page(res, 200, `
                 <h2>Approved</h2>
                 <p>Give this one-time code to the agent to start <strong>${escapeHtml(job.name)}</strong>:</p>
                 <p style="font-size:2em;font-family:monospace;letter-spacing:0.2em">${job.confirmToken}</p>
-                <p>It expires in 15 minutes and works once.</p>`);
+                <p>It expires in 15 minutes and works once.</p>
+                <h3>This code will run exactly:</h3>
+                <pre style="background:#f6f6f6;padding:12px;overflow:auto;max-height:300px">${escapeHtml(approvedPreview)}</pre>`);
             return;
         }
         if (req.method === 'POST' && action === 'reject') {

--- a/src/server/services/mcp/landmarks.ts
+++ b/src/server/services/mcp/landmarks.ts
@@ -19,6 +19,13 @@ export interface Landmark {
     description: string;
     // Machine-coordinate XY extent of the feature on/over the bed.
     machine: { x0: number; y0: number; x1: number; y1: number };
+    // Obstacle clearance: minimum safe TOOLHEAD machine Z when the XY path
+    // crosses this landmark's box (operator accounts for tool length when
+    // setting it). null = not an obstacle. Enforced by the direct XY move
+    // guard - added after the 2026-09-01 probe crash, where a traverse at a
+    // fabricated "clearance" height crossed the rotary and destroyed the
+    // fitted touch probe.
+    clearanceZ: number | null;
     notes: string | null;
     createdAt: number;
 }
@@ -45,7 +52,9 @@ export class LandmarkStore {
         }
         try {
             const raw = fs.readJsonSync(this.file());
-            this.cache = { landmarks: Array.isArray(raw?.landmarks) ? raw.landmarks : [] };
+            const landmarks = (Array.isArray(raw?.landmarks) ? raw.landmarks : [])
+                .map((l: Landmark) => ({ ...l, clearanceZ: Number.isFinite(Number(l.clearanceZ)) ? Number(l.clearanceZ) : null }));
+            this.cache = { landmarks };
         } catch (err) {
             this.cache = { landmarks: [] };
         }
@@ -88,6 +97,51 @@ export class LandmarkStore {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Obstacle landmarks (clearanceZ set) whose box - inflated by margin -
+     * the straight XY segment from (x0,y0) to (x1,y1) touches, and whose
+     * clearanceZ the given toolhead machine Z is BELOW. These are collisions
+     * waiting to happen; the direct XY guard refuses them.
+     */
+    public obstaclesOnPath(
+        x0: number, y0: number, x1: number, y1: number,
+        toolheadZ: number, marginMm = 5
+    ): Landmark[] {
+        return this.load().landmarks.filter((l) => {
+            if (l.clearanceZ === null || toolheadZ >= l.clearanceZ) {
+                return false;
+            }
+            const bx0 = l.machine.x0 - marginMm;
+            const by0 = l.machine.y0 - marginMm;
+            const bx1 = l.machine.x1 + marginMm;
+            const by1 = l.machine.y1 + marginMm;
+            // 2D segment-vs-AABB slab test.
+            const dx = x1 - x0;
+            const dy = y1 - y0;
+            let tMin = 0;
+            let tMax = 1;
+            for (const [p, d, lo, hi] of [[x0, dx, bx0, bx1], [y0, dy, by0, by1]] as [number, number, number, number][]) {
+                if (Math.abs(d) < 1e-12) {
+                    if (p < lo || p > hi) {
+                        return false;
+                    }
+                } else {
+                    let t1 = (lo - p) / d;
+                    let t2 = (hi - p) / d;
+                    if (t1 > t2) {
+                        [t1, t2] = [t2, t1];
+                    }
+                    tMin = Math.max(tMin, t1);
+                    tMax = Math.min(tMax, t2);
+                    if (tMin > tMax) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        });
     }
 
     /**

--- a/src/server/services/mcp/probeFeed.ts
+++ b/src/server/services/mcp/probeFeed.ts
@@ -170,7 +170,9 @@ export interface ProbeReading {
     topic: string;
 }
 
-interface OvertravelTrip {
+interface SafetyTrip {
+    kind: 'overtravel' | 'crash';
+    channel: ProbeChannel;
     at: number;
     value: string;
     actions: string[];
@@ -186,7 +188,15 @@ export class ProbeFeedService {
 
     private readings = new Map<ProbeChannel, ProbeReading>();
 
-    private trip: OvertravelTrip | null = null;
+    private trip: SafetyTrip | null = null;
+
+    // Crash guard (added after the 2026-09-01 probe crash): while any
+    // sensor-visible motion is in flight, a triggered reading on a contact
+    // channel that is NOT expected to touch anything is a collision - same
+    // response as overtravel. Procedures declare their expected channels.
+    private motionCount = 0;
+
+    private expectedContact = new Set<ProbeChannel>();
 
     private reconnectTimer: NodeJS.Timeout | null = null;
 
@@ -264,7 +274,7 @@ export class ProbeFeedService {
         });
     }
 
-    public getTrip(): OvertravelTrip | null {
+    public getTrip(): SafetyTrip | null {
         return this.trip;
     }
 
@@ -274,20 +284,40 @@ export class ProbeFeedService {
      */
     public assertNoOvertravel(): void {
         if (this.trip) {
-            throw new McpToolError(`OVERTRAVEL ALARM latched at ${new Date(this.trip.at).toISOString()} `
-                + `(sensor value "${this.trip.value}"). All motion is blocked. The operator must inspect `
+            throw new McpToolError(`${this.trip.kind === 'crash' ? 'CRASH' : 'OVERTRAVEL'} ALARM latched at `
+                + `${new Date(this.trip.at).toISOString()} (${this.trip.channel} sensor value "${this.trip.value}"). `
+                + 'All motion is blocked. The operator must inspect '
                 + 'the machine and explicitly clear the alarm (clear_overtravel_alarm) or restart Luban.');
         }
     }
 
     /** Operator-authorised alarm clear; refuses while still reporting triggered. */
     public clearTrip(): void {
-        const reading = this.readings.get('overtravel');
+        const channel = this.trip ? this.trip.channel : 'overtravel';
+        const reading = this.readings.get(channel);
         if (reading && reading.triggered) {
-            throw new McpToolError('The overtravel feed still reports triggered; refusing to clear the alarm.');
+            throw new McpToolError(`The ${channel} feed still reports triggered; refusing to clear the alarm.`);
         }
         this.trip = null;
-        log.warn('Overtravel alarm cleared by operator authority.');
+        log.warn('Safety alarm cleared by operator authority.');
+    }
+
+    /** Motion-in-flight bracket for the crash guard. Always pair with motionEnd. */
+    public motionBegin(): void {
+        this.motionCount += 1;
+    }
+
+    public motionEnd(): void {
+        this.motionCount = Math.max(0, this.motionCount - 1);
+    }
+
+    /** Declare which channels a probing procedure EXPECTS to touch. */
+    public setExpectedContact(channels: ProbeChannel[]): void {
+        this.expectedContact = new Set(channels);
+    }
+
+    public clearExpectedContact(): void {
+        this.expectedContact.clear();
     }
 
     public status(): object {
@@ -319,7 +349,7 @@ export class ProbeFeedService {
             clientId: cfg.clientId,
             configSources: cfg.sources,
             feeds,
-            overtravelTrip: this.trip,
+            safetyTrip: this.trip,
             reconnectAttempts: this.reconnectAttempts,
             lastError: this.lastError,
         };
@@ -436,8 +466,15 @@ export class ProbeFeedService {
                 value: payload,
                 triggered: reading.triggered,
             });
-            if (channel === 'overtravel' && reading.triggered && !this.trip) {
-                this.tripOvertravel(reading);
+            log.info(`reading ${channel}=${payload} triggered=${reading.triggered}`);
+            if (!this.trip && reading.triggered) {
+                if (channel === 'overtravel') {
+                    this.tripSafety('overtravel', channel, reading);
+                } else if (this.motionCount > 0 && !this.expectedContact.has(channel)) {
+                    // A contact sensor fired during motion that expected no
+                    // contact: collision. Stop everything.
+                    this.tripSafety('crash', channel, reading);
+                }
             }
             return;
         }
@@ -448,35 +485,35 @@ export class ProbeFeedService {
      * machine connection, latch the alarm, tell the operator. Best-effort on
      * every step - a failed stop must not prevent the disconnect.
      */
-    private tripOvertravel(reading: ProbeReading): void {
+    private tripSafety(kind: 'overtravel' | 'crash', channel: ProbeChannel, reading: ProbeReading): void {
         const actions: string[] = [];
-        this.trip = { at: reading.receivedAt, value: reading.value, actions };
-        log.error(`OVERTRAVEL reported by probe feed (value "${reading.value}") - aborting all jobs and connections`);
+        this.trip = { kind, channel, at: reading.receivedAt, value: reading.value, actions };
+        log.error(`${kind.toUpperCase()} reported by ${channel} feed (value "${reading.value}") - aborting all jobs and connections`);
 
-        const channel = connectionManager.getCurrentChannel() as unknown as {
+        const machineChannel = connectionManager.getCurrentChannel() as unknown as {
             stopGcodeJob?: () => Promise<unknown>;
             connectionClose?: (options: { force: boolean }) => Promise<unknown>;
         } | null;
-        if (channel) {
+        if (machineChannel) {
             (async () => {
-                if (typeof channel.stopGcodeJob === 'function') {
+                if (typeof machineChannel.stopGcodeJob === 'function') {
                     try {
-                        await channel.stopGcodeJob();
+                        await machineChannel.stopGcodeJob();
                         actions.push('stop_gcode_job sent');
-                        log.error('Overtravel abort: stop sent to the machine');
+                        log.error(`${kind} abort: stop sent to the machine`);
                     } catch (err) {
                         actions.push(`stop_gcode_job failed: ${err.message}`);
-                        log.error(`Overtravel abort: stop failed: ${err.message}`);
+                        log.error(`${kind} abort: stop failed: ${err.message}`);
                     }
                 }
-                if (typeof channel.connectionClose === 'function') {
+                if (typeof machineChannel.connectionClose === 'function') {
                     try {
-                        await channel.connectionClose({ force: true });
+                        await machineChannel.connectionClose({ force: true });
                         actions.push('connection force-closed');
-                        log.error('Overtravel abort: machine connection force-closed');
+                        log.error(`${kind} abort: machine connection force-closed`);
                     } catch (err) {
                         actions.push(`connection close failed: ${err.message}`);
-                        log.error(`Overtravel abort: close failed: ${err.message}`);
+                        log.error(`${kind} abort: close failed: ${err.message}`);
                     }
                 }
             })();
@@ -486,10 +523,11 @@ export class ProbeFeedService {
 
         mcpBroadcast('mcp:activity', {
             tool: 'probe_feed',
-            phase: 'OVERTRAVEL_ALARM',
+            phase: kind === 'crash' ? 'CRASH_ALARM' : 'OVERTRAVEL_ALARM',
             value: reading.value,
-            message: 'Overtravel sensor tripped: running job stopped, machine connection force-closed, '
-                + 'all MCP motion blocked until the operator clears the alarm.',
+            message: `${kind === 'crash' ? `Collision: ${channel} sensor fired during motion that expected no contact` : 'Overtravel sensor tripped'}: `
+                + 'running job stopped, machine connection force-closed, all MCP motion blocked '
+                + 'until the operator clears the alarm.',
         });
     }
 }

--- a/src/server/services/mcp/probeTool.ts
+++ b/src/server/services/mcp/probeTool.ts
@@ -151,6 +151,9 @@ export interface ProbePointResult {
 export async function runProbePointProcedure(plan: ProbePointPlan): Promise<object> {
     assertChannelReady('probe', 'touch probe');
     assertMachineReadyForProcedure();
+    // The probe is EXPECTED to touch during this procedure; the toolsetter
+    // firing instead would be a collision (crash guard). Cleared in finally.
+    probeFeedService.setExpectedContact(['probe']);
 
     const position = getPositionSnapshot();
     const here = position.machine;
@@ -312,5 +315,7 @@ export async function runProbePointProcedure(plan: ProbePointPlan): Promise<obje
             throw new McpToolError(`Probe run aborted: ${err.message} Phases completed: ${JSON.stringify(phases)}`);
         }
         throw err;
+    } finally {
+        probeFeedService.clearExpectedContact();
     }
 }

--- a/src/server/services/mcp/toolSetter.ts
+++ b/src/server/services/mcp/toolSetter.ts
@@ -18,7 +18,7 @@ import {
     senseReleaseAfter,
 } from './probing';
 import { McpToolError } from './registry';
-import { getPositionSnapshot } from './tools/machine';
+import { getPositionSnapshot, safeTraverseZ } from './tools/machine';
 
 const log = logger('service:mcp:tool-setter');
 
@@ -329,6 +329,9 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
     for (const channel of contactChannels) {
         assertChannelReady(channel, 'tool setter');
     }
+    // This procedure EXPECTS these channels to touch; anything else firing
+    // mid-motion is a collision (crash guard). Cleared in the finally.
+    probeFeedService.setExpectedContact(contactChannels);
     assertMachineReadyForProcedure();
     const position = getPositionSnapshot();
 
@@ -361,9 +364,15 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
             announce('start-from-current', currentZ, 'skipping travel; descending from the current position');
         } else {
             // Phase 1: position over the centre, then travel down to start
-            // height. XY first at the current (post-home, high) Z, so the bit
-            // never sweeps across the bed at approach height.
-            announce('travel-xy', position.machine.z ?? plan.startZ, `XY to (${c.centerX}, ${c.centerY})`);
+            // height. XY first, and ONLY at top gantry height (operator law
+            // after the 2026-09-01 probe crash) - the bit never sweeps across
+            // the bed below the safe traverse Z.
+            const z = position.machine.z;
+            if (z === null || z < safeTraverseZ()) {
+                throw new ProcedureAbort(`XY travel to the setter refused at machine Z ${z === null ? 'unknown' : z.toFixed(1)} - `
+                    + `below the safe traverse height ${safeTraverseZ()}. Raise Z first (move_z, operator-confirmed).`);
+            }
+            announce('travel-xy', z, `XY to (${c.centerX}, ${c.centerY})`);
             await moveMachineSettled('toolsetter:travel', { x: c.centerX, y: c.centerY }, TRAVEL_FEED);
             announce('travel-z', plan.startZ);
             await moveMachineSettled('toolsetter:travel', { z: plan.startZ }, TRAVEL_FEED);
@@ -548,5 +557,7 @@ export async function runToolSetterProcedure(plan: ToolSetterPlan): Promise<obje
                 + `Phases completed: ${JSON.stringify(phases)}`);
         }
         throw err;
+    } finally {
+        probeFeedService.clearExpectedContact();
     }
 }

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -9,7 +9,7 @@ import { decodeToGray, trackFeature } from '../tracking';
 import { McpToolError, ToolRegistry } from '../registry';
 import { landmarkStore } from '../landmarks';
 import { probeFeedService } from '../probeFeed';
-import { PositionSnapshot, getMachineSizeByIdentifier, getPositionSnapshot } from './machine';
+import { PositionSnapshot, getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './machine';
 
 // Motion policy (#23, refined): the direct move path is for the odd single
 // action only. move_and_capture performs ONE bounded XY move at the current
@@ -41,7 +41,16 @@ const gcodeLog = logger('service:mcp:gcode');
 export async function sendGcodeVisible(channel: GcodeChannel, tool: string, gcode: string): Promise<{ result: number; text?: string }> {
     mcpBroadcast('mcp:gcode', { tool, gcode });
     gcodeLog.info(`[${tool}] > ${gcode.replace(/\r?\n/g, ' | ')}`);
-    const executed = await channel.executeGcode(gcode);
+    // Crash-guard bracket: the HTTP channel executes synchronously, so the
+    // await spans the motion window - a contact-sensor trigger inside it
+    // that no procedure expects is treated as a collision (probeFeed).
+    probeFeedService.motionBegin();
+    let executed;
+    try {
+        executed = await channel.executeGcode(gcode);
+    } finally {
+        probeFeedService.motionEnd();
+    }
     const response = executed.text || (executed.result === 0 ? 'ok' : `result=${executed.result}`);
     mcpBroadcast('mcp:gcode', { tool, response });
     gcodeLog.info(`[${tool}] < ${String(response).replace(/\r?\n/g, ' | ')}`);
@@ -194,6 +203,35 @@ export async function executeBoundedMoveAndCapture(args: BoundedMoveArgs): Promi
         x: target.x - before.originOffset.x,
         y: target.y - before.originOffset.y,
     };
+
+    // OPERATOR LAW (2026-09-01, after the probe crash): X/Y traverses happen
+    // at top gantry height. An XY move below the safe traverse Z, or one
+    // whose path crosses an obstacle landmark below its clearance height, is
+    // refused unless the operator has EXPLICITLY confirmed this corridor -
+    // never on the model's own judgment, never derived from assumptions
+    // about what is on the bed.
+    const machineZ = before.machine.z;
+    if (args.operator_confirmed_clearance !== true && machineZ !== null) {
+        const traverseFloor = safeTraverseZ();
+        if (machineZ < traverseFloor) {
+            throw new McpToolError(`XY move refused: machine Z ${machineZ.toFixed(1)} is below the safe `
+                + `traverse height ${traverseFloor} (top gantry). Retreat Z first (move_z, operator-`
+                + 'confirmed), then traverse, then descend at the destination. Only the operator\'s '
+                + 'explicit word (operator_confirmed_clearance: true) authorises a lower corridor.');
+        }
+        const machineFrom = { x: before.machine.x, y: before.machine.y };
+        if (machineFrom.x !== null && machineFrom.y !== null) {
+            const obstacles = landmarkStore.obstaclesOnPath(
+                machineFrom.x, machineFrom.y, machineTarget.x, machineTarget.y, machineZ
+            );
+            if (obstacles.length) {
+                throw new McpToolError('XY move refused: the path crosses obstacle landmark(s) '
+                    + `${obstacles.map((l) => `"${l.name}" (clearance Z ${l.clearanceZ})`).join(', ')} `
+                    + `while at machine Z ${machineZ.toFixed(1)}. Raise Z above the clearance, or get the `
+                    + 'operator\'s explicit confirmation for this corridor.');
+            }
+        }
+    }
     if (size) {
         // Floors allow real overtravel: the A350 X home switch sits at
         // machine -19, so "keep the current X while parked at home" must

--- a/src/server/services/mcp/tools/landmarks.ts
+++ b/src/server/services/mcp/tools/landmarks.ts
@@ -33,6 +33,12 @@ export function registerLandmarkTools(registry: ToolRegistry): void {
                 y0: { type: 'number' },
                 x1: { type: 'number' },
                 y1: { type: 'number' },
+                clearance_z: {
+                    type: 'number',
+                    description: 'Marks this landmark as an OBSTACLE: minimum safe toolhead machine Z '
+                        + 'when an XY path crosses its box (operator accounts for tool length). Direct '
+                        + 'XY moves below it across the box are refused. Omit for non-obstacles.',
+                },
                 notes: { type: 'string' },
             },
             required: ['name', 'description', 'x0', 'y0', 'x1', 'y1'],
@@ -45,6 +51,7 @@ export function registerLandmarkTools(registry: ToolRegistry): void {
             y0?: number;
             x1?: number;
             y1?: number;
+            clearance_z?: number;
             notes?: string;
         }) => {
             const name = String(args.name || '').trim();
@@ -56,10 +63,15 @@ export function registerLandmarkTools(registry: ToolRegistry): void {
             if (box.some((v) => !Number.isFinite(v)) || box[0] >= box[2] || box[1] >= box[3]) {
                 throw new McpToolError('Require finite machine coordinates with x0 < x1 and y0 < y1.');
             }
+            const clearanceZ = args.clearance_z !== undefined ? Number(args.clearance_z) : null;
+            if (clearanceZ !== null && !Number.isFinite(clearanceZ)) {
+                throw new McpToolError('clearance_z must be a finite machine Z when given.');
+            }
             const landmark = landmarkStore.add({
                 name,
                 description,
                 machine: { x0: box[0], y0: box[1], x1: box[2], y1: box[3] },
+                clearanceZ,
                 notes: args.notes ? String(args.notes) : null,
             });
             return { landmark: describeLandmark(landmark) };

--- a/src/server/services/mcp/tools/machine.ts
+++ b/src/server/services/mcp/tools/machine.ts
@@ -57,6 +57,18 @@ function axisValue(value: unknown): number | null {
     return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * The minimum toolhead machine Z for X/Y traverses - OPERATOR LAW after the
+ * 2026-09-01 probe crash: "always retreat to top gantry height (home
+ * effectively) before x/y moves". Default 320 (home Z is 328 on the A350);
+ * override via configstore mcpSafeTraverseZ. Anything lower needs the
+ * operator's explicit clearance for that specific corridor.
+ */
+export function safeTraverseZ(): number {
+    const raw = Number(config.get('mcpSafeTraverseZ'));
+    return Number.isFinite(raw) && raw > 0 ? raw : 320;
+}
+
 export interface PositionSnapshot {
     work: { x: number | null; y: number | null; z: number | null };
     machine: { x: number | null; y: number | null; z: number | null };

--- a/src/server/services/mcp/tools/probe.ts
+++ b/src/server/services/mcp/tools/probe.ts
@@ -55,10 +55,11 @@ export function registerProbeTools(registry: ToolRegistry): void {
 
     registry.register({
         name: 'clear_overtravel_alarm',
-        description: 'Clear the latched overtravel alarm that is blocking all motion. ONLY on the '
-            + 'operator\'s explicit word, after they have physically inspected the machine and the '
-            + 'overtravel mechanism: pass operator_confirmed: true and repeat their words in reason. '
-            + 'Refused while the overtravel feed still reports triggered.',
+        description: 'Clear the latched safety alarm (overtravel OR crash - a contact sensor firing '
+            + 'during motion that expected no contact) that is blocking all motion. ONLY on the '
+            + 'operator\'s explicit word, after they have physically inspected the machine: pass '
+            + 'operator_confirmed: true and repeat their words in reason. Refused while the tripped '
+            + 'channel still reports triggered.',
         inputSchema: {
             type: 'object',
             properties: {

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -12,14 +12,13 @@ import { describeProbePlanAsGcode, planProbePoint, runProbePointProcedure } from
 import { probeFeedService } from '../probeFeed';
 import { TRAVEL_FEED, assertMachineReadyForProcedure, moveMachineSettled } from '../probing';
 import { McpToolError, ToolRegistry } from '../registry';
-import { getMachineSizeByIdentifier, getPositionSnapshot } from './machine';
+import { getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './machine';
 import { validateGcode } from '../validator';
 
 // The spindle touch probe (probe feed channel) and the whole-bed camera
 // survey: the survey gives the agent visual context ("measure the stock on
 // the rotary axis"), the probe turns that context into millimetres.
 
-const SURVEY_MIN_MACHINE_Z = 250;
 
 export function registerProbingTools(registry: ToolRegistry, getConfirmBaseUrl: () => string): void {
     registry.register({
@@ -122,10 +121,11 @@ export function registerProbingTools(registry: ToolRegistry, getConfirmBaseUrl: 
             if (x === null || y === null || z === null) {
                 throw new McpToolError('Current machine position unknown.');
             }
-            if (z < SURVEY_MIN_MACHINE_Z && args.operator_confirmed_clearance !== true) {
-                throw new McpToolError(`Machine Z ${z.toFixed(1)} is below the survey height floor `
-                    + `${SURVEY_MIN_MACHINE_Z} - raise Z (move_z), or pass operator_confirmed_clearance: `
-                    + 'true only on the operator\'s explicit word that this Z clears everything on the bed.');
+            if (z < safeTraverseZ() && args.operator_confirmed_clearance !== true) {
+                throw new McpToolError(`Machine Z ${z.toFixed(1)} is below the safe traverse height `
+                    + `${safeTraverseZ()} (top gantry - operator law for all X/Y motion) - raise Z `
+                    + '(move_z), or pass operator_confirmed_clearance: true only on the operator\'s '
+                    + 'explicit word that this Z clears everything on the bed.');
             }
             const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
             if (!size) {


### PR DESCRIPTION
Stacked on #65. Post-mortem and enforcement for the 2026-09-01 incident that destroyed the touch probe.

## What happened

The operator authorised "step 1" (Z to 200) of a three-step plan. The XY traverse (step 2) was chained onto the approved move in one command and fired **117 ms** after it — no decision point existed. The traverse height was **fabricated from assumptions** about the rotary stock's geometry (visual reads of the same stock's orientation had flip-flopped twice); the tip crossed the rotary at physical 128.9 mm, struck the stock, and destroyed the probe. The firmware reported `ok` throughout, the settle verified, and the one sensor that knew in real time — the probe itself — was connected and ignored, because only the overtravel channel was a tripwire.

## Enforcement, mapped to causes

| Cause | Fix |
|---|---|
| Steps chained with no decision point | **Process law** (skill + README): one motion per instruction; never chain motion calls in one command/turn |
| Fabricated clearance height | **Safe traverse height** (operator law: *"always retreat to top gantry height before x/y moves"*): direct XY below `mcpSafeTraverseZ` (default 320) refused without `operator_confirmed_clearance` — in `move_and_capture`/`goto_work_origin`/`visual_servo`, the tool setter travel phase, and `survey_bed` staging |
| No obstacle model on the bed | **Obstacle landmarks**: `set_landmark` gains `clearance_z`; XY paths crossing an obstacle's box below it are refused (segment-vs-AABB, 5 mm margin) |
| Probe ignored during motion | **Crash tripwire**: probe/toolsetter trigger during motion (bracketed in `sendGcodeVisible`) with no declared expected contact → CRASH alarm: stop job, force-close connection, latch all motion — same machinery as overtravel; procedures declare their expected channels |
| No forensics | Feed readings now logged server-side (the crash left no server-log trace of whether the probe fired) |
| Operator request | The approved-code page **re-shows the exact gcode** next to the one-time code |

New skill `.claude/skills/cnc-probing/SKILL.md` and a **Motion laws** README section carry the incident verbatim so no future session re-derives the mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)