### PR TITLE
Fix: stale-heartbeat refusal, honest M114, probe_circle inside mode

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -62,6 +62,18 @@ height drove the probe into the rotary stock and destroyed it.
    backend, configstore, or machine directly while the app runs — the
    guards live in the tools.
 
+## Recording rules
+
+- **Machine coordinates only** (operator, 2026-09-02): datums, landmarks and
+  measurements are recorded in the machine frame. Work origins are volatile —
+  a machine reboot mints a new one — so saved work coordinates are meaningless
+  later. Re-verify `originOffset` after every (re)connect.
+- **Heartbeat freshness is a precondition**: a stale report (>10 s; period is
+  ~1 s) means the connection dropped without the server noticing (seen live —
+  5.7 min of stale state served as truth). Motion and staging refuse on
+  staleness; an M114 that returns no position text is a dead connection, not
+  a success.
+
 ## Probe calibration (do once per probe fitting)
 
 `run_tool_setter` with `accept_probe_contact: true` and a conservative

--- a/src/server/services/mcp/probeCircle.ts
+++ b/src/server/services/mcp/probeCircle.ts
@@ -19,22 +19,32 @@ import { McpToolError } from './registry';
 import { getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './tools/machine';
 import { connectionManager } from '../machine/ConnectionManager';
 
-// Circle probing: N sensor-gated radial marches around a roughly-round
-// vertical feature (a post, a boss, a pin), then a least-squares circle fit.
-// Physics note the result carries: every contact adds the probe tip's
-// effective radius, so the fit yields the COMBINED diameter
-// (feature + tip) - they cannot be separated without one being known.
-// The operator's min/max diameter estimates bound every march: approaches
-// start beyond max/2 and abort at min/2 without contact instead of
-// pressing on into a wrong guess.
+// Circle probing: N sensor-gated radial marches around (or inside) a
+// roughly-round vertical feature, then a least-squares circle fit.
+//
+// OUTSIDE mode (a post, a boss, a pin): marches start beyond the feature and
+// step inward. Every contact adds the probe tip's effective radius, so the
+// fit yields the COMBINED diameter (feature + tip). Repositioning between
+// points obeys motion law 2 in full (operator, 2026-09-02: "x/y motion over
+// 1mm is never below gantry height"): every hop lifts to the safe traverse
+// height, traverses, then descends.
+//
+// INSIDE mode (a hole, operator-requested 2026-09-02): the operator
+// positions the tip INSIDE the hole at the measuring depth first; every
+// march starts from that staged position and steps OUTWARD to the wall,
+// retreating back to the start between azimuths - no hops, no Z motion
+// until the final raise to the traverse height (a vertical exit along the
+// path the probe entered by). Contacts SUBTRACT the tip radius: the fit
+// yields hole diameter MINUS tip diameter.
+//
+// The operator's min/max diameter estimates bound every march - outside:
+// start beyond max/2, abort at min/2; inside: abort at max/2 (+ the
+// eccentricity margin) - so a wrong guess aborts instead of pressing on.
 //
 // Safety inherits the probe_point mechanics (hardware-proven), plus: the
 // probe channel is EXPECTED contact only while marching/confirming - during
 // repositioning hops and descents it is not, so a graze there latches the
-// CRASH alarm instead of being absorbed. Repositioning between points obeys
-// motion law 2 in full (operator, 2026-09-02: "x/y motion over 1mm is never
-// below gantry height"): every hop lifts to the safe traverse height,
-// traverses, then descends - no local hop heights above the feature.
+// CRASH alarm instead of being absorbed.
 
 export interface ProbeCirclePoint {
     azimuthDeg: number;
@@ -42,14 +52,15 @@ export interface ProbeCirclePoint {
 }
 
 export interface ProbeCirclePlan {
-    center: { x: number; y: number }; // operator estimate, machine coords
+    inside: boolean;
+    center: { x: number; y: number }; // machine coords: estimate (outside) / march origin (inside)
     diameterMinMm: number;
     diameterMaxMm: number;
-    topZMachine: number; // toolhead machine Z with the tip at the feature top
+    topZMachine: number | null; // toolhead machine Z with the tip at the feature top (outside mode)
     probeZ: number; // side-contact toolhead Z
-    hopZ: number; // repositioning toolhead Z: the safe traverse height (law 2)
-    startRadiusMm: number;
-    floorRadiusMm: number;
+    hopZ: number; // repositioning / final-raise toolhead Z: the safe traverse height (law 2)
+    startRadiusMm: number; // outside: approach start radius; inside: 0
+    limitRadiusMm: number; // outside: abort floor (min/2); inside: abort ceiling (max/2 + margin)
     points: ProbeCirclePoint[];
     coarseStepMm: number;
     fineStepMm: number;
@@ -60,6 +71,7 @@ export interface ProbeCirclePlan {
 }
 
 export function planProbeCircle(args: {
+    inside?: boolean;
     center_x?: number;
     center_y?: number;
     diameter_min_mm?: number;
@@ -74,98 +86,144 @@ export function planProbeCircle(args: {
     sensor_delay_ms?: number;
     confirm_passes?: number;
 }): ProbeCirclePlan {
-    const centerX = Number(args.center_x);
-    const centerY = Number(args.center_y);
-    if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) {
-        throw new McpToolError('center_x and center_y (machine coords, operator estimate) are required.');
-    }
+    const inside = args.inside === true;
     const dMin = Number(args.diameter_min_mm);
     const dMax = Number(args.diameter_max_mm);
     if (!Number.isFinite(dMin) || !Number.isFinite(dMax) || dMin <= 0 || dMax < dMin || dMax > 100) {
         throw new McpToolError('diameter_min_mm and diameter_max_mm are required: the operator\'s bounds '
-            + 'on the feature diameter (0 < min <= max <= 100). They bound every march - no contact by '
-            + 'the min-diameter radius aborts instead of pressing on.');
+            + 'on the feature diameter (0 < min <= max <= 100). They bound every march - a wrong guess '
+            + 'aborts instead of pressing on.');
     }
-    const topZ = Number(args.top_z_machine);
-    if (!Number.isFinite(topZ) || topZ <= 0 || topZ > 400) {
-        throw new McpToolError('top_z_machine is required: the toolhead machine Z at which the probe tip '
-            + 'touches the feature TOP - a measured or operator-stated number, never a guess.');
-    }
-    const probeDepth = Math.min(Math.max(Number(args.probe_depth_mm) || 3, 0.5), 20);
     const pointCount = Math.min(Math.max(Math.round(Number(args.points) || 8), 4), 16);
     const approach = Math.min(Math.max(Number(args.approach_clearance_mm) || 5, 1), 20);
-
-    const startRadius = dMax / 2 + approach;
-    const floorRadius = dMin / 2;
-    if (startRadius - floorRadius < 1) {
-        throw new McpToolError('Less than 1 mm between the approach start radius and the min-diameter '
-            + 'floor - widen approach_clearance_mm or the diameter bounds.');
-    }
 
     const position = getPositionSnapshot();
     const { x, y, z } = position.machine;
     if (x === null || y === null || z === null) {
         throw new McpToolError('Current machine position unknown; cannot anchor the envelope.');
     }
-
+    const staged = { x, y, z };
     const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+
+    let center: { x: number; y: number };
+    let probeZ: number;
+    let topZ: number | null;
+    let startRadius: number;
+    let limitRadius: number;
+    if (inside) {
+        // The operator has already positioned the tip inside the hole at the
+        // measuring depth: the staged position is the march origin AND the
+        // probing depth. No estimated centre is needed - the fit finds it.
+        center = { x, y };
+        probeZ = z;
+        topZ = args.top_z_machine !== undefined ? Number(args.top_z_machine) : null;
+        startRadius = 0;
+        // The eccentricity margin: the staged position may sit off the true
+        // hole centre; marches may legitimately travel farther on one side.
+        limitRadius = Number((dMax / 2 + approach).toFixed(3));
+    } else {
+        const centerX = Number(args.center_x);
+        const centerY = Number(args.center_y);
+        if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) {
+            throw new McpToolError('center_x and center_y (machine coords, operator estimate) are '
+                + 'required for an outside measurement.');
+        }
+        center = { x: centerX, y: centerY };
+        topZ = Number(args.top_z_machine);
+        if (!Number.isFinite(topZ) || topZ <= 0 || topZ > 400) {
+            throw new McpToolError('top_z_machine is required: the toolhead machine Z at which the probe '
+                + 'tip touches the feature TOP - a measured or operator-stated number, never a guess.');
+        }
+        const probeDepth = Math.min(Math.max(Number(args.probe_depth_mm) || 3, 0.5), 20);
+        probeZ = Number((topZ - probeDepth).toFixed(3));
+        startRadius = Number((dMax / 2 + approach).toFixed(3));
+        limitRadius = Number((dMin / 2).toFixed(3));
+        if (startRadius - limitRadius < 1) {
+            throw new McpToolError('Less than 1 mm between the approach start radius and the '
+                + 'min-diameter floor - widen approach_clearance_mm or the diameter bounds.');
+        }
+    }
+
     const points: ProbeCirclePoint[] = [];
     for (let i = 0; i < pointCount; i++) {
         const azimuth = (360 / pointCount) * i;
         const rad = (azimuth * Math.PI) / 180;
-        const sx = Number((centerX + startRadius * Math.cos(rad)).toFixed(3));
-        const sy = Number((centerY + startRadius * Math.sin(rad)).toFixed(3));
-        if (size && (sx < -25 || sx > size.x + 40 || sy < -25 || sy > size.y + 40)) {
-            throw new McpToolError(`Approach start for azimuth ${azimuth.toFixed(0)} deg `
-                + `(${sx}, ${sy}) falls outside the machine envelope.`);
+        const reach = inside ? limitRadius : startRadius;
+        const sx = Number((center.x + (inside ? 0 : startRadius) * Math.cos(rad)).toFixed(3));
+        const sy = Number((center.y + (inside ? 0 : startRadius) * Math.sin(rad)).toFixed(3));
+        const fx = center.x + reach * Math.cos(rad);
+        const fy = center.y + reach * Math.sin(rad);
+        if (size && (fx < -25 || fx > size.x + 40 || fy < -25 || fy > size.y + 40
+            || sx < -25 || sx > size.x + 40 || sy < -25 || sy > size.y + 40)) {
+            throw new McpToolError(`March for azimuth ${azimuth.toFixed(0)} deg falls outside the `
+                + 'machine envelope.');
         }
         points.push({ azimuthDeg: azimuth, startXY: { x: sx, y: sy } });
     }
 
     return {
-        center: { x: centerX, y: centerY },
+        inside,
+        center,
         diameterMinMm: dMin,
         diameterMaxMm: dMax,
         topZMachine: topZ,
-        probeZ: Number((topZ - probeDepth).toFixed(3)),
+        probeZ,
         hopZ: safeTraverseZ(),
-        startRadiusMm: Number(startRadius.toFixed(3)),
-        floorRadiusMm: Number(floorRadius.toFixed(3)),
+        startRadiusMm: startRadius,
+        limitRadiusMm: limitRadius,
         points,
         coarseStepMm: Math.min(Math.max(Number(args.coarse_step_mm) || 0.5, 0.2), 2),
         fineStepMm: Math.min(Math.max(Number(args.fine_step_mm) || 0.1, 0.02), 0.5),
         backoffMm: Math.min(Math.max(Number(args.backoff_mm) || 0.5, Number(args.fine_step_mm) || 0.1), 3),
         sensorDelayMs: Math.min(Math.max(Number(args.sensor_delay_ms) || 200, 100), 10000),
         confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 2), 1), 5),
-        staged: { x, y, z },
+        staged,
     };
 }
 
 /** Confirm-page gcode: every commanded move of the whole star, enumerated. */
 export function describeProbeCirclePlanAsGcode(plan: ProbeCirclePlan): string {
-    const lines = [
-        `; TOUCH PROBE CIRCLE MEASUREMENT: ${plan.points.length} radial marches around `
-            + `estimated centre (${plan.center.x}, ${plan.center.y})`,
-        `; operator diameter bounds ${plan.diameterMinMm}..${plan.diameterMaxMm} mm; approaches start at `
-            + `radius ${plan.startRadiusMm} and ABORT at radius ${plan.floorRadiusMm} without contact`,
-        `; feature top measured at toolhead Z ${plan.topZMachine}; side contacts at Z ${plan.probeZ}; `
-            + `hops between points at the safe traverse height Z ${plan.hopZ} (motion law 2)`,
+    const lines = plan.inside
+        ? [
+            `; TOUCH PROBE INSIDE-CIRCLE (HOLE) MEASUREMENT: ${plan.points.length} radial marches `
+                + `OUTWARD from the staged position (${plan.center.x}, ${plan.center.y}, Z${plan.probeZ})`,
+            '; the operator positioned the tip INSIDE the hole at the measuring depth; each march',
+            '; steps outward to the wall and retreats back to the start - no hops, no Z motion',
+            `; until the final vertical raise to the traverse height Z${plan.hopZ}.`,
+            `; operator hole-diameter bounds ${plan.diameterMinMm}..${plan.diameterMaxMm} mm; a march `
+                + `ABORTS at radius ${plan.limitRadiusMm} (max/2 + eccentricity margin) without contact`,
+            '; fit yields hole diameter MINUS the probe tip effective diameter.',
+        ]
+        : [
+            `; TOUCH PROBE CIRCLE MEASUREMENT: ${plan.points.length} radial marches around `
+                + `estimated centre (${plan.center.x}, ${plan.center.y})`,
+            `; operator diameter bounds ${plan.diameterMinMm}..${plan.diameterMaxMm} mm; approaches start at `
+                + `radius ${plan.startRadiusMm} and ABORT at radius ${plan.limitRadiusMm} without contact`,
+            `; feature top measured at toolhead Z ${plan.topZMachine}; side contacts at Z ${plan.probeZ}; `
+                + `hops between points at the safe traverse height Z ${plan.hopZ} (motion law 2)`,
+        ];
+    lines.push(
         '; EVERY LINE IS SENT INDIVIDUALLY and settle-verified; the probe feed is checked after each',
         '; march step. A probe touch during a hop or descent latches the CRASH alarm.',
         '; overtravel feed trips -> job stop + connection close + latched alarm',
         'G90',
         'G53;',
-    ];
+    );
     for (const point of plan.points) {
         const rad = (point.azimuthDeg * Math.PI) / 180;
         lines.push(`; --- point at azimuth ${point.azimuthDeg.toFixed(1)} deg ---`);
-        lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; lift to safe traverse height`);
-        lines.push(`G1 X${point.startXY.x.toFixed(3)} Y${point.startXY.y.toFixed(3)} F${TRAVEL_FEED}; approach start`);
-        lines.push(`G1 Z${plan.probeZ.toFixed(3)} F${TRAVEL_FEED}; descend to probing depth`);
-        let r = plan.startRadiusMm;
+        if (!plan.inside) {
+            lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; lift to safe traverse height`);
+            lines.push(`G1 X${point.startXY.x.toFixed(3)} Y${point.startXY.y.toFixed(3)} F${TRAVEL_FEED}; approach start`);
+            lines.push(`G1 Z${plan.probeZ.toFixed(3)} F${TRAVEL_FEED}; descend to probing depth`);
+        }
+        let r = plan.inside ? 0 : plan.startRadiusMm;
         let step = 0;
