### PR TITLE
Fix: File jobs reach a terminal state when the machine goes idle

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -12,11 +12,17 @@ height drove the probe into the rotary stock and destroyed it.
 
 ## The motion laws (operator law — never overridden on model judgment)
 
-1. **One motion per instruction.** When the operator enumerates steps,
-   execute exactly the step they name and stop. NEVER chain motion calls in
-   a single command (`&&`, one script, one turn) — each motion needs a
-   decision point in front of it. The crash happened because step 2 fired
-   117 ms after step 1 succeeded, with no chance to intervene.
+1. **One motion per instruction, and no inferred approvals.** When the
+   operator enumerates steps, execute exactly the step they name and stop.
+   NEVER chain motion calls in a single command (`&&`, one script, one
+   turn) — each motion needs a decision point in front of it. The crash
+   happened because step 2 fired 117 ms after step 1 succeeded, with no
+   chance to intervene. A motion is authorized ONLY by an explicit
+   imperative in the operator's latest message ("home it", "go", "run the
+   probe"). A motion mentioned in passing — "take a photo before homing",
+   "then we'll traverse", an approved plan that lists it — is context, not
+   a command: announce the next motion and WAIT for the word (violated
+   2026-09-02: homed off the back of "before homing").
 2. **X/Y traverses happen at top gantry height.** Retreat Z (operator-
    confirmed `move_z`) to the safe traverse height FIRST, traverse, then
    descend at the destination. Enforced: direct XY moves below
@@ -34,7 +40,15 @@ height drove the probe into the rotary stock and destroyed it.
    probe channel that no procedure declared as expected trips a CRASH alarm:
    job stopped, connection closed, motion latched until the operator clears
    it. Do not disconnect the probe feed while anything might move.
