### PR TITLE
Feat: probe_vector + probe_circle, and the law-2 hardening they forced

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -23,12 +23,17 @@ height drove the probe into the rotary stock and destroyed it.
    "then we'll traverse", an approved plan that lists it — is context, not
    a command: announce the next motion and WAIT for the word (violated
    2026-09-02: homed off the back of "before homing").
-2. **X/Y traverses happen at top gantry height.** Retreat Z (operator-
-   confirmed `move_z`) to the safe traverse height FIRST, traverse, then
-   descend at the destination. Enforced: direct XY moves below
-   `mcpSafeTraverseZ` (default 320) are refused without
-   `operator_confirmed_clearance` — which only the operator's explicit words
-   authorise.
+2. **X/Y traverses happen at top gantry height — ALL of them.** Any XY move
+   over 1 mm is planned at the safe traverse height, with no exceptions: not
+   between probe points, not "local hops" above a measured feature top, not
+   at any other "measured safe" height (operator, 2026-09-02: "x/y motion
+   over 1mm is never below gantry height"). Retreat Z FIRST, traverse, then
+   descend at the destination. The only sub-gantry XY motion is fine
+   positioning of <= 1 mm (touch-test nudges, probe march steps). Enforced:
+   direct XY moves below `mcpSafeTraverseZ` (default 320) are refused
+   without `operator_confirmed_clearance` — which only the operator's
+   explicit words authorise, and which is for emergencies, not for planning
+   around this law.
 3. **Never fabricate clearance.** Only measured numbers or operator-stated
    numbers count for heights. Visual inference from survey frames is for
    FINDING things, not for clearing them — the crash analysis misread the
@@ -82,6 +87,19 @@ tip-radius before the tip centre — correct for it.
 Feed latency (hardware-measured, Adafruit IO): trigger message ~120–150 ms
 after physical contact; 200 ms contact windows are right. Release messages
 lag ~1 s — release checks are patient by design; never shorten them.
+
+## Circle probing
+
+`probe_circle` measures a roughly-round vertical feature (post, boss, pin):
+N radial marches from evenly spaced azimuths, one staged envelope, then a
+least-squares circle fit. It REQUIRES the operator's min/max diameter
+estimates (marches start beyond max/2 and abort at min/2 without contact)
+and a MEASURED top height. Physics: every contact adds the tip's effective
+radius, so the fit yields the COMBINED diameter — feature and tip are
+inseparable unless one is known. Direction-dependent residuals expose an
+out-of-round tip (the post-unbending health check). Repositioning between
+points obeys law 2 in full: lift to the safe traverse height, hop, descend;
+a probe touch during a hop or descent latches the CRASH alarm.
 
 ## Bed survey
 

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -83,9 +83,13 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
    run one at a time. Only an explicit imperative in the operator's latest message
    authorizes a motion; a motion mentioned in passing ("before homing", "then we'll…",
    a previously approved plan) is context, not a command — announce and wait.
-2. **X/Y traverses at top gantry height** — direct XY moves below `mcpSafeTraverseZ`
-   (default 320) are refused without `operator_confirmed_clearance`. Retreat, traverse,
-   descend — in that order.
+2. **X/Y traverses at top gantry height — ALL of them** (operator, 2026-09-02: "x/y motion
+   over 1mm is never below gantry height"). Any XY move over 1 mm is planned at the safe
+   traverse height — no local hops above a measured feature, no other "measured safe"
+   heights. Retreat, traverse, descend — in that order. Sub-gantry XY is only fine
+   positioning <= 1 mm (touch nudges, probe march steps). Enforced: direct XY below
+   `mcpSafeTraverseZ` (default 320) refused without `operator_confirmed_clearance`, which
+   is for emergencies on the operator's explicit words, not a planning device.
 3. **No fabricated clearances** — only measured or operator-stated heights count. Visual
    inference finds things; it never clears them.
 4. **Landmarks are obstacles** — `clearance_z` on a landmark refuses XY paths crossing its
@@ -146,7 +150,10 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
   homing = `G53;G28;G54` exactly like Luban's button
   (a bare G28 leaves reporting in an unselected workspace → impossible derived coords like
   Y 464/Z 656). Homing takes ~15–20 s and **also homes B — stock on the rotary rotates**.
-- **Work origins are operator-set per workspace and persist across homing.**
+- **Work origins are operator-set per workspace and persist across homing — but NOT across
+  machine reboots** (operator, 2026-09-02): a rebooted machine gets a new work origin, so
+  never assume it carries over between sessions; re-verify `originOffset` after every
+  (re)connect before trusting work coordinates.
 - **The machine interpreter returns to Z top at the job's finish position when a file job
   COMPLETES** (operator-clarified 2026-09-02; supersedes the earlier "parks at the work
   origin" reading — Z top and this setup's work-origin Z are both 328, which hid the

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -132,7 +132,15 @@ export class JobManager {
      * Verify a human-supplied confirm token for a job. Single-use, expiring.
      */
     public consumeToken(job: McpJob, token: string): { ok: boolean; reason?: string } {
-        if (job.state !== 'approved' || !job.confirmToken) {
+        // A batch direct job mid-series reads 'started' with steps remaining
+        // and its token re-armed; the operator's one approval covers the
+        // exact list, so the same code keeps working (bug found live
+        // 2026-09-02: step 2 of a 9-step ladder was refused).
+        const batchMidSeries = job.state === 'started'
+            && Array.isArray(job.steps)
+            && (job.nextStep || 0) < job.steps.length
+            && !job.tokenUsed;
+        if ((job.state !== 'approved' && !batchMidSeries) || !job.confirmToken) {
             return { ok: false, reason: `Job is ${job.state}, not approved.` };
         }
         if (job.tokenUsed) {
@@ -204,6 +212,15 @@ export class JobManager {
         const action = match[3];
 
         if (req.method === 'GET' && !action) {
+            // Revisiting an approved job re-shows its code while it is still
+            // valid (unused, unexpired) - losing the tab must not dead-end
+            // the approval (operator request 2026-09-02). MCP still never
+            // sees the code; this is the loopback browser only.
+            if (job.state === 'approved' && job.confirmToken && !job.tokenUsed
+                && Date.now() - (job.approvedAt || 0) <= CONFIRM_TOKEN_TTL_MS) {
+                this.page(res, 200, this.approvedPage(job));
+                return;
+            }
             this.page(res, 200, this.reviewPage(job));
             return;
         }
@@ -216,21 +233,7 @@ export class JobManager {
             job.approvedAt = Date.now();
             job.state = 'approved';
             log.info(`MCP job ${job.id} approved by operator`);
-            // The gcode is shown AGAIN next to the code (operator request
-            // after the 2026-09-01 probe crash): the last thing seen before
-            // handing over the code is exactly what the code will run.
-            const approvedGcode = fs.readFileSync(job.filePath, 'utf8');
-            const approvedLines = approvedGcode.split(/\r?\n/);
-            const approvedPreview = approvedLines.length > 80
-                ? [...approvedLines.slice(0, 40), `... ${approvedLines.length - 80} lines elided ...`, ...approvedLines.slice(-40)].join('\n')
-                : approvedGcode;
-            this.page(res, 200, `
-                <h2>Approved</h2>
-                <p>Give this one-time code to the agent to start <strong>${escapeHtml(job.name)}</strong>:</p>
-                <p style="font-size:2em;font-family:monospace;letter-spacing:0.2em">${job.confirmToken}</p>
-                <p>It expires in 15 minutes and works once.</p>
-                <h3>This code will run exactly:</h3>
-                <pre style="background:#f6f6f6;padding:12px;overflow:auto;max-height:300px">${escapeHtml(approvedPreview)}</pre>`);
+            this.page(res, 200, this.approvedPage(job));
             return;
         }
         if (req.method === 'POST' && action === 'reject') {
@@ -242,6 +245,28 @@ export class JobManager {
         }
         res.writeHead(405, { Allow: 'GET, POST' });
         res.end();
+    }
+
+    /**
+     * The gcode is shown AGAIN next to the code (operator request after the
+     * 2026-09-01 probe crash): the last thing seen before handing over the
+     * code is exactly what the code will run. Re-rendered on GET while the
+     * code is still valid, so a lost tab does not dead-end the approval.
+     */
+    private approvedPage(job: McpJob): string {
+        const approvedGcode = fs.readFileSync(job.filePath, 'utf8');
+        const approvedLines = approvedGcode.split(/\r?\n/);
+        const approvedPreview = approvedLines.length > 80
+            ? [...approvedLines.slice(0, 40), `... ${approvedLines.length - 80} lines elided ...`, ...approvedLines.slice(-40)].join('\n')
+            : approvedGcode;
+        return `
+            <h2>Approved</h2>
+            <p>Give this one-time code to the agent to start <strong>${escapeHtml(job.name)}</strong>:</p>
+            <p style="font-size:2em;font-family:monospace;letter-spacing:0.2em">${job.confirmToken}</p>
+            <p>It expires 15 minutes after approval and works once
+               (a batch of moves: once per approved step).</p>
+            <h3>This code will run exactly:</h3>
+            <pre style="background:#f6f6f6;padding:12px;overflow:auto;max-height:300px">${escapeHtml(approvedPreview)}</pre>`;
     }
 
     private reviewPage(job: McpJob): string {

--- a/src/server/services/mcp/probeCircle.ts
+++ b/src/server/services/mcp/probeCircle.ts
@@ -1,0 +1,453 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention (planProbeCircle takes the
+// probe_circle arguments verbatim).
+import { mcpBroadcast } from './index';
+import { probeFeedService } from './probeFeed';
+import {
+    COARSE_FEED,
+    FINE_FEED,
+    MAX_RETREAT_MM,
+    ProcedureAbort,
+    TRAVEL_FEED,
+    assertChannelReady,
+    assertMachineReadyForProcedure,
+    moveMachineSettled,
+    senseAfter,
+    senseReleaseAfter,
+} from './probing';
+import { McpToolError } from './registry';
+import { getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './tools/machine';
+import { connectionManager } from '../machine/ConnectionManager';
+
+// Circle probing: N sensor-gated radial marches around a roughly-round
+// vertical feature (a post, a boss, a pin), then a least-squares circle fit.
+// Physics note the result carries: every contact adds the probe tip's
+// effective radius, so the fit yields the COMBINED diameter
+// (feature + tip) - they cannot be separated without one being known.
+// The operator's min/max diameter estimates bound every march: approaches
+// start beyond max/2 and abort at min/2 without contact instead of
+// pressing on into a wrong guess.
+//
+// Safety inherits the probe_point mechanics (hardware-proven), plus: the
+// probe channel is EXPECTED contact only while marching/confirming - during
+// repositioning hops and descents it is not, so a graze there latches the
+// CRASH alarm instead of being absorbed. Repositioning between points obeys
+// motion law 2 in full (operator, 2026-09-02: "x/y motion over 1mm is never
+// below gantry height"): every hop lifts to the safe traverse height,
+// traverses, then descends - no local hop heights above the feature.
+
+export interface ProbeCirclePoint {
+    azimuthDeg: number;
+    startXY: { x: number; y: number };
+}
+
+export interface ProbeCirclePlan {
+    center: { x: number; y: number }; // operator estimate, machine coords
+    diameterMinMm: number;
+    diameterMaxMm: number;
+    topZMachine: number; // toolhead machine Z with the tip at the feature top
+    probeZ: number; // side-contact toolhead Z
+    hopZ: number; // repositioning toolhead Z: the safe traverse height (law 2)
+    startRadiusMm: number;
+    floorRadiusMm: number;
+    points: ProbeCirclePoint[];
+    coarseStepMm: number;
+    fineStepMm: number;
+    backoffMm: number;
+    sensorDelayMs: number;
+    confirmPasses: number;
+    staged: { x: number; y: number; z: number }; // position at staging
+}
+
+export function planProbeCircle(args: {
+    center_x?: number;
+    center_y?: number;
+    diameter_min_mm?: number;
+    diameter_max_mm?: number;
+    top_z_machine?: number;
+    probe_depth_mm?: number;
+    points?: number;
+    approach_clearance_mm?: number;
+    coarse_step_mm?: number;
+    fine_step_mm?: number;
+    backoff_mm?: number;
+    sensor_delay_ms?: number;
+    confirm_passes?: number;
+}): ProbeCirclePlan {
+    const centerX = Number(args.center_x);
+    const centerY = Number(args.center_y);
+    if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) {
+        throw new McpToolError('center_x and center_y (machine coords, operator estimate) are required.');
+    }
+    const dMin = Number(args.diameter_min_mm);
+    const dMax = Number(args.diameter_max_mm);
+    if (!Number.isFinite(dMin) || !Number.isFinite(dMax) || dMin <= 0 || dMax < dMin || dMax > 100) {
+        throw new McpToolError('diameter_min_mm and diameter_max_mm are required: the operator\'s bounds '
+            + 'on the feature diameter (0 < min <= max <= 100). They bound every march - no contact by '
+            + 'the min-diameter radius aborts instead of pressing on.');
+    }
+    const topZ = Number(args.top_z_machine);
+    if (!Number.isFinite(topZ) || topZ <= 0 || topZ > 400) {
+        throw new McpToolError('top_z_machine is required: the toolhead machine Z at which the probe tip '
+            + 'touches the feature TOP - a measured or operator-stated number, never a guess.');
+    }
+    const probeDepth = Math.min(Math.max(Number(args.probe_depth_mm) || 3, 0.5), 20);
+    const pointCount = Math.min(Math.max(Math.round(Number(args.points) || 8), 4), 16);
+    const approach = Math.min(Math.max(Number(args.approach_clearance_mm) || 5, 1), 20);
+
+    const startRadius = dMax / 2 + approach;
+    const floorRadius = dMin / 2;
+    if (startRadius - floorRadius < 1) {
+        throw new McpToolError('Less than 1 mm between the approach start radius and the min-diameter '
+            + 'floor - widen approach_clearance_mm or the diameter bounds.');
+    }
+
+    const position = getPositionSnapshot();
+    const { x, y, z } = position.machine;
+    if (x === null || y === null || z === null) {
+        throw new McpToolError('Current machine position unknown; cannot anchor the envelope.');
+    }
+
+    const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+    const points: ProbeCirclePoint[] = [];
+    for (let i = 0; i < pointCount; i++) {
+        const azimuth = (360 / pointCount) * i;
+        const rad = (azimuth * Math.PI) / 180;
+        const sx = Number((centerX + startRadius * Math.cos(rad)).toFixed(3));
+        const sy = Number((centerY + startRadius * Math.sin(rad)).toFixed(3));
+        if (size && (sx < -25 || sx > size.x + 40 || sy < -25 || sy > size.y + 40)) {
+            throw new McpToolError(`Approach start for azimuth ${azimuth.toFixed(0)} deg `
+                + `(${sx}, ${sy}) falls outside the machine envelope.`);
+        }
+        points.push({ azimuthDeg: azimuth, startXY: { x: sx, y: sy } });
+    }
+
+    return {
+        center: { x: centerX, y: centerY },
+        diameterMinMm: dMin,
+        diameterMaxMm: dMax,
+        topZMachine: topZ,
+        probeZ: Number((topZ - probeDepth).toFixed(3)),
+        hopZ: safeTraverseZ(),
+        startRadiusMm: Number(startRadius.toFixed(3)),
+        floorRadiusMm: Number(floorRadius.toFixed(3)),
+        points,
+        coarseStepMm: Math.min(Math.max(Number(args.coarse_step_mm) || 0.5, 0.2), 2),
+        fineStepMm: Math.min(Math.max(Number(args.fine_step_mm) || 0.1, 0.02), 0.5),
+        backoffMm: Math.min(Math.max(Number(args.backoff_mm) || 0.5, Number(args.fine_step_mm) || 0.1), 3),
+        sensorDelayMs: Math.min(Math.max(Number(args.sensor_delay_ms) || 200, 100), 10000),
+        confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 2), 1), 5),
+        staged: { x, y, z },
+    };
+}
+
+/** Confirm-page gcode: every commanded move of the whole star, enumerated. */
+export function describeProbeCirclePlanAsGcode(plan: ProbeCirclePlan): string {
+    const lines = [
+        `; TOUCH PROBE CIRCLE MEASUREMENT: ${plan.points.length} radial marches around `
+            + `estimated centre (${plan.center.x}, ${plan.center.y})`,
+        `; operator diameter bounds ${plan.diameterMinMm}..${plan.diameterMaxMm} mm; approaches start at `
+            + `radius ${plan.startRadiusMm} and ABORT at radius ${plan.floorRadiusMm} without contact`,
+        `; feature top measured at toolhead Z ${plan.topZMachine}; side contacts at Z ${plan.probeZ}; `
+            + `hops between points at the safe traverse height Z ${plan.hopZ} (motion law 2)`,
+        '; EVERY LINE IS SENT INDIVIDUALLY and settle-verified; the probe feed is checked after each',
+        '; march step. A probe touch during a hop or descent latches the CRASH alarm.',
+        '; overtravel feed trips -> job stop + connection close + latched alarm',
+        'G90',
+        'G53;',
+    ];
+    for (const point of plan.points) {
+        const rad = (point.azimuthDeg * Math.PI) / 180;
+        lines.push(`; --- point at azimuth ${point.azimuthDeg.toFixed(1)} deg ---`);
+        lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; lift to safe traverse height`);
+        lines.push(`G1 X${point.startXY.x.toFixed(3)} Y${point.startXY.y.toFixed(3)} F${TRAVEL_FEED}; approach start`);
+        lines.push(`G1 Z${plan.probeZ.toFixed(3)} F${TRAVEL_FEED}; descend to probing depth`);
+        let r = plan.startRadiusMm;
+        let step = 0;
+        while (r - plan.floorRadiusMm > 1e-9) {
+            r = Math.max(r - plan.coarseStepMm, plan.floorRadiusMm);
+            step += 1;
+            const px = plan.center.x + r * Math.cos(rad);
+            const py = plan.center.y + r * Math.sin(rad);
+            lines.push(`G1 X${px.toFixed(3)} Y${py.toFixed(3)} F${COARSE_FEED}; coarse step ${step} `
+                + `(radius ${r.toFixed(3)}) - settle, check probe, stop at contact`);
+        }
+        lines.push(`; ...on contact: retreat ${plan.coarseStepMm} mm radially until released, fine approach `
+            + `in ${plan.fineStepMm} mm steps, ${plan.confirmPasses} confirm cycle(s) (lift ${plan.backoffMm} mm)`);
+        lines.push(`G1 X${point.startXY.x.toFixed(3)} Y${point.startXY.y.toFixed(3)} F${TRAVEL_FEED}; retreat to approach start`);
+    }
+    lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; final lift to hop height`);
+    lines.push('G54;');
+    return lines.join('\n');
+}
+
+/** Kasa least-squares circle fit; returns centre, radius and residuals. */
+function fitCircle(contacts: { x: number; y: number }[]): {
+    center: { x: number; y: number };
+    radius: number;
+    residuals: number[];
+    rmsResidual: number;
+    maxResidual: number;
+} {
+    // Linear system: x^2 + y^2 = 2ax + 2by + c, solved by normal equations.
+    let sxx = 0; let sxy = 0; let syy = 0; let sx = 0; let sy = 0;
+    let sxz = 0; let syz = 0; let sz = 0;
+    const n = contacts.length;
+    for (const p of contacts) {
+        const zz = p.x * p.x + p.y * p.y;
+        sxx += p.x * p.x; sxy += p.x * p.y; syy += p.y * p.y;
+        sx += p.x; sy += p.y;
+        sxz += p.x * zz; syz += p.y * zz; sz += zz;
+    }
+    // Solve [2sxx 2sxy sx; 2sxy 2syy sy; 2sx 2sy n] * [a b c]' = [sxz syz sz]'
+    const m = [
+        [2 * sxx, 2 * sxy, sx, sxz],
+        [2 * sxy, 2 * syy, sy, syz],
+        [2 * sx, 2 * sy, n, sz],
+    ];
+    for (let col = 0; col < 3; col++) {
+        let pivot = col;
+        for (let row = col + 1; row < 3; row++) {
+            if (Math.abs(m[row][col]) > Math.abs(m[pivot][col])) {
+                pivot = row;
+            }
+        }
+        [m[col], m[pivot]] = [m[pivot], m[col]];
+        if (Math.abs(m[col][col]) < 1e-12) {
+            throw new ProcedureAbort('Circle fit is degenerate (contacts nearly collinear).');
+        }
+        for (let row = 0; row < 3; row++) {
+            if (row === col) {
+                continue;
+            }
+            const factor = m[row][col] / m[col][col];
+            for (let k = col; k < 4; k++) {
+                m[row][k] -= factor * m[col][k];
+            }
+        }
+    }
+    const a = m[0][3] / m[0][0];
+    const b = m[1][3] / m[1][1];
+    const c = m[2][3] / m[2][2];
+    const radius = Math.sqrt(Math.max(c + a * a + b * b, 0));
+    const residuals = contacts.map((p) => Number((Math.hypot(p.x - a, p.y - b) - radius).toFixed(4)));
+    const rms = Math.sqrt(residuals.reduce((acc, r) => acc + r * r, 0) / n);
+    return {
+        center: { x: Number(a.toFixed(3)), y: Number(b.toFixed(3)) },
+        radius: Number(radius.toFixed(4)),
+        residuals,
+        rmsResidual: Number(rms.toFixed(4)),
+        maxResidual: Number(Math.max(...residuals.map((r) => Math.abs(r))).toFixed(4)),
+    };
+}
+
+export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<object> {
+    assertChannelReady('probe', 'circle probe');
+    assertMachineReadyForProcedure();
+
+    const position = getPositionSnapshot();
+    const here = position.machine;
+    if (here.x === null || here.y === null || here.z === null
+        || Math.abs(here.x - plan.staged.x) > 0.5
+        || Math.abs(here.y - plan.staged.y) > 0.5
+        || Math.abs(here.z - plan.staged.z) > 0.5) {
+        throw new McpToolError('The machine is not at the position this envelope was staged from '
+            + `(staged (${plan.staged.x}, ${plan.staged.y}, ${plan.staged.z}), now `
+            + `(${here.x}, ${here.y}, ${here.z})). Stage probe_circle again.`);
+    }
+    if (here.z < plan.hopZ - 0.5) {
+        throw new McpToolError(`Current machine Z ${here.z} is below the hop height ${plan.hopZ}; `
+            + 'position at or above it before staging.');
+    }
+
+    const phases: { phase: string; note?: string }[] = [];
+    const announce = (phase: string, note?: string) => {
+        phases.push({ phase, note });
+        mcpBroadcast('mcp:activity', { tool: 'probe_circle', phase, note });
+    };
+    const releaseTimeoutMs = Math.max(plan.sensorDelayMs * 4, 2500);
+    const contacts: { azimuthDeg: number; x: number; y: number; radius: number; passRadii: number[]; spreadMm: number }[] = [];
+
+    const radialXY = (azimuthRad: number, r: number) => ({
+        x: Number((plan.center.x + r * Math.cos(azimuthRad)).toFixed(3)),
+        y: Number((plan.center.y + r * Math.sin(azimuthRad)).toFixed(3)),
+    });
+
+    try {
+        for (const point of plan.points) {
+            const rad = (point.azimuthDeg * Math.PI) / 180;
+            const label = `az${point.azimuthDeg.toFixed(0)}`;
+
+            // Reposition: contact here is NOT expected - a graze latches CRASH.
+            probeFeedService.clearExpectedContact();
+            await moveMachineSettled(`circle:hop:${label}`, { z: plan.hopZ }, TRAVEL_FEED);
+            await moveMachineSettled(`circle:hop:${label}`, { ...point.startXY }, TRAVEL_FEED);
+            await moveMachineSettled(`circle:descend:${label}`, { z: plan.probeZ }, TRAVEL_FEED);
+            announce(`start-${label}`, `approach start (${point.startXY.x}, ${point.startXY.y}) Z${plan.probeZ}`);
+
+            // March radially inward; contact on the probe channel is expected.
+            probeFeedService.setExpectedContact(['probe']);
+            let r = plan.startRadiusMm;
+            let coarseContactR: number | null = null;
+            while (r - plan.floorRadiusMm > 1e-9) {
+                const stepStart = Date.now();
+                r = Math.max(r - plan.coarseStepMm, plan.floorRadiusMm);
+                await moveMachineSettled(`circle:coarse:${label}`, radialXY(rad, r), COARSE_FEED);
+                const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+                if (sensed.contact) {
+                    coarseContactR = r;
+                    announce(`coarse-contact-${label}`, `radius ${r.toFixed(3)}`);
+                    break;
+                }
+            }
+            if (coarseContactR === null) {
+                throw new ProcedureAbort(`No contact by the min-diameter radius ${plan.floorRadiusMm} at `
+                    + `azimuth ${point.azimuthDeg.toFixed(0)} deg - the centre estimate or diameter bounds `
+                    + 'are wrong, or the probe is not reporting.');
+            }
+
+            // Retreat radially until released.
+            let released = false;
+            while (r < plan.startRadiusMm - 1e-9 && r - coarseContactR < MAX_RETREAT_MM + 1e-9) {
+                const stepStart = Date.now();
+                r = Math.min(r + plan.coarseStepMm, plan.startRadiusMm);
+                await moveMachineSettled(`circle:release:${label}`, radialXY(rad, r), COARSE_FEED);
+                const sensed = await senseReleaseAfter('probe', stepStart, releaseTimeoutMs);
+                if (!sensed.contact) {
+                    released = true;
+                    break;
+                }
+            }
+            if (!released) {
+                throw new ProcedureAbort(`Probe still triggered ${MAX_RETREAT_MM} mm back from contact at `
+                    + `azimuth ${point.azimuthDeg.toFixed(0)} deg - stuck probe or feed fault.`);
+            }
+
+            // Fine approach.
+            let fineContactR: number | null = null;
+            while (r - plan.floorRadiusMm > 1e-9) {
+                const stepStart = Date.now();
+                r = Math.max(r - plan.fineStepMm, plan.floorRadiusMm);
+                await moveMachineSettled(`circle:fine:${label}`, radialXY(rad, r), FINE_FEED);
+                const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+                if (sensed.contact) {
+                    fineContactR = r;
+                    break;
+                }
+            }
+            if (fineContactR === null) {
+                throw new ProcedureAbort(`Fine approach lost the contact at azimuth ${point.azimuthDeg.toFixed(0)} deg.`);
+            }
+
+            // Confirm cycles on the radius; median wins.
+            const passRadii: number[] = [];
+            const cycleFloor = Math.max(fineContactR - 0.5, plan.floorRadiusMm);
+            let reference = fineContactR;
+            for (let pass = 1; pass <= plan.confirmPasses; pass++) {
+                const liftIssuedAt = Date.now();
+                r = Math.min(reference + plan.backoffMm, plan.startRadiusMm);
+                await moveMachineSettled(`circle:backoff:${label}`, radialXY(rad, r), FINE_FEED);
+                const liftSense = await senseReleaseAfter('probe', liftIssuedAt, releaseTimeoutMs);
+                if (liftSense.contact) {
+                    throw new ProcedureAbort(`Probe still triggered after backing off ${plan.backoffMm} mm at `
+                        + `azimuth ${point.azimuthDeg.toFixed(0)} deg - hysteresis exceeds the backoff.`);
+                }
+                let passContact: number | null = null;
+                while (r - cycleFloor > 1e-9) {
+                    const stepStart = Date.now();
+                    r = Math.max(r - plan.fineStepMm, cycleFloor);
+                    await moveMachineSettled(`circle:confirm:${label}`, radialXY(rad, r), FINE_FEED);
+                    const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+                    if (sensed.contact) {
+                        passContact = r;
+                        break;
+                    }
+                }
+                if (passContact === null) {
+                    throw new ProcedureAbort(`Confirm pass ${pass} lost the contact at azimuth `
+                        + `${point.azimuthDeg.toFixed(0)} deg.`);
+                }
+                passRadii.push(Number(passContact.toFixed(3)));
+                reference = passContact;
+            }
+            const sorted = [...passRadii].sort((a, b) => a - b);
+            const measuredR = sorted[Math.floor((sorted.length - 1) / 2)];
+            const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
+            const contactPoint = radialXY(rad, measuredR);
+            contacts.push({
+                azimuthDeg: point.azimuthDeg,
+                ...contactPoint,
+                radius: Number(measuredR.toFixed(3)),
+                passRadii,
+                spreadMm,
+            });
+            announce(`measured-${label}`, `radius ${measuredR.toFixed(3)} spread ${spreadMm}`);
+
+            // Retreat radially to the approach start (still expected-contact
+            // until physically clear).
+            await moveMachineSettled(`circle:retreat:${label}`, { ...point.startXY }, TRAVEL_FEED);
+        }
+
+        // Final lift; reposition rules apply again.
+        probeFeedService.clearExpectedContact();
+        await moveMachineSettled('circle:final-lift', { z: plan.hopZ }, TRAVEL_FEED);
+        announce('final-lift', `Z${plan.hopZ}`);
+
+        const fit = fitCircle(contacts.map((c) => ({ x: c.x, y: c.y })));
+        const combinedDiameter = Number((fit.radius * 2).toFixed(3));
+        const tipMin = Number(Math.max(combinedDiameter - plan.diameterMaxMm, 0).toFixed(3));
+        const tipMax = Number(Math.max(combinedDiameter - plan.diameterMinMm, 0).toFixed(3));
+        const worstSpread = Math.max(...contacts.map((c) => c.spreadMm));
+        return {
+            contacts,
+            fit: {
+                center: fit.center,
+                combinedDiameterMm: combinedDiameter,
+                rmsResidualMm: fit.rmsResidual,
+                maxResidualMm: fit.maxResidual,
+                residualsMm: fit.residuals,
+            },
+            centerOffsetFromEstimate: {
+                x: Number((fit.center.x - plan.center.x).toFixed(3)),
+                y: Number((fit.center.y - plan.center.y).toFixed(3)),
+            },
+            tipEffectiveDiameterMm: { min: tipMin, max: tipMax },
+            phases,
+            note: `Fitted centre machine (${fit.center.x}, ${fit.center.y}), COMBINED diameter `
+                + `${combinedDiameter} mm (feature + probe tip - inseparable without one known: if the `
+                + `feature is truly ${plan.diameterMinMm}..${plan.diameterMaxMm} mm, the tip's effective `
+                + `diameter is ${tipMin}..${tipMax} mm). Fit residuals rms ${fit.rmsResidual} / max `
+                + `${fit.maxResidual} mm - direction-dependent residuals mean an out-of-round tip or `
+                + `feature. Worst per-point confirm spread ${worstSpread} mm.`,
+            warning: fit.maxResidual > 0.2
+                ? 'Max fit residual exceeds 0.2 mm: the feature or the probe tip is significantly '
+                    + 'out of round, or a contact was bad. Inspect residualsMm by azimuth.'
+                : undefined,
+        };
+    } catch (err) {
+        const isTrip = !!probeFeedService.getTrip();
+        if (!isTrip) {
+            try {
+                // Abort retreat: radially out to the current point's start
+                // radius is unknown here, so lift straight up to hopZ only if
+                // the probe reads released; a stuck-triggered probe means
+                // physical contact - leave the machine where it is.
+                const reading = probeFeedService.getReading('probe');
+                if (!reading || !reading.triggered) {
+                    await moveMachineSettled('circle:abort-lift', { z: plan.hopZ }, TRAVEL_FEED);
+                    announce('abort-lifted', `Z${plan.hopZ}`);
+                } else {
+                    announce('abort-held', 'probe still triggered - holding position for the operator');
+                }
+            } catch (retreatErr) {
+                // Logged by the activity stream.
+            }
+        }
+        if (err instanceof ProcedureAbort) {
+            throw new McpToolError(`Circle probe aborted: ${err.message} Phases completed: ${JSON.stringify(phases)}`);
+        }
+        throw err;
+    } finally {
+        probeFeedService.clearExpectedContact();
+    }
+}

--- a/src/server/services/mcp/probeTool.ts
+++ b/src/server/services/mcp/probeTool.ts
@@ -16,7 +16,7 @@ import {
     senseReleaseAfter,
 } from './probing';
 import { McpToolError } from './registry';
-import { getMachineSizeByIdentifier, getPositionSnapshot } from './tools/machine';
+import { getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './tools/machine';
 import { connectionManager } from '../machine/ConnectionManager';
 
 // Point probing with the spindle-mounted touch probe (normally-open, probe
@@ -131,8 +131,12 @@ export function describeProbePlanAsGcode(plan: ProbePointPlan): string {
         `; steps to contact, then ${plan.confirmPasses} quick confirm cycles (lift ${plan.backoffMm} mm, wait for release,`,
         `; re-approach). Result = median contact ${word} (spread reported).`,
         `G1 ${word}${plan.start[plan.axis].toFixed(3)} F${TRAVEL_FEED}; retreat to the start ${word} when done (also on any abort)`,
-        'G54;',
     );
+    const traverse = safeTraverseZ();
+    if (plan.start.z < traverse) {
+        lines.push(`G1 Z${traverse.toFixed(3)} F${TRAVEL_FEED}; finish at the safe traverse height (motion law 2)`);
+    }
+    lines.push('G54;');
     return lines.join('\n');
 }
 
@@ -277,9 +281,16 @@ export async function runProbePointProcedure(plan: ProbePointPlan): Promise<obje
         const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
         announce('measured', measured, `median of [${passContacts.join(', ')}], spread ${spreadMm} mm`);
 
-        // Retreat along the probed axis to the start coordinate.
+        // Retreat along the probed axis to the start coordinate, then finish
+        // at the safe traverse height (operator request 2026-09-02) so no
+        // separate staged lift is needed before the next reposition.
         await move('probe:retreat', startCoord, TRAVEL_FEED);
         announce('retreated', startCoord);
+        const traverse = safeTraverseZ();
+        if (plan.start.z < traverse) {
+            await moveMachineSettled('probe:raise', { z: traverse }, TRAVEL_FEED);
+            announce('raised', traverse, 'safe traverse height');
+        }
 
         const contactMachine = { ...plan.start, [plan.axis]: measured };
         const after = getPositionSnapshot();
@@ -306,6 +317,12 @@ export async function runProbePointProcedure(plan: ProbePointPlan): Promise<obje
             try {
                 await move('probe:abort-retreat', startCoord, TRAVEL_FEED);
                 announce('abort-retreated', startCoord);
+                const traverse = safeTraverseZ();
+                const reading = probeFeedService.getReading('probe');
+                if (plan.start.z < traverse && (!reading || !reading.triggered)) {
+                    await moveMachineSettled('probe:abort-raise', { z: traverse }, TRAVEL_FEED);
+                    announce('abort-raised', traverse, 'safe traverse height');
+                }
             } catch (retreatErr) {
                 // The abort itself already reports; retreat failure is logged
                 // by the activity stream.

--- a/src/server/services/mcp/probeVector.ts
+++ b/src/server/services/mcp/probeVector.ts
@@ -1,0 +1,367 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention (planProbeVector takes the
+// probe_vector arguments verbatim).
+import { mcpBroadcast } from './index';
+import { probeFeedService } from './probeFeed';
+import {
+    COARSE_FEED,
+    FINE_FEED,
+    MAX_RETREAT_MM,
+    ProcedureAbort,
+    TRAVEL_FEED,
+    assertChannelReady,
+    assertMachineReadyForProcedure,
+    moveMachineSettled,
+    senseAfter,
+    senseReleaseAfter,
+} from './probing';
+import { McpToolError } from './registry';
+import { getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './tools/machine';
+import { connectionManager } from '../machine/ConnectionManager';
+
+// Vector probing: a sensor-gated march from the CURRENT position along an
+// ARBITRARY direction (any XY heading, optionally angled downward - never
+// upward), with the same hardware-proven mechanics as probe_point: coarse
+// steps to contact, retreat to release, fine steps, lift-and-retest confirm
+// cycles, median + spread. probe_point is the axis-aligned special case;
+// this is the general primitive (operator-requested 2026-09-02) that
+// composes into edges, chamfers, polygons and inside-a-hole checks. The
+// march is parametrized by scalar distance along the unit vector, so every
+// commanded position lies on the approved segment.
+
+export interface ProbeVectorPlan {
+    unit: { x: number; y: number; z: number };
+    start: { x: number; y: number; z: number }; // machine coords at staging
+    maxTravelMm: number; // after envelope clamping
+    requestedTravelMm: number;
+    limit: { x: number; y: number; z: number };
+    coarseStepMm: number;
+    fineStepMm: number;
+    backoffMm: number;
+    sensorDelayMs: number;
+    confirmPasses: number;
+}
+
+export function planProbeVector(args: {
+    dx?: number;
+    dy?: number;
+    dz?: number;
+    max_travel_mm?: number;
+    coarse_step_mm?: number;
+    fine_step_mm?: number;
+    backoff_mm?: number;
+    sensor_delay_ms?: number;
+    confirm_passes?: number;
+}): ProbeVectorPlan {
+    const dx = Number(args.dx) || 0;
+    const dy = Number(args.dy) || 0;
+    const dz = Number(args.dz) || 0;
+    const norm = Math.hypot(dx, dy, dz);
+    if (!Number.isFinite(norm) || norm < 1e-9) {
+        throw new McpToolError('Direction vector required: at least one of dx, dy, dz non-zero. '
+            + 'Magnitude is ignored - only the direction matters.');
+    }
+    if (dz > 1e-9) {
+        throw new McpToolError('Upward probing (dz > 0) is refused - the probe cannot measure the gantry.');
+    }
+    const unit = { x: dx / norm, y: dy / norm, z: dz / norm };
+
+    const requested = Number(args.max_travel_mm);
+    if (!Number.isFinite(requested) || requested < 1 || requested > 150) {
+        throw new McpToolError('max_travel_mm is required: how far the probe may march before aborting (1-150).');
+    }
+
+    const position = getPositionSnapshot();
+    const { x, y, z } = position.machine;
+    if (x === null || y === null || z === null) {
+        throw new McpToolError('Current machine position unknown; cannot anchor the probe envelope.');
+    }
+    const start = { x, y, z };
+
+    // Clamp the travel SCALAR so the entire segment stays inside the same
+    // envelope the direct-move guards use (machine -25..size+40 for X/Y,
+    // Z never below 0) - clamping per-axis would change the direction.
+    let travel = requested;
+    const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+    const clampAxis = (u: number, from: number, lo: number, hi: number) => {
+        if (Math.abs(u) < 1e-9) {
+            return Infinity;
+        }
+        const bound = u > 0 ? hi : lo;
+        return (bound - from) / u;
+    };
+    if (size) {
+        travel = Math.min(travel, clampAxis(unit.x, start.x, -25, size.x + 40));
+        travel = Math.min(travel, clampAxis(unit.y, start.y, -25, size.y + 40));
+    }
+    travel = Math.min(travel, clampAxis(unit.z, start.z, 0, Infinity));
+    if (!Number.isFinite(travel) || travel < 0.5) {
+        throw new McpToolError('The clamped probe travel is under 0.5 mm - already at the envelope edge '
+            + 'along this direction.');
+    }
+    travel = Number(travel.toFixed(3));
+
+    return {
+        unit: {
+            x: Number(unit.x.toFixed(6)),
+            y: Number(unit.y.toFixed(6)),
+            z: Number(unit.z.toFixed(6)),
+        },
+        start,
+        maxTravelMm: travel,
+        requestedTravelMm: requested,
+        limit: {
+            x: Number((start.x + unit.x * travel).toFixed(3)),
+            y: Number((start.y + unit.y * travel).toFixed(3)),
+            z: Number((start.z + unit.z * travel).toFixed(3)),
+        },
+        coarseStepMm: Math.min(Math.max(Number(args.coarse_step_mm) || 1, 0.2), 2),
+        fineStepMm: Math.min(Math.max(Number(args.fine_step_mm) || 0.1, 0.02), 0.5),
+        backoffMm: Math.min(Math.max(Number(args.backoff_mm) || 0.5, Number(args.fine_step_mm) || 0.1), 3),
+        sensorDelayMs: Math.min(Math.max(Number(args.sensor_delay_ms) || 200, 100), 10000),
+        confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 3), 1), 10),
+    };
+}
+
+function pointAt(plan: ProbeVectorPlan, s: number): { x: number; y: number; z: number } {
+    return {
+        x: Number((plan.start.x + plan.unit.x * s).toFixed(3)),
+        y: Number((plan.start.y + plan.unit.y * s).toFixed(3)),
+        z: Number((plan.start.z + plan.unit.z * s).toFixed(3)),
+    };
+}
+
+/** Which axes the move actually needs - pure-XY vectors never command Z. */
+function moveWords(plan: ProbeVectorPlan, s: number): { x?: number; y?: number; z?: number } {
+    const p = pointAt(plan, s);
+    const words: { x?: number; y?: number; z?: number } = {};
+    if (Math.abs(plan.unit.x) > 1e-9) {
+        words.x = p.x;
+    }
+    if (Math.abs(plan.unit.y) > 1e-9) {
+        words.y = p.y;
+    }
+    if (Math.abs(plan.unit.z) > 1e-9) {
+        words.z = p.z;
+    }
+    return words;
+}
+
+/** Confirm-page gcode: every stepped command as it would execute. */
+export function describeProbeVectorPlanAsGcode(plan: ProbeVectorPlan): string {
+    const dir = `(${plan.unit.x}, ${plan.unit.y}, ${plan.unit.z})`;
+    const lines = [
+        '; TOUCH PROBE VECTOR MEASUREMENT (server-driven, sensor-gated on the probe channel)',
+        `; march along unit direction ${dir} from the staging position, max travel ${plan.maxTravelMm} mm`
+            + (plan.maxTravelMm < plan.requestedTravelMm
+                ? ` (requested ${plan.requestedTravelMm}, clamped to the machine envelope)` : ''),
+        '; EVERY LINE IS SENT INDIVIDUALLY: after each move settles, the probe feed is checked',
+        '; before the next line. The march stops at first contact; running the full ladder',
+        `; without contact ABORTS at (${plan.limit.x}, ${plan.limit.y}, ${plan.limit.z}).`,
+        `; anchored at machine (${plan.start.x.toFixed(2)}, ${plan.start.y.toFixed(2)}, ${plan.start.z.toFixed(2)})`
+            + ' - re-verified before any motion',
+        '; overtravel feed trips -> job stop + connection close + latched alarm',
+        'G90',
+        'G53;',
+    ];
+    let s = 0;
+    let step = 0;
+    while (plan.maxTravelMm - s > 1e-9) {
+        s = Math.min(s + plan.coarseStepMm, plan.maxTravelMm);
+        step += 1;
+        const w = moveWords(plan, s);
+        const wordText = [
+            w.x !== undefined ? `X${w.x.toFixed(3)}` : '',
+            w.y !== undefined ? `Y${w.y.toFixed(3)}` : '',
+            w.z !== undefined ? `Z${w.z.toFixed(3)}` : '',
+        ].filter(Boolean).join(' ');
+        lines.push(`G1 ${wordText} F${COARSE_FEED}; coarse step ${step} (${s.toFixed(3)} mm along) - settle, check probe, stop at contact`);
+    }
+    lines.push(
+        `; ...on contact: retreat ${plan.coarseStepMm} mm steps along the reverse vector until released,`,
+        `; approach in ${plan.fineStepMm} mm steps to contact, then ${plan.confirmPasses} quick confirm cycles`,
+        `; (lift ${plan.backoffMm} mm along the reverse vector, wait for release, re-approach).`,
+        '; Result = median contact distance -> machine XYZ (spread reported).',
+        `G1 X${plan.start.x.toFixed(3)} Y${plan.start.y.toFixed(3)} Z${plan.start.z.toFixed(3)} F${TRAVEL_FEED}; retreat to the start when done (also on any abort)`,
+    );
+    const traverse = safeTraverseZ();
+    if (plan.start.z < traverse) {
+        lines.push(`G1 Z${traverse.toFixed(3)} F${TRAVEL_FEED}; finish at the safe traverse height (motion law 2)`);
+    }
+    lines.push('G54;');
+    return lines.join('\n');
+}
+
+export async function runProbeVectorProcedure(plan: ProbeVectorPlan): Promise<object> {
+    assertChannelReady('probe', 'vector probe');
+    assertMachineReadyForProcedure();
+    probeFeedService.setExpectedContact(['probe']);
+
+    const position = getPositionSnapshot();
+    const here = position.machine;
+    if (here.x === null || here.y === null || here.z === null
+        || Math.abs(here.x - plan.start.x) > 0.5
+        || Math.abs(here.y - plan.start.y) > 0.5
+        || Math.abs(here.z - plan.start.z) > 0.5) {
+        throw new McpToolError('The machine is not at the position this probe envelope was staged from '
+            + `(staged (${plan.start.x}, ${plan.start.y}, ${plan.start.z}), now `
+            + `(${here.x}, ${here.y}, ${here.z})). Stage probe_vector again from the current position.`);
+    }
+
+    const phases: { phase: string; s: number; note?: string }[] = [];
+    const announce = (phase: string, s: number, note?: string) => {
+        phases.push({ phase, s: Number(s.toFixed(3)), note });
+        mcpBroadcast('mcp:activity', { tool: 'probe_vector', phase, s: Number(s.toFixed(3)), note });
+    };
+    const releaseTimeoutMs = Math.max(plan.sensorDelayMs * 4, 2500);
+    const move = async (tool: string, s: number, feed: number) => {
+        await moveMachineSettled(tool, moveWords(plan, s), feed);
+    };
+
+    let s = 0;
+    try {
+        // Coarse march to first contact.
+        let coarseContactS: number | null = null;
+        while (plan.maxTravelMm - s > 1e-9) {
+            const stepStart = Date.now();
+            s = Math.min(s + plan.coarseStepMm, plan.maxTravelMm);
+            await move('probe-vec:coarse', s, COARSE_FEED);
+            const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+            if (sensed.contact) {
+                coarseContactS = s;
+                announce('coarse-contact', s, `probe "${sensed.reading?.value}"`);
+                break;
+            }
+        }
+        if (coarseContactS === null) {
+            throw new ProcedureAbort(`Reached the travel limit ${plan.maxTravelMm.toFixed(3)} mm without `
+                + 'contact - nothing to probe within max_travel_mm, or the probe is not reporting.');
+        }
+
+        // Retreat until released.
+        let released = false;
+        while (s > 1e-9 && coarseContactS - s < MAX_RETREAT_MM + 1e-9) {
+            const stepStart = Date.now();
+            s = Math.max(s - plan.coarseStepMm, 0);
+            await move('probe-vec:release', s, COARSE_FEED);
+            const sensed = await senseReleaseAfter('probe', stepStart, releaseTimeoutMs);
+            if (!sensed.contact) {
+                released = true;
+                announce('released', s);
+                break;
+            }
+        }
+        if (!released) {
+            throw new ProcedureAbort(`Probe still reads triggered ${MAX_RETREAT_MM} mm back from first `
+                + 'contact - stuck probe or feed fault.');
+        }
+
+        // Fine approach.
+        let fineContactS: number | null = null;
+        while (plan.maxTravelMm - s > 1e-9) {
+            const stepStart = Date.now();
+            s = Math.min(s + plan.fineStepMm, plan.maxTravelMm);
+            await move('probe-vec:fine', s, FINE_FEED);
+            const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+            if (sensed.contact) {
+                fineContactS = s;
+                announce('fine-contact', s, `probe "${sensed.reading?.value}"`);
+                break;
+            }
+        }
+        if (fineContactS === null) {
+            throw new ProcedureAbort('Fine approach reached the travel limit without re-contact after a '
+                + 'coarse contact - inconsistent probe.');
+        }
+
+        // Quick lift-and-retest confirm cycles; median wins, spread reported.
+        const passContacts: number[] = [];
+        const cycleLimit = Math.min(fineContactS + 0.5, plan.maxTravelMm);
+        let reference = fineContactS;
+        for (let pass = 1; pass <= plan.confirmPasses; pass++) {
+            const liftIssuedAt = Date.now();
+            s = Math.max(reference - plan.backoffMm, 0);
+            await move('probe-vec:backoff', s, FINE_FEED);
+            const liftSense = await senseReleaseAfter('probe', liftIssuedAt, releaseTimeoutMs);
+            if (liftSense.contact) {
+                throw new ProcedureAbort(`Probe still triggered ${releaseTimeoutMs} ms after backing off `
+                    + `${plan.backoffMm} mm - hysteresis exceeds the backoff. Rerun with a larger backoff_mm.`);
+            }
+            let passContact: number | null = null;
+            while (cycleLimit - s > 1e-9) {
+                const stepStart = Date.now();
+                s = Math.min(s + plan.fineStepMm, cycleLimit);
+                await move('probe-vec:confirm', s, FINE_FEED);
+                const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
+                if (sensed.contact) {
+                    passContact = s;
+                    break;
+                }
+            }
+            if (passContact === null) {
+                throw new ProcedureAbort(`Confirm pass ${pass} went 0.5 mm past the first contact without `
+                    + 're-contact - inconsistent probe.');
+            }
+            passContacts.push(Number(passContact.toFixed(3)));
+            announce(`confirm-${pass}`, passContact, `of ${plan.confirmPasses}`);
+            reference = passContact;
+        }
+        const sorted = [...passContacts].sort((a, b) => a - b);
+        const measuredS = sorted[Math.floor((sorted.length - 1) / 2)];
+        const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
+        announce('measured', measuredS, `median of [${passContacts.join(', ')}], spread ${spreadMm} mm`);
+
+        // Retreat along the reverse vector to the start, then finish at
+        // the safe traverse height (operator request 2026-09-02).
+        await move('probe-vec:retreat', 0, TRAVEL_FEED);
+        announce('retreated', 0);
+        const traverse = safeTraverseZ();
+        if (plan.start.z < traverse) {
+            await moveMachineSettled('probe-vec:raise', { z: traverse }, TRAVEL_FEED);
+            announce('raised', 0, `safe traverse height Z${traverse}`);
+        }
+
+        const contactMachine = pointAt(plan, measuredS);
+        const after = getPositionSnapshot();
+        return {
+            direction: plan.unit,
+            contactDistanceMm: measuredS,
+            contactMachine,
+            contactWorkOffsetApplied: `work = machine + originOffset (${JSON.stringify(after.originOffset)})`,
+            confirmPassContacts: passContacts,
+            spreadMm,
+            phases,
+            note: `Probe contact ${measuredS.toFixed(3)} mm along (${plan.unit.x}, ${plan.unit.y}, `
+                + `${plan.unit.z}) from the start -> machine (${contactMachine.x}, ${contactMachine.y}, `
+                + `${contactMachine.z}) - median of ${plan.confirmPasses} passes [${passContacts.join(', ')}], `
+                + `spread ${spreadMm} mm (+/- ${plan.fineStepMm} mm step resolution, minus the probe tip `
+                + 'radius on lateral probes - the tip touches before its centre).',
+            warning: spreadMm > plan.fineStepMm + 1e-9
+                ? `Confirm passes spread ${spreadMm} mm exceeds one fine step - feed timing was unstable; `
+                    + 'consider more confirm_passes or a longer sensor_delay_ms.'
+                : undefined,
+        };
+    } catch (err) {
+        const isTrip = !!probeFeedService.getTrip();
+        if (!isTrip) {
+            try {
+                await move('probe-vec:abort-retreat', 0, TRAVEL_FEED);
+                announce('abort-retreated', 0);
+                const traverse = safeTraverseZ();
+                const reading = probeFeedService.getReading('probe');
+                if (plan.start.z < traverse && (!reading || !reading.triggered)) {
+                    await moveMachineSettled('probe-vec:abort-raise', { z: traverse }, TRAVEL_FEED);
+                    announce('abort-raised', 0, `safe traverse height Z${traverse}`);
+                }
+            } catch (retreatErr) {
+                // Logged by the activity stream.
+            }
+        }
+        if (err instanceof ProcedureAbort) {
+            throw new McpToolError(`Vector probe aborted: ${err.message} Phases completed: ${JSON.stringify(phases)}`);
+        }
+        throw err;
+    } finally {
+        probeFeedService.clearExpectedContact();
+    }
+}

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -311,7 +311,18 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 const gcodeText = isBatch
                     ? job.steps[job.nextStep]
                     : fs.readFileSync(job.filePath, 'utf8');
-                const executed = await sendGcodeVisible(channel as GcodeChannel, `direct:${job.name}`, gcodeText);
+                // The staged text carries a human-facing comment header for
+                // the confirm page; the realtime execute path must get pure
+                // commands - the controller never replied to a payload led by
+                // comment lines (hung live, 2026-09-02, job e34b19a913ff).
+                const executable = gcodeText
+                    .split(/\r?\n/)
+                    .filter((line) => {
+                        const trimmed = line.trim();
+                        return trimmed.length > 0 && !trimmed.startsWith(';');
+                    })
+                    .join('\n');
+                const executed = await sendGcodeVisible(channel as GcodeChannel, `direct:${job.name}`, executable);
                 if (executed.result !== 0) {
                     job.state = 'start_failed';
                     job.error = `Controller rejected the move: ${executed.text || executed.result}`;
@@ -327,7 +338,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                         warning: 'wait_until_moved was false: the move was accepted but not awaited - '
                             + 'poll get_position (or query_firmware_position) before relying on position.',
                     }
-                    : await waitForStableHeartbeat(issuedAt, parseZTarget(gcodeText));
+                    : await waitForStableHeartbeat(issuedAt, parseZTarget(executable));
                 if (isBatch) {
                     job.nextStep += 1;
                     if (job.nextStep < job.steps.length) {
@@ -485,8 +496,40 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 : `G90\nG1 Z${t.toFixed(3)} F${feedRate}`);
             const steps = targets.map(stepGcode);
             const isBatch = targets.length > 1;
-            const reviewText = steps.join('\n; --- next approved step ---\n');
             const delta = targetZ - currentZ;
+            // The gcode preview must let the operator validate the numbers
+            // without trusting chat: state the reason, the frame, where the
+            // machine is now and the delta of every step (operator request
+            // 2026-09-02). Sensors: no contact is expected during a Z move.
+            const wrapText = (text: string, width: number): string[] => {
+                const words = String(text).split(/\s+/);
+                const rows: string[] = [];
+                let row = '';
+                for (const word of words) {
+                    if (row && (row.length + word.length + 1) > width) {
+                        rows.push(row);
+                        row = word;
+                    } else {
+                        row = row ? `${row} ${word}` : word;
+                    }
+                }
+                if (row) {
+                    rows.push(row);
+                }
+                return rows;
+            };
+            const header = [
+                ...wrapText(`reason: ${args.reason}`, 90).map((row) => `; ${row}`),
+                `; frame: ${coordinateSystem} coords; current ${coordinateSystem} Z ${currentZ.toFixed(3)}`,
+                ...targets.map((t, i) => {
+                    const from = i === 0 ? currentZ : targets[i - 1];
+                    const d = t - from;
+                    return `; step ${i + 1}: Z ${from.toFixed(3)} -> ${t.toFixed(3)} (${d >= 0 ? '+' : ''}${d.toFixed(3)} mm) F${feedRate}`;
+                }),
+                '; sensors: NO contact expected during these moves - a probe/toolsetter trigger',
+                '; while moving latches the CRASH alarm (probe feed must be armed).',
+            ].join('\n');
+            const reviewText = `${header}\n${steps.join('\n; --- next approved step ---\n')}`;
             const name = isBatch
                 ? `z-series ${coordinateSystem} [${targets.map((t) => t.toFixed(1)).join(', ')}] - ${String(args.reason).slice(0, 40)}`
                 : `z-move ${coordinateSystem} Z${targetZ.toFixed(1)} (${delta >= 0 ? '+' : ''}${delta.toFixed(1)}mm) - ${String(args.reason).slice(0, 40)}`;

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -8,7 +8,9 @@ import DataStorage from '../../../DataStorage';
 import { connectionManager } from '../../machine/ConnectionManager';
 import { captureFrame } from '../camera';
 import { jobManager } from '../jobs';
+import { describeProbeCirclePlanAsGcode, planProbeCircle, runProbeCircleProcedure } from '../probeCircle';
 import { describeProbePlanAsGcode, planProbePoint, runProbePointProcedure } from '../probeTool';
+import { describeProbeVectorPlanAsGcode, planProbeVector, runProbeVectorProcedure } from '../probeVector';
 import { probeFeedService } from '../probeFeed';
 import { TRAVEL_FEED, assertMachineReadyForProcedure, moveMachineSettled } from '../probing';
 import { McpToolError, ToolRegistry } from '../registry';
@@ -56,7 +58,8 @@ export function registerProbingTools(registry: ToolRegistry, getConfirmBaseUrl: 
             }
             probeFeedService.assertNoOvertravel();
             const plan = planProbePoint(args as Parameters<typeof planProbePoint>[0]);
-            const envelope = describeProbePlanAsGcode(plan);
+            const envelope = `; reason: ${String(args.reason).trim()}
+${describeProbePlanAsGcode(plan)}`;
             const validation = validateGcode(envelope);
             const job = jobManager.submit(
                 envelope,
@@ -74,6 +77,144 @@ export function registerProbingTools(registry: ToolRegistry, getConfirmBaseUrl: 
                 next_step: 'Ask the operator to open confirm_url, review the envelope (anchored to the '
                     + 'current position), and approve. Their one-time code passed to start_gcode_job '
                     + 'runs the march and returns the contact coordinate.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'probe_vector',
+        description: 'Stage a touch-probe march along an ARBITRARY direction for human confirmation: '
+            + 'from the CURRENT position along the given (dx, dy, dz) heading - any XY direction, '
+            + 'optionally angled downward, never upward. Same staged mechanics as probe_point '
+            + '(coarse steps to contact, retreat to release, fine steps, lift-and-retest confirm '
+            + 'cycles); the march is parametrized along the unit vector so every commanded position '
+            + 'lies on the approved segment. Returns the median contact as machine XYZ plus the '
+            + 'distance along the vector. probe_point is the axis-aligned special case; use this '
+            + 'for angled edges, chamfers, polygon faces, and inside-a-hole checks. Position first '
+            + '(top-gantry traverse, operator-confirmed descent), then stage.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                dx: { type: 'number', description: 'Direction X component (machine frame). Magnitude ignored.' },
+                dy: { type: 'number', description: 'Direction Y component.' },
+                dz: { type: 'number', description: 'Direction Z component; must be <= 0 (downward or level).' },
+                max_travel_mm: {
+                    type: 'number',
+                    description: 'REQUIRED hard travel limit (1-150) along the vector: the march aborts '
+                        + 'there without contact. Clamped so the whole segment stays in the machine envelope.',
+                },
+                coarse_step_mm: { type: 'number', description: 'Coarse step, default 1 (0.2-2).' },
+                fine_step_mm: { type: 'number', description: 'Fine step, default 0.1 (0.02-0.5).' },
+                backoff_mm: { type: 'number', description: 'Confirm-cycle lift, default 0.5.' },
+                sensor_delay_ms: { type: 'number', description: 'Contact-check window per step, default 200.' },
+                confirm_passes: { type: 'number', description: 'Lift-and-retest cycles, default 3 (1-10).' },
+                reason: { type: 'string', description: 'Shown to the operator: what is being measured and why.' },
+            },
+            required: ['max_travel_mm', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            if (!String(args.reason || '').trim()) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            probeFeedService.assertNoOvertravel();
+            const plan = planProbeVector(args as Parameters<typeof planProbeVector>[0]);
+            const envelope = `; reason: ${String(args.reason).trim()}
+${describeProbeVectorPlanAsGcode(plan)}`;
+            const validation = validateGcode(envelope);
+            const job = jobManager.submit(
+                envelope,
+                `probe-vector (${plan.unit.x},${plan.unit.y},${plan.unit.z}) ${plan.maxTravelMm}mm `
+                    + `- ${String(args.reason).slice(0, 40)}`,
+                'cnc',
+                validation,
+                'procedure'
+            );
+            job.runner = async () => runProbeVectorProcedure(plan);
+            return {
+                job: jobManager.describe(job),
+                plan,
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url, review the envelope (anchored to the '
+                    + 'current position), and approve. Their one-time code passed to start_gcode_job '
+                    + 'runs the march and returns the contact coordinate.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'probe_circle',
+        description: 'Stage an N-point circle measurement of a roughly-round vertical feature (post, '
+            + 'boss, pin) for human confirmation: radial sensor-gated marches from evenly spaced '
+            + 'azimuths, then a least-squares circle fit. Requires the operator\'s MIN and MAX '
+            + 'diameter estimates - they bound every march (start beyond max/2, abort at min/2 '
+            + 'without contact) - and a MEASURED top height (top_z_machine). Yields the fitted '
+            + 'centre and the COMBINED diameter (feature + probe tip, inseparable without one '
+            + 'known), with residuals exposing an out-of-round tip or feature. Repositioning between '
+            + 'points obeys motion law 2: lift to the safe traverse height, hop, descend; a probe '
+            + 'touch during a hop or descent latches the CRASH alarm.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                center_x: { type: 'number', description: 'Estimated feature centre X, machine coords.' },
+                center_y: { type: 'number', description: 'Estimated feature centre Y, machine coords.' },
+                diameter_min_mm: {
+                    type: 'number',
+                    description: 'Operator\'s LOWER bound on the feature diameter: marches abort at this '
+                        + 'radius without contact instead of pressing on.',
+                },
+                diameter_max_mm: {
+                    type: 'number',
+                    description: 'Operator\'s UPPER bound on the feature diameter: approaches start '
+                        + 'approach_clearance_mm beyond this radius.',
+                },
+                top_z_machine: {
+                    type: 'number',
+                    description: 'Toolhead machine Z at which the probe tip touches the feature TOP - '
+                        + 'measured (probe_point -Z) or operator-stated, never guessed.',
+                },
+                probe_depth_mm: { type: 'number', description: 'Side contacts this far below the top, default 3 (0.5-20).' },
+                points: { type: 'number', description: 'Contact points around the circle, default 8 (4-16).' },
+                approach_clearance_mm: {
+                    type: 'number',
+                    description: 'Start-radius margin beyond max/2, default 5 (1-20). Must exceed the '
+                        + 'probe tip radius plus a safety margin.',
+                },
+                coarse_step_mm: { type: 'number', description: 'Coarse radial step, default 0.5 (0.2-2).' },
+                fine_step_mm: { type: 'number', description: 'Fine step, default 0.1 (0.02-0.5).' },
+                backoff_mm: { type: 'number', description: 'Confirm-cycle lift, default 0.5.' },
+                sensor_delay_ms: { type: 'number', description: 'Contact-check window per step, default 200.' },
+                confirm_passes: { type: 'number', description: 'Lift-and-retest cycles per point, default 2 (1-5).' },
+                reason: { type: 'string', description: 'Shown to the operator: what is being measured and why.' },
+            },
+            required: ['center_x', 'center_y', 'diameter_min_mm', 'diameter_max_mm', 'top_z_machine', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            if (!String(args.reason || '').trim()) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            probeFeedService.assertNoOvertravel();
+            const plan = planProbeCircle(args as Parameters<typeof planProbeCircle>[0]);
+            const envelope = `; reason: ${String(args.reason).trim()}
+${describeProbeCirclePlanAsGcode(plan)}`;
+            const validation = validateGcode(envelope);
+            const job = jobManager.submit(
+                envelope,
+                `probe-circle ${plan.points.length}pts d${plan.diameterMinMm}-${plan.diameterMaxMm} `
+                    + `- ${String(args.reason).slice(0, 40)}`,
+                'cnc',
+                validation,
+                'procedure'
+            );
+            job.runner = async () => runProbeCircleProcedure(plan);
+            return {
+                job: jobManager.describe(job),
+                plan,
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url, review the full envelope (all marches, '
+                    + 'hops and depths), and approve. Their one-time code passed to start_gcode_job runs '
+                    + 'the whole star and returns the circle fit.',
             };
         },
     });


### PR DESCRIPTION
Two new staged probing procedures, both **hardware-validated 2026-09-02** on the tool-setter air-blast post:

- **`probe_vector`** — sensor-gated march along an arbitrary direction (any XY heading, optionally angled downward, never upward), parametrized along the unit vector so every commanded position lies on the approved segment. `probe_point` is the axis-aligned special case; this composes into edges, chamfers, polygons and inside-a-hole checks. First run: S-side contact at Y 277.400, three passes identical.
- **`probe_circle`** — N radial marches around a round vertical feature, then a least-squares (Kasa) fit. Requires the operator's **min/max diameter estimates** (approaches start beyond max/2 and ABORT at min/2 without contact — never presses into a wrong guess) and a **measured** top height. Reports fitted centre, the COMBINED diameter (feature + tip, physically inseparable without one known), and per-azimuth residuals. First run: 8 points, fit centre agreed with the independent 4-side measurement within 0.05 mm, max residual 0.074 mm.

**Motion-law hardening** (live operator corrections): law 2 is absolute — all XY moves over 1 mm at top gantry height, no "local hop heights"; marches finish at the traverse height inside their approved envelope; `move_z` staged gcode self-documents (reason, frame, per-step deltas, sensor arrangement); probe envelopes carry their reason as a comment; and the direct execute path strips comments — the controller never replies to a payload led by `;` lines (found by a live hang).

**Job-flow fixes found live**: batch direct jobs can resume past step 1 (mid-series state is `started`, not `approved`); the confirm page re-shows a still-valid code on revisit so a lost tab no longer dead-ends an approval.

**Docs**: work origins do not survive machine reboots — re-verify `originOffset` every session.

Stacked on #68 (`mcp/34-file-job-completion`). Zero new dependencies; build gated on Finished 'production', zero errored, key strings verified in dist; every behavior above exercised against the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)