-        while (r - plan.floorRadiusMm > 1e-9) {
-            r = Math.max(r - plan.coarseStepMm, plan.floorRadiusMm);
+        const done = () => (plan.inside ? plan.limitRadiusMm - r <= 1e-9 : r - plan.limitRadiusMm <= 1e-9);
+        while (!done()) {
+            r = plan.inside
+                ? Math.min(r + plan.coarseStepMm, plan.limitRadiusMm)
+                : Math.max(r - plan.coarseStepMm, plan.limitRadiusMm);
             step += 1;
             const px = plan.center.x + r * Math.cos(rad);
             const py = plan.center.y + r * Math.sin(rad);
@@ -174,9 +232,10 @@ export function describeProbeCirclePlanAsGcode(plan: ProbeCirclePlan): string {
         }
         lines.push(`; ...on contact: retreat ${plan.coarseStepMm} mm radially until released, fine approach `
             + `in ${plan.fineStepMm} mm steps, ${plan.confirmPasses} confirm cycle(s) (lift ${plan.backoffMm} mm)`);
-        lines.push(`G1 X${point.startXY.x.toFixed(3)} Y${point.startXY.y.toFixed(3)} F${TRAVEL_FEED}; retreat to approach start`);
+        lines.push(`G1 X${point.startXY.x.toFixed(3)} Y${point.startXY.y.toFixed(3)} F${TRAVEL_FEED}; retreat to `
+            + `${plan.inside ? 'the march origin' : 'approach start'}`);
     }
-    lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; final lift to hop height`);
+    lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; final ${plan.inside ? 'vertical raise out of the hole' : 'lift'} to the traverse height`);
     lines.push('G54;');
     return lines.join('\n');
 }