-6. **Use tools for their purpose, through the MCP surface only.**
+6. **Chat is not a motion gate — the staged job is.** Deliberate traverses
+   and descents go through `submit_gcode_job` / staged procedures, so the
+   operator authorises the literal gcode with a one-time code from the
+   confirm page. A "go" in chat is only permission to STAGE; interpretation
+   of chat wording is exactly what fails (see law 1's violations). Direct
+   move tools are for small vision nudges only. Home (re-prove position)
+   before a traverse whenever position state has any doubt — including
+   after any motion that wasn't part of the agreed sequence.
+7. **Use tools for their purpose, through the MCP surface only.**
    `move_and_capture` is a vision reposition, not a goto — its required
    `reason` is shown to the operator, and rapid sequential direct moves are
    refused (pacing guard). A script looping motion calls is an unsupervised

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -78,8 +78,11 @@ the rotary stock's geometry — wrong twice over) destroyed the fitted touch pro
 step had also been chained onto an approved Z move in one command, executing 117 ms after
 it with no decision point, when the operator had authorised "step 1" only. Laws:
 
-1. **One motion per instruction** — never chain motion tool calls in a single command or
-   turn; each motion gets its own decision point. Enumerated steps run one at a time.
+1. **One motion per instruction, no inferred approvals** — never chain motion tool calls
+   in a single command or turn; each motion gets its own decision point. Enumerated steps
+   run one at a time. Only an explicit imperative in the operator's latest message
+   authorizes a motion; a motion mentioned in passing ("before homing", "then we'll…",
+   a previously approved plan) is context, not a command — announce and wait.
 2. **X/Y traverses at top gantry height** — direct XY moves below `mcpSafeTraverseZ`
    (default 320) are refused without `operator_confirmed_clearance`. Retreat, traverse,
    descend — in that order.
@@ -92,6 +95,11 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
    same machinery as overtravel; `clear_overtravel_alarm` clears either kind on the
    operator's explicit word. Feed readings and all gcode traffic are logged server-side.
 6. The approved-code page re-shows the exact gcode next to the one-time code.
+   **Chat is not a motion gate — the staged job is** (operator, 2026-09-02): deliberate
+   traverses/descents go through staged jobs so authorization is the one-time code against
+   the literal gcode, not a model's reading of chat wording. A "go" in chat only permits
+   staging. Re-prove position (home) before a traverse when state is in any doubt,
+   including after any motion that wasn't part of the agreed sequence.
 7. **Use tools for their purpose** — `move_and_capture` is a vision reposition, not a
    transport primitive (its `reason` is required and shown to the operator); sequences of
    motion belong in the staged, operator-approved mechanisms (`survey_bed`, `move_z`
@@ -139,8 +147,12 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
   (a bare G28 leaves reporting in an unselected workspace → impossible derived coords like
   Y 464/Z 656). Homing takes ~15–20 s and **also homes B — stock on the rotary rotates**.
 - **Work origins are operator-set per workspace and persist across homing.**
-- **The firmware parks at the work origin when a file job COMPLETES** — file jobs cannot
-  hold a position; that is why `move_z` exists on the direct path.
+- **The machine interpreter returns to Z top at the job's finish position when a file job
+  COMPLETES** (operator-clarified 2026-09-02; supersedes the earlier "parks at the work
+  origin" reading — Z top and this setup's work-origin Z are both 328, which hid the
+  difference). XY holds; Z does not — that is why `move_z` exists on the direct path.
+  The job-concept split that matters: machine-interpreter (file) jobs get the door-detector
+  emergency stop; MCP direct single-command ops do NOT.
 - Heartbeat period ~1 s; a settled-looking heartbeat can predate the motion (hence the
   verified-settle contract). `query_firmware_position` (M114) is the authoritative check.
 - Camera is **toolhead-mounted** (rides X/Z; the platform moves under it in Y): pixel→mm

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -29,9 +29,11 @@ export type McpJobState =
 
 /**
  * 'file' runs through prepare_print/start_print (door interlock applies, and
- * the firmware parks at the work origin on completion). 'direct' executes
- * over execute_code on approval - it persists position but is NOT subject to
- * the door interlock, so the confirm page says so and the operator supervises.
+ * the machine interpreter returns to Z top at the job's finish position on
+ * completion - XY holds, Z does not; operator-clarified 2026-09-02). 'direct'
+ * executes over execute_code on approval - it persists position but is NOT
+ * subject to the door interlock, so the confirm page says so and the operator
+ * supervises.
  * 'procedure' is a server-driven measurement routine (e.g. the tool setter):
  * the operator approves a motion ENVELOPE and the runner steps within it
  * against live sensor feedback - also on the direct path, not interlocked.
@@ -51,6 +53,8 @@ export interface McpJob {
     approvedAt: number | null;
     tokenUsed: boolean;
     startedAt: number | null;
+    // Set when the job reaches a terminal state (completed / stopped).
+    endedAt: number | null;
     error: string | null;
     // Batch direct jobs: the operator approved this exact list; each
     // start_gcode_job call executes ONE step, so captures can happen between
@@ -109,6 +113,7 @@ export class JobManager {
             approvedAt: null,
             tokenUsed: false,
             startedAt: null,
+            endedAt: null,
             error: null,
             steps,
             nextStep: steps ? 0 : undefined,
@@ -158,6 +163,7 @@ export class JobManager {
             createdAt: job.createdAt,
             approvedAt: job.approvedAt,
             startedAt: job.startedAt,
+            endedAt: job.endedAt,
             error: job.error,
             totalSteps: job.steps ? job.steps.length : undefined,
             nextStep: job.steps ? job.nextStep : undefined,

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -2,8 +2,9 @@
 // MCP tool arguments are snake_case by convention.
 import * as fs from 'fs-extra';
 
+import logger from '../../../lib/logger';
 import { connectionManager } from '../../machine/ConnectionManager';
-import { jobManager } from '../jobs';
+import { McpJob, jobManager } from '../jobs';
 import { probeFeedService } from '../probeFeed';
 import { McpToolError, ToolRegistry } from '../registry';
 import { validateGcode } from '../validator';
@@ -103,6 +104,69 @@ function parseZTarget(gcode: string): { frame: 'work' | 'machine'; z: number } |
 function machineStatus(): string | null {
     const state = connectionManager.getLatestMachineState();
     return state ? ((state as { status?: string }).status || null) : null;
+}
+
+const log = logger('service:mcp:gcode-jobs');
+
+// File jobs run on the machine's own interpreter, which reports progress only
+// through the heartbeat - nothing calls back when the job ends, so a started
+// file job previously stayed "started" forever (observed 2026-09-02, job
+// b3f4ef467a93: a 10s job, heartbeat back to idle, state never moved). Watch
+// the heartbeat: once the job has been seen active, a debounced return to
+// idle is completion. A job too short to ever show as active is completed
+// after the heartbeat holds idle for a longer fallback window.
+const FILE_JOB_POLL_MS = 1000;
+const FILE_JOB_IDLE_DEBOUNCE_POLLS = 3;
+const FILE_JOB_NEVER_SEEN_ACTIVE_IDLE_POLLS = 20;
+const FILE_JOB_UNREADABLE_POLLS_GIVE_UP = 120;
+const FILE_JOB_ACTIVE_STATUSES = ['running', 'paused', 'pausing', 'stopping', 'resuming'];
+
+function watchFileJobCompletion(job: McpJob): void {
+    let sawActive = false;
+    let idleStreak = 0;
+    let unreadableStreak = 0;
+    const timer = setInterval(() => {
+        if (job.state !== 'started') {
+            // Stopped (or otherwise finalised) through another path.
+            clearInterval(timer);
+            return;
+        }
+        const status = machineStatus();
+        if (status === null) {
+            unreadableStreak += 1;
+            idleStreak = 0;
+            if (unreadableStreak >= FILE_JOB_UNREADABLE_POLLS_GIVE_UP) {
+                clearInterval(timer);
+                job.error = 'Completion unverified: machine state became unreadable after the job '
+                    + 'started (connection lost?). The job may still be running on the machine.';
+                log.warn(`MCP file job ${job.id}: ${job.error}`);
+            }
+            return;
+        }
+        unreadableStreak = 0;
+        if (FILE_JOB_ACTIVE_STATUSES.includes(status)) {
+            sawActive = true;
+            idleStreak = 0;
+            return;
+        }
+        if (status === 'idle') {
+            idleStreak += 1;
+            const needed = sawActive ? FILE_JOB_IDLE_DEBOUNCE_POLLS : FILE_JOB_NEVER_SEEN_ACTIVE_IDLE_POLLS;
+            if (idleStreak >= needed) {
+                clearInterval(timer);
+                job.state = 'completed';
+                job.endedAt = Date.now();
+                log.info(`MCP file job ${job.id} completed: heartbeat idle for ${idleStreak}s`
+                    + `${sawActive ? '' : ' (job too short for an active heartbeat to be observed)'}`);
+            }
+            return;
+        }
+        // Unknown status string: treat as activity of some kind, keep waiting.
+        idleStreak = 0;
+    }, FILE_JOB_POLL_MS);
+    if (typeof timer.unref === 'function') {
+        timer.unref();
+    }
 }
 
 export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: () => string): void {
@@ -220,6 +284,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 try {
                     const outcome = await job.runner();
                     job.state = 'completed';
+                    job.endedAt = Date.now();
                     return {
                         job: jobManager.describe(job),
                         result: outcome,
@@ -233,8 +298,9 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
 
             if (job.kind === 'direct') {
                 // Direct moves execute over the realtime path so position
-                // PERSISTS - the firmware parks back at the work origin when
-                // a file job completes, so a file job cannot hold a Z. The
+                // PERSISTS - the machine interpreter raises Z to top at the
+                // finish position when a file job completes, so a file job
+                // cannot hold a working Z (XY holds). The
                 // operator approved exactly this gcode on the confirm page.
                 // For a batch, each call executes ONE approved step; the
                 // token stays valid for the remaining steps (within its TTL).
@@ -281,6 +347,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                     }
                 }
                 job.state = 'completed';
+                job.endedAt = Date.now();
                 return {
                     job: jobManager.describe(job),
                     position: settle.position,
@@ -311,10 +378,12 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
 
             job.state = 'started';
             job.startedAt = Date.now();
+            watchFileJobCompletion(job);
             return {
                 job: jobManager.describe(job),
                 note: 'Job started. Poll get_gcode_job_status; the controller, its door interlock '
-                    + 'and the machine UI remain in control.',
+                    + 'and the machine UI remain in control. The job is marked completed when the '
+                    + 'heartbeat settles back to idle.',
             };
         },
     });
@@ -322,7 +391,8 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
     registry.register({
         name: 'move_z',
         description: 'Request absolute Z motion, executed on the direct path so positions PERSIST '
-            + '(file jobs park back at the work origin when they complete - firmware behaviour). '
+            + '(the machine interpreter raises Z to top at the finish position when a file job '
+            + 'completes, so a file job cannot hold a working Z - firmware behaviour). '
             + 'Either one target (z) or an ordered list (z_targets, max 20) for a methodical search: '
             + 'the operator approves the EXACT list once, and each start_gcode_job call then executes '
             + 'one step, so you can capture between steps and abandon the series at any point. The '
@@ -494,6 +564,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             const stopped = await channel.stopGcodeJob();
             if (stopped.ok) {
                 job.state = 'stopped';
+                job.endedAt = Date.now();
             }
             return {
                 ok: stopped.ok,


### PR DESCRIPTION
File-kind gcode jobs started via `start_gcode_job` stayed `started` forever — nothing watched the machine after start. Observed live 2026-09-02 (job `b3f4ef467a93`): a 10-second home+traverse finished on the machine (heartbeat running→idle, position verified at target), while `get_gcode_job_status` reported `started` indefinitely.

**Fix**
- `watchFileJobCompletion` is armed when a file job starts: heartbeat polled at 1 s. Once the job has been seen active (`running`/`paused`/…), 3 consecutive idle polls mark it `completed`; a job too short to ever observe active completes after 20 consecutive idle polls. If machine state is unreadable for 2 minutes it gives up, leaves the state untouched, and records `completion unverified` in `job.error` — never guesses. Bails instantly if another path finalises the job (e.g. `stop_gcode_job`); the timer is unref'd.
- Jobs carry `endedAt` (set on completed/stopped across all three kinds), exposed via `describe()`.

**Doc corrections (operator-clarified on hardware)**
- End-of-job behaviour: the machine interpreter returns to **Z top at the job's finish position** — XY holds. The earlier "parks at the work origin" reading was an artifact of Z top equalling this setup's work-origin Z (328). The distinction that matters: machine-interpreter (file) jobs get the door-detector e-stop; MCP direct ops do not.
- Motion laws: **no inferred approvals** (a motion named in passing — "before homing", an approved plan — is context, not a command) and **chat is not a motion gate** (a chat "go" only permits staging; authorization is the one-time code against the literal gcode). Both born from real incidents this session.

Stacked on #67 (`mcp/33-interface-respect`). Zero new dependencies; build gated on `Finished 'production'", zero errored, fix string verified in dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)