@@ -199,7 +258,6 @@ function fitCircle(contacts: { x: number; y: number }[]): {
         sx += p.x; sy += p.y;
         sxz += p.x * zz; syz += p.y * zz; sz += zz;
     }
-    // Solve [2sxx 2sxy sx; 2sxy 2syy sy; 2sx 2sy n] * [a b c]' = [sxz syz sz]'
     const m = [
         [2 * sxx, 2 * sxy, sx, sxz],
         [2 * sxy, 2 * syy, sy, syz],
@@ -255,9 +313,9 @@ export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<ob
             + `(staged (${plan.staged.x}, ${plan.staged.y}, ${plan.staged.z}), now `
             + `(${here.x}, ${here.y}, ${here.z})). Stage probe_circle again.`);
     }
-    if (here.z < plan.hopZ - 0.5) {
+    if (!plan.inside && here.z < plan.hopZ - 0.5) {
         throw new McpToolError(`Current machine Z ${here.z} is below the hop height ${plan.hopZ}; `
-            + 'position at or above it before staging.');
+            + 'position at or above it before staging an outside measurement.');
     }
 
     const phases: { phase: string; note?: string }[] = [];
@@ -272,46 +330,56 @@ export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<ob
         x: Number((plan.center.x + r * Math.cos(azimuthRad)).toFixed(3)),
         y: Number((plan.center.y + r * Math.sin(azimuthRad)).toFixed(3)),
     });
+    // March parametrization: s grows from 0 as the march advances toward the
+    // expected wall. Outside: radius = startRadius - s (inward). Inside:
+    // radius = s (outward). Travel budget per point:
+    const travelBudget = plan.inside ? plan.limitRadiusMm : plan.startRadiusMm - plan.limitRadiusMm;
+    const radiusAt = (s: number) => (plan.inside ? s : plan.startRadiusMm - s);
 
     try {
         for (const point of plan.points) {
             const rad = (point.azimuthDeg * Math.PI) / 180;
             const label = `az${point.azimuthDeg.toFixed(0)}`;
 
-            // Reposition: contact here is NOT expected - a graze latches CRASH.
-            probeFeedService.clearExpectedContact();
-            await moveMachineSettled(`circle:hop:${label}`, { z: plan.hopZ }, TRAVEL_FEED);
-            await moveMachineSettled(`circle:hop:${label}`, { ...point.startXY }, TRAVEL_FEED);
-            await moveMachineSettled(`circle:descend:${label}`, { z: plan.probeZ }, TRAVEL_FEED);
-            announce(`start-${label}`, `approach start (${point.startXY.x}, ${point.startXY.y}) Z${plan.probeZ}`);
+            if (!plan.inside) {
+                // Reposition: contact here is NOT expected - a graze latches CRASH.
+                probeFeedService.clearExpectedContact();
+                await moveMachineSettled(`circle:hop:${label}`, { z: plan.hopZ }, TRAVEL_FEED);
+                await moveMachineSettled(`circle:hop:${label}`, { ...point.startXY }, TRAVEL_FEED);
+                await moveMachineSettled(`circle:descend:${label}`, { z: plan.probeZ }, TRAVEL_FEED);
+                announce(`start-${label}`, `approach start (${point.startXY.x}, ${point.startXY.y}) Z${plan.probeZ}`);
+            } else {
+                announce(`start-${label}`, `outward march from (${point.startXY.x}, ${point.startXY.y}) Z${plan.probeZ}`);
+            }
 
-            // March radially inward; contact on the probe channel is expected.
+            // March radially; contact on the probe channel is expected.
             probeFeedService.setExpectedContact(['probe']);
-            let r = plan.startRadiusMm;
-            let coarseContactR: number | null = null;
-            while (r - plan.floorRadiusMm > 1e-9) {
+            let s = 0;
+            let coarseContactS: number | null = null;
+            while (travelBudget - s > 1e-9) {
                 const stepStart = Date.now();
-                r = Math.max(r - plan.coarseStepMm, plan.floorRadiusMm);
-                await moveMachineSettled(`circle:coarse:${label}`, radialXY(rad, r), COARSE_FEED);
+                s = Math.min(s + plan.coarseStepMm, travelBudget);
+                await moveMachineSettled(`circle:coarse:${label}`, radialXY(rad, radiusAt(s)), COARSE_FEED);
                 const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
                 if (sensed.contact) {
-                    coarseContactR = r;
-                    announce(`coarse-contact-${label}`, `radius ${r.toFixed(3)}`);
+                    coarseContactS = s;
+                    announce(`coarse-contact-${label}`, `radius ${radiusAt(s).toFixed(3)}`);
                     break;
                 }
             }
-            if (coarseContactR === null) {
-                throw new ProcedureAbort(`No contact by the min-diameter radius ${plan.floorRadiusMm} at `
-                    + `azimuth ${point.azimuthDeg.toFixed(0)} deg - the centre estimate or diameter bounds `
-                    + 'are wrong, or the probe is not reporting.');
+            if (coarseContactS === null) {
+                throw new ProcedureAbort(`No contact by radius ${radiusAt(travelBudget).toFixed(3)} at `
+                    + `azimuth ${point.azimuthDeg.toFixed(0)} deg - the ${plan.inside ? 'hole is larger '
+                        + 'than diameter_max_mm (or the start is not inside it)' : 'centre estimate or '
+                        + 'diameter bounds are wrong'}, or the probe is not reporting.`);
             }
 
-            // Retreat radially until released.
+            // Retreat until released.
             let released = false;
-            while (r < plan.startRadiusMm - 1e-9 && r - coarseContactR < MAX_RETREAT_MM + 1e-9) {
+            while (s > 1e-9 && coarseContactS - s < MAX_RETREAT_MM + 1e-9) {
                 const stepStart = Date.now();
-                r = Math.min(r + plan.coarseStepMm, plan.startRadiusMm);
-                await moveMachineSettled(`circle:release:${label}`, radialXY(rad, r), COARSE_FEED);
+                s = Math.max(s - plan.coarseStepMm, 0);
+                await moveMachineSettled(`circle:release:${label}`, radialXY(rad, radiusAt(s)), COARSE_FEED);
                 const sensed = await senseReleaseAfter('probe', stepStart, releaseTimeoutMs);
                 if (!sensed.contact) {
                     released = true;
@@ -324,42 +392,42 @@ export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<ob
             }
 
             // Fine approach.
-            let fineContactR: number | null = null;
-            while (r - plan.floorRadiusMm > 1e-9) {
+            let fineContactS: number | null = null;
+            while (travelBudget - s > 1e-9) {
                 const stepStart = Date.now();
-                r = Math.max(r - plan.fineStepMm, plan.floorRadiusMm);
-                await moveMachineSettled(`circle:fine:${label}`, radialXY(rad, r), FINE_FEED);
+                s = Math.min(s + plan.fineStepMm, travelBudget);
+                await moveMachineSettled(`circle:fine:${label}`, radialXY(rad, radiusAt(s)), FINE_FEED);
                 const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
                 if (sensed.contact) {
-                    fineContactR = r;
+                    fineContactS = s;
                     break;
                 }
             }
-            if (fineContactR === null) {
+            if (fineContactS === null) {
                 throw new ProcedureAbort(`Fine approach lost the contact at azimuth ${point.azimuthDeg.toFixed(0)} deg.`);
             }
 
-            // Confirm cycles on the radius; median wins.
-            const passRadii: number[] = [];
-            const cycleFloor = Math.max(fineContactR - 0.5, plan.floorRadiusMm);
-            let reference = fineContactR;
+            // Confirm cycles on the march distance; median wins.
+            const passS: number[] = [];
+            const cycleLimit = Math.min(fineContactS + 0.5, travelBudget);
+            let reference = fineContactS;
             for (let pass = 1; pass <= plan.confirmPasses; pass++) {
                 const liftIssuedAt = Date.now();
-                r = Math.min(reference + plan.backoffMm, plan.startRadiusMm);
-                await moveMachineSettled(`circle:backoff:${label}`, radialXY(rad, r), FINE_FEED);
+                s = Math.max(reference - plan.backoffMm, 0);
+                await moveMachineSettled(`circle:backoff:${label}`, radialXY(rad, radiusAt(s)), FINE_FEED);
                 const liftSense = await senseReleaseAfter('probe', liftIssuedAt, releaseTimeoutMs);
                 if (liftSense.contact) {
                     throw new ProcedureAbort(`Probe still triggered after backing off ${plan.backoffMm} mm at `
                         + `azimuth ${point.azimuthDeg.toFixed(0)} deg - hysteresis exceeds the backoff.`);
                 }
                 let passContact: number | null = null;
-                while (r - cycleFloor > 1e-9) {
+                while (cycleLimit - s > 1e-9) {
                     const stepStart = Date.now();
-                    r = Math.max(r - plan.fineStepMm, cycleFloor);
-                    await moveMachineSettled(`circle:confirm:${label}`, radialXY(rad, r), FINE_FEED);
+                    s = Math.min(s + plan.fineStepMm, cycleLimit);
+                    await moveMachineSettled(`circle:confirm:${label}`, radialXY(rad, radiusAt(s)), FINE_FEED);
                     const sensed = await senseAfter('probe', stepStart, plan.sensorDelayMs);
                     if (sensed.contact) {
-                        passContact = r;
+                        passContact = s;
                         break;
                     }
                 }
@@ -367,12 +435,14 @@ export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<ob
                     throw new ProcedureAbort(`Confirm pass ${pass} lost the contact at azimuth `
                         + `${point.azimuthDeg.toFixed(0)} deg.`);
                 }
-                passRadii.push(Number(passContact.toFixed(3)));
+                passS.push(passContact);
                 reference = passContact;
             }
-            const sorted = [...passRadii].sort((a, b) => a - b);
-            const measuredR = sorted[Math.floor((sorted.length - 1) / 2)];
+            const sorted = [...passS].sort((a, b) => a - b);
+            const measuredS = sorted[Math.floor((sorted.length - 1) / 2)];
+            const passRadii = passS.map((v) => Number(radiusAt(v).toFixed(3)));
             const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
+            const measuredR = radiusAt(measuredS);
             const contactPoint = radialXY(rad, measuredR);
             contacts.push({
                 azimuthDeg: point.azimuthDeg,
@@ -383,26 +453,32 @@ export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<ob
             });
             announce(`measured-${label}`, `radius ${measuredR.toFixed(3)} spread ${spreadMm}`);
 
-            // Retreat radially to the approach start (still expected-contact
+            // Retreat radially to the march start (still expected-contact
             // until physically clear).
             await moveMachineSettled(`circle:retreat:${label}`, { ...point.startXY }, TRAVEL_FEED);
         }
 
-        // Final lift; reposition rules apply again.
+        // Final raise; reposition rules apply again.
         probeFeedService.clearExpectedContact();
         await moveMachineSettled('circle:final-lift', { z: plan.hopZ }, TRAVEL_FEED);
         announce('final-lift', `Z${plan.hopZ}`);
 
         const fit = fitCircle(contacts.map((c) => ({ x: c.x, y: c.y })));
-        const combinedDiameter = Number((fit.radius * 2).toFixed(3));
-        const tipMin = Number(Math.max(combinedDiameter - plan.diameterMaxMm, 0).toFixed(3));
-        const tipMax = Number(Math.max(combinedDiameter - plan.diameterMinMm, 0).toFixed(3));
+        const fittedDiameter = Number((fit.radius * 2).toFixed(3));
+        // Outside: fitted = feature + tip. Inside: fitted = hole - tip.
+        const tipMin = plan.inside
+            ? Number(Math.max(plan.diameterMinMm - fittedDiameter, 0).toFixed(3))
+            : Number(Math.max(fittedDiameter - plan.diameterMaxMm, 0).toFixed(3));
+        const tipMax = plan.inside
+            ? Number(Math.max(plan.diameterMaxMm - fittedDiameter, 0).toFixed(3))
+            : Number(Math.max(fittedDiameter - plan.diameterMinMm, 0).toFixed(3));
         const worstSpread = Math.max(...contacts.map((c) => c.spreadMm));
         return {
+            inside: plan.inside,
             contacts,
             fit: {
                 center: fit.center,
-                combinedDiameterMm: combinedDiameter,
+                fittedDiameterMm: fittedDiameter,
                 rmsResidualMm: fit.rmsResidual,
                 maxResidualMm: fit.maxResidual,
                 residualsMm: fit.residuals,
@@ -413,12 +489,19 @@ export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<ob
             },
             tipEffectiveDiameterMm: { min: tipMin, max: tipMax },
             phases,
-            note: `Fitted centre machine (${fit.center.x}, ${fit.center.y}), COMBINED diameter `
-                + `${combinedDiameter} mm (feature + probe tip - inseparable without one known: if the `
-                + `feature is truly ${plan.diameterMinMm}..${plan.diameterMaxMm} mm, the tip's effective `
-                + `diameter is ${tipMin}..${tipMax} mm). Fit residuals rms ${fit.rmsResidual} / max `
-                + `${fit.maxResidual} mm - direction-dependent residuals mean an out-of-round tip or `
-                + `feature. Worst per-point confirm spread ${worstSpread} mm.`,
+            note: plan.inside
+                ? `Fitted hole centre machine (${fit.center.x}, ${fit.center.y}), fitted diameter `
+                    + `${fittedDiameter} mm = hole MINUS probe tip (inseparable without one known: if the `
+                    + `hole is truly ${plan.diameterMinMm}..${plan.diameterMaxMm} mm, the tip's effective `
+                    + `diameter is ${tipMin}..${tipMax} mm). Fit residuals rms ${fit.rmsResidual} / max `
+                    + `${fit.maxResidual} mm. Worst per-point confirm spread ${worstSpread} mm. All in `
+                    + 'MACHINE coordinates.'
+                : `Fitted centre machine (${fit.center.x}, ${fit.center.y}), COMBINED diameter `
+                    + `${fittedDiameter} mm (feature + probe tip - inseparable without one known: if the `
+                    + `feature is truly ${plan.diameterMinMm}..${plan.diameterMaxMm} mm, the tip's effective `
+                    + `diameter is ${tipMin}..${tipMax} mm). Fit residuals rms ${fit.rmsResidual} / max `
+                    + `${fit.maxResidual} mm - direction-dependent residuals mean an out-of-round tip or `
+                    + `feature. Worst per-point confirm spread ${worstSpread} mm. All in MACHINE coordinates.`,
             warning: fit.maxResidual > 0.2
                 ? 'Max fit residual exceeds 0.2 mm: the feature or the probe tip is significantly '
                     + 'out of round, or a contact was bad. Inspect residualsMm by azimuth.'
@@ -428,12 +511,17 @@ export async function runProbeCircleProcedure(plan: ProbeCirclePlan): Promise<ob
         const isTrip = !!probeFeedService.getTrip();
         if (!isTrip) {
             try {
-                // Abort retreat: radially out to the current point's start
-                // radius is unknown here, so lift straight up to hopZ only if
-                // the probe reads released; a stuck-triggered probe means
-                // physical contact - leave the machine where it is.
+                // Abort retreat: lift straight up only if the probe reads
+                // released; a stuck-triggered probe means physical contact -
+                // leave the machine where it is for the operator. Inside a
+                // hole, retreat to the march origin first so the vertical
+                // exit is the entry path.
                 const reading = probeFeedService.getReading('probe');
                 if (!reading || !reading.triggered) {
+                    if (plan.inside) {
+                        await moveMachineSettled('circle:abort-recentre', { x: plan.center.x, y: plan.center.y }, TRAVEL_FEED);
+                        announce('abort-recentred', `(${plan.center.x}, ${plan.center.y})`);
+                    }
                     await moveMachineSettled('circle:abort-lift', { z: plan.hopZ }, TRAVEL_FEED);
                     announce('abort-lifted', `Z${plan.hopZ}`);
                 } else {

--- a/src/server/services/mcp/probing.ts
+++ b/src/server/services/mcp/probing.ts
@@ -2,7 +2,7 @@ import { connectionManager } from '../machine/ConnectionManager';
 import { ProbeChannel, probeFeedService } from './probeFeed';
 import { McpToolError } from './registry';
 import { GcodeChannel, sendGcodeVisible } from './tools/camera';
-import { getPositionSnapshot } from './tools/machine';
+import { assertFreshHeartbeat, getPositionSnapshot } from './tools/machine';
 
 // The shared sensor-gated motion engine: settled single moves on the direct
 // path, contact/release sensing against a probe feed channel, and the
@@ -230,6 +230,7 @@ export function assertChannelReady(channel: ProbeChannel, what: string): void {
 
 /** Machine idle, homed, toolhead off - the common motion preconditions. */
 export function assertMachineReadyForProcedure(): void {
+    assertFreshHeartbeat('a probing procedure');
     const position = getPositionSnapshot();
     if (position.machineStatus !== 'idle') {
         throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);

--- a/src/server/services/mcp/tools/camera.ts
+++ b/src/server/services/mcp/tools/camera.ts
@@ -9,7 +9,7 @@ import { decodeToGray, trackFeature } from '../tracking';
 import { McpToolError, ToolRegistry } from '../registry';
 import { landmarkStore } from '../landmarks';
 import { probeFeedService } from '../probeFeed';
-import { PositionSnapshot, getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './machine';
+import { assertFreshHeartbeat, PositionSnapshot, getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './machine';
 
 // Motion policy (#23, refined): the direct move path is for the odd single
 // action only. move_and_capture performs ONE bounded XY move at the current
@@ -128,6 +128,7 @@ function frameContent(frame: CapturedFrame, meta: object): object {
 
 function assertSafeToMove(position: PositionSnapshot, operatorConfirmedClearance: boolean): void {
     probeFeedService.assertNoOvertravel();
+    assertFreshHeartbeat('a direct move');
     if (position.machineStatus !== 'idle') {
         throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);
     }
@@ -521,10 +522,44 @@ export function registerCameraTools(registry: ToolRegistry): void {
                 throw new McpToolError('No machine connected, or the channel does not support direct commands.');
             }
             const executed = await sendGcodeVisible(channel, 'query_firmware_position', 'M114');
+            const raw = executed.text || null;
+            if (!raw || !/X:-?\d/.test(raw)) {
+                // An "ok" with no position text is not a position report - it
+                // is the dead-connection signature (observed live 2026-09-02:
+                // the machine had disconnected without the server noticing).
+                throw new McpToolError('M114 returned no position text - the connection is likely dead '
+                    + 'even though the channel accepted the command. Reconnect the machine and verify '
+                    + `get_position is fresh before trusting anything. (raw: ${JSON.stringify(raw)}, `
+                    + `result: ${executed.result})`);
+            }
+            // M114 reports WORK coordinates in the currently selected
+            // workspace (operator-clarified 2026-09-02) - it is primarily a
+            // liveness/frame check. Machine coordinates are DERIVED here via
+            // the heartbeat's originOffset; if the frames disagree (e.g.
+            // after a bare G28) the derived values are the thing to distrust.
+            const heartbeat = positionOrNull();
+            const match = raw.match(/X:(-?\d+(?:\.\d+)?)\s+Y:(-?\d+(?:\.\d+)?)\s+Z:(-?\d+(?:\.\d+)?)/);
+            const firmwareWork = match
+                ? { x: Number(match[1]), y: Number(match[2]), z: Number(match[3]) }
+                : null;
+            const offset = heartbeat ? heartbeat.originOffset : null;
+            const derivedMachine = firmwareWork && offset
+                ? {
+                    x: Number((firmwareWork.x - offset.x).toFixed(3)),
+                    y: Number((firmwareWork.y - offset.y).toFixed(3)),
+                    z: Number((firmwareWork.z - offset.z).toFixed(3)),
+                }
+                : null;
             return {
-                raw: executed.text || null,
+                raw,
                 result: executed.result,
-                heartbeat: positionOrNull(),
+                firmware_work: firmwareWork,
+                derived_machine: derivedMachine,
+                note: 'M114 reports WORK coordinates in the selected workspace - primarily a '
+                    + 'liveness/frame check. derived_machine = firmware work - heartbeat originOffset; '
+                    + 'work origins are volatile (reset on machine reboot), so record MACHINE '
+                    + 'coordinates only.',
+                heartbeat,
             };
         },
     });

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -9,7 +9,7 @@ import { probeFeedService } from '../probeFeed';
 import { McpToolError, ToolRegistry } from '../registry';
 import { validateGcode } from '../validator';
 import { GcodeChannel, sendGcodeVisible } from './camera';
-import { PositionSnapshot, getMachineSizeByIdentifier, getPositionSnapshot } from './machine';
+import { PositionSnapshot, assertFreshHeartbeat, getMachineSizeByIdentifier, getPositionSnapshot } from './machine';
 
 // Motion policy (#23): compound motion leaves this process only as a G-code
 // file submitted through the same prepare/start path as "Start on Luban",
@@ -256,8 +256,10 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 throw new McpToolError('Unknown job_id.');
             }
 
-            // Connectivity and idleness are checked before the token is
-            // consumed, so an offline attempt does not waste an approval.
+            // Connectivity, heartbeat freshness and idleness are checked
+            // before the token is consumed, so an offline attempt does not
+            // waste an approval.
+            assertFreshHeartbeat('starting a job');
             const channel = getJobChannel();
             const status = machineStatus();
             if (status !== 'idle') {
@@ -465,6 +467,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             }
             const feedRate = Math.min(Math.max(Number(args.feed_rate) || 300, 50), 600);
 
+            assertFreshHeartbeat('staging a Z move');
             const position = getPositionSnapshot();
             if (position.machineStatus !== 'idle') {
                 throw new McpToolError(`Machine is ${position.machineStatus || 'in an unknown state'}, not idle.`);

--- a/src/server/services/mcp/tools/machine.ts
+++ b/src/server/services/mcp/tools/machine.ts
@@ -82,6 +82,30 @@ export interface PositionSnapshot {
     warnings: string[];
 }
 
+// Heartbeat period is ~1s; a report older than this means the machine
+// connection has likely dropped without the server noticing (observed live
+// 2026-09-02: 5.7 minutes of stale state served as truth while the machine
+// was disconnected).
+export const HEARTBEAT_STALE_MS = 10000;
+
+/**
+ * Refuse to act on a stale heartbeat. Every motion-adjacent path (staging,
+ * procedure preconditions, direct execution) must call this: a position the
+ * machine reported minutes ago is not a position.
+ */
+export function assertFreshHeartbeat(what: string): void {
+    const state = connectionManager.getLatestMachineState();
+    if (!state) {
+        throw new McpToolError('No heartbeat received yet on this channel; position unknown.');
+    }
+    const age = Date.now() - state.timestamp;
+    if (age > HEARTBEAT_STALE_MS) {
+        throw new McpToolError(`Refusing ${what}: the last heartbeat is ${(age / 1000).toFixed(0)}s old `
+            + '(period ~1s) - the machine connection has likely dropped without the server noticing. '
+            + 'Reconnect the machine, verify get_position reports a fresh, correct position, then retry.');
+    }
+}
+
 /**
  * Position from the latest heartbeat, shared by get_position and the
  * capture tools. Throws McpToolError when unavailable.
@@ -123,6 +147,13 @@ export function getPositionSnapshot(): PositionSnapshot {
     // coordinates land outside the build volume (e.g. Z 656 on a 325 mm
     // machine). Flag it rather than let an agent trust it.
     const warnings: string[] = [];
+    const reportAgeMs = Date.now() - state.timestamp;
+    if (reportAgeMs > HEARTBEAT_STALE_MS) {
+        warnings.push(`STALE: the last heartbeat is ${(reportAgeMs / 1000).toFixed(0)}s old `
+            + `(period ~1s) - the machine connection has likely dropped without the server `
+            + 'noticing (observed live 2026-09-02). Do NOT trust this position; reconnect and '
+            + 're-verify before any motion.');
+    }
     const size = getMachineSizeByIdentifier(status.machineIdentifier);
     if (size) {
         // Floors/headroom allow real overtravel: the A350 X home switch sits
@@ -147,7 +178,7 @@ export function getPositionSnapshot(): PositionSnapshot {
         isFourAxis: !!pos.isFourAxis,
         isHomed: (state as { isHomed?: boolean }).isHomed ?? null,
         machineStatus: (state as { status?: string }).status || null,
-        reportAgeMs: Date.now() - state.timestamp,
+        reportAgeMs,
         convention: 'machine = work - originOffset; heartbeat reports work coordinates',
         warnings,
     };

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -144,20 +144,28 @@ ${describeProbeVectorPlanAsGcode(plan)}`;
 
     registry.register({
         name: 'probe_circle',
-        description: 'Stage an N-point circle measurement of a roughly-round vertical feature (post, '
-            + 'boss, pin) for human confirmation: radial sensor-gated marches from evenly spaced '
-            + 'azimuths, then a least-squares circle fit. Requires the operator\'s MIN and MAX '
-            + 'diameter estimates - they bound every march (start beyond max/2, abort at min/2 '
-            + 'without contact) - and a MEASURED top height (top_z_machine). Yields the fitted '
-            + 'centre and the COMBINED diameter (feature + probe tip, inseparable without one '
-            + 'known), with residuals exposing an out-of-round tip or feature. Repositioning between '
-            + 'points obeys motion law 2: lift to the safe traverse height, hop, descend; a probe '
-            + 'touch during a hop or descent latches the CRASH alarm.',
+        description: 'Stage an N-point circle measurement of a roughly-round vertical feature for '
+            + 'human confirmation: radial sensor-gated marches from evenly spaced azimuths, then a '
+            + 'least-squares circle fit. OUTSIDE mode (post/boss/pin, default): marches step inward; '
+            + 'requires the estimated centre and a MEASURED top height; yields the COMBINED diameter '
+            + '(feature + tip). INSIDE mode (inside: true, a HOLE): the operator first positions the '
+            + 'tip INSIDE the hole at the measuring depth; marches step OUTWARD from that staged '
+            + 'position to the wall, no hops, ending with a vertical raise out along the entry path; '
+            + 'yields hole diameter MINUS tip. Both need the operator\'s MIN and MAX diameter '
+            + 'estimates - they bound every march so a wrong guess aborts instead of pressing on. '
+            + 'Residuals expose an out-of-round tip or feature. Outside repositioning obeys motion '
+            + 'law 2 (traverse-height hops); a probe touch during a hop or descent latches CRASH. '
+            + 'All results in MACHINE coordinates.',
         inputSchema: {
             type: 'object',
             properties: {
-                center_x: { type: 'number', description: 'Estimated feature centre X, machine coords.' },
-                center_y: { type: 'number', description: 'Estimated feature centre Y, machine coords.' },
+                inside: {
+                    type: 'boolean',
+                    description: 'true = measure a HOLE from inside (tip already positioned in it at '
+                        + 'depth); false/omitted = measure a feature from outside.',
+                },
+                center_x: { type: 'number', description: 'OUTSIDE mode: estimated feature centre X, machine coords. Ignored inside (the staged position is the march origin).' },
+                center_y: { type: 'number', description: 'OUTSIDE mode: estimated feature centre Y, machine coords.' },
                 diameter_min_mm: {
                     type: 'number',
                     description: 'Operator\'s LOWER bound on the feature diameter: marches abort at this '
@@ -170,8 +178,9 @@ ${describeProbeVectorPlanAsGcode(plan)}`;
                 },
                 top_z_machine: {
                     type: 'number',
-                    description: 'Toolhead machine Z at which the probe tip touches the feature TOP - '
-                        + 'measured (probe_point -Z) or operator-stated, never guessed.',
+                    description: 'OUTSIDE mode (required there): toolhead machine Z at which the probe '
+                        + 'tip touches the feature TOP - measured (probe_point -Z) or operator-stated, '
+                        + 'never guessed. Optional record-keeping inside.',
                 },
                 probe_depth_mm: { type: 'number', description: 'Side contacts this far below the top, default 3 (0.5-20).' },
                 points: { type: 'number', description: 'Contact points around the circle, default 8 (4-16).' },
@@ -187,7 +196,7 @@ ${describeProbeVectorPlanAsGcode(plan)}`;
                 confirm_passes: { type: 'number', description: 'Lift-and-retest cycles per point, default 2 (1-5).' },
                 reason: { type: 'string', description: 'Shown to the operator: what is being measured and why.' },
             },
-            required: ['center_x', 'center_y', 'diameter_min_mm', 'diameter_max_mm', 'top_z_machine', 'reason'],
+            required: ['diameter_min_mm', 'diameter_max_mm', 'reason'],
             additionalProperties: false,
         },
         handler: async (args: { [key: string]: unknown }) => {
@@ -201,7 +210,7 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
             const validation = validateGcode(envelope);
             const job = jobManager.submit(
                 envelope,
-                `probe-circle ${plan.points.length}pts d${plan.diameterMinMm}-${plan.diameterMaxMm} `
+                `probe-circle${plan.inside ? ' INSIDE' : ''} ${plan.points.length}pts d${plan.diameterMinMm}-${plan.diameterMaxMm} `
                     + `- ${String(args.reason).slice(0, 40)}`,
                 'cnc',
                 validation,


### PR DESCRIPTION
**The incident**: the machine disconnected and the server never noticed — `get_position` served a 5.7-minute-old heartbeat as truth with no warning, and M114 returned success with no position text, while the probe tip was physically inside a hole in the chuck. Staging against that phantom position is how crashes happen.

**Fixes**
- `getPositionSnapshot` flags reports older than 10 s (heartbeat period ~1 s) with a loud STALE warning; `assertFreshHeartbeat` refuses procedure starts, `move_z` staging, job starts and direct moves on stale state.
- `query_firmware_position` errors on an empty M114 reply (the dead-connection signature) and parses a real one as what it is — **work coordinates** in the selected workspace (operator-clarified), primarily a liveness/frame check — returning `derived_machine` via the heartbeat originOffset.
- Recording rule (operator): **machine coordinates only** — work origins are volatile; a machine reboot mints a new one.

**`probe_circle` inside mode** (operator-requested hole checking): the operator positions the tip inside the hole at depth; marches step **outward** from that staged origin to the wall, retreating to the origin between azimuths — no hops, no Z motion until the final vertical raise out along the entry path. Result = hole diameter **minus** tip; the min/max bounds still gate every march (abort at max/2 + eccentricity margin).

**First hardware run** (chuck fixed hole): depth probe found the floor 7.4 mm below entry (spread 0); inside circle — 8 points, every confirm-pass spread 0, fit rms **0.021 mm**, max residual **0.041 mm**, centre found 0.27 mm from the staged origin. Combined with the outside run on the air-blast post, the two features' diameters are pinned to `post + hole = 10.41 mm` independent of tip size.

Stacked on #69 (`mcp/35-probe-vector-circle`). Zero new dependencies; build gated as usual, all behavior exercised live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)