### PR TITLE
Improvement: job event log + long-poll status; even survey grid

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -121,6 +121,20 @@ a tool refusing with "the touch probe / tool setter is disabled (Settings -> MCP
 Server)" means the operator switched that sensor off in the app - ask, never
 bypass. Sensors the operator has disabled have no pill at all.
 
+## Waiting on a job or procedure
+
+Never read server logs to find out whether a job finished. `get_gcode_job_status` carries
+the whole story: `job.state` (+ `terminal`), the procedure `result` once stored, and
+`events` — state changes, the runner's phase announcements, gcode sent/replies while the
+job was active, file-job progress every 5 %. Long-poll it: `wait_ms: 60000` returns as soon
+as the state turns terminal or new events arrive past `since_event` (pass back
+`next_event_index`), so one call replaces a polling loop. `start_gcode_job` on a procedure
+still returns the result directly; if that call times out, the result is on the record.
+
+`survey_bed`'s `pitch_mm` is a MAXIMUM: each axis is divided evenly into steps no larger
+than it (min 20), so rows and columns are uniform and both edges are covered — no more 80 mm
+jumps followed by a 10 mm stub. Pick the pitch from what one frame covers.
+
 ## Circle probing
 
 `probe_circle` measures a roughly-round vertical feature (post, boss, pin):

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -309,7 +309,8 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
 `get_connection_status` · `get_machine_profile` (kinematics, module offsets) ·
 `get_position` (both frames, warnings on incoherent reporting) ·
 `query_firmware_position` (raw M114) · `validate_gcode` · `submit_gcode_job` →
-`start_gcode_job` → `get_gcode_job_status` / `stop_gcode_job` · `move_z` (single or
+`start_gcode_job` → `get_gcode_job_status` (event log + stored result; long-poll with
+`wait_ms`/`since_event`) / `stop_gcode_job` · `move_z` (single or
 `z_targets` batch) · `home` · `goto_work_origin` · `move_and_capture` · `list_cameras` ·
 `capture_frame` (position-stamped, `frameId`, `expectedToolRegion`) · `set_tool_region` ·
 `track_feature` (NCC between cached frames — use instead of eyeballing pixels) ·
@@ -461,9 +462,12 @@ toolhead camera. Everything a fresh install needs:
   zero — the defaults are still MQTT-sized, so tighten them per-call when running on
   gpio.
 
-- **Procedure results only travel on the `start_gcode_job` response** — a client timeout
-  loses them (recovered once from the motion log; `probe_sequence` aborts also drop
-  completed results into the error text). Store the runner outcome on the job record.
+- ~~Procedure results only travel on the `start_gcode_job` response~~ — done 2026-09-05: the
+  runner outcome is stored as `job.result`, every job carries an event log (state changes,
+  runner phases, gcode traffic while active, file-job progress), and `get_gcode_job_status`
+  long-polls (`wait_ms`, `since_event`) — agents no longer read server logs to learn how a
+  job went. Still open: `probe_sequence` aborts drop completed marches into the error text
+  (they are now in the events, but not structured).
 - **`traverse_xy` staged batch tool** (law-2-compliant XY transport twin of `move_z`): hops
   currently need `submit_gcode_job` file jobs or `probe_sequence` hop steps.
 - **Console bug**: MCP gcode broadcasts leak into the Workspace console INPUT element with

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -43,6 +43,9 @@ let broadcaster: McpBroadcaster | null = null;
  * No-op until the service starts.
  */
 export function mcpBroadcast(eventName: string, options?: object): void {
+    // The active job keeps its own copy of what happened (get_gcode_job_status
+    // events), so agents read the record instead of the server log.
+    jobManager.recordActivity(eventName, options);
     broadcaster && broadcaster.broadcast(eventName, options);
 }
 

--- a/src/server/services/mcp/jobs.ts
+++ b/src/server/services/mcp/jobs.ts
@@ -40,6 +40,20 @@ export type McpJobState =
  */
 export type McpJobKind = 'file' | 'direct' | 'procedure';
 
+export interface JobEvent {
+    at: number;
+    /** State change ('submitted', 'approved', 'started', 'completed', ...), a runner phase, 'gcode', 'progress'. */
+    phase: string;
+    /** Which tool/source produced it. */
+    tool?: string;
+    note?: string;
+    [detail: string]: unknown;
+}
+
+const MAX_JOB_EVENTS = 400;
+
+export const TERMINAL_JOB_STATES: McpJobState[] = ['rejected', 'start_failed', 'stopped', 'completed'];
+
 export interface McpJob {
     id: string;
     name: string;
@@ -56,6 +70,14 @@ export interface McpJob {
     // Set when the job reaches a terminal state (completed / stopped).
     endedAt: number | null;
     error: string | null;
+    // Everything that happened to the job, in order: state changes, the
+    // runner's phase announcements, gcode sent/replies while it was the active
+    // job, file-job progress. Returned by get_gcode_job_status so an agent
+    // never has to read server logs to learn how a job went. Capped.
+    events: JobEvent[];
+    // Procedure outcome (tool setter / probe results), kept on the record so
+    // a client that timed out waiting on start_gcode_job can still read it.
+    result: object | null;
     // Batch direct jobs: the operator approved this exact list; each
     // start_gcode_job call executes ONE step, so captures can happen between
     // steps and the series can be abandoned at any point.
@@ -82,6 +104,8 @@ function range(r: { min: number; max: number } | null): string {
 }
 
 export class JobManager {
+    private activeJob: McpJob | null = null;
+
     private jobs = new Map<string, McpJob>();
 
     private jobsDir: string | null = null;
@@ -115,13 +139,63 @@ export class JobManager {
             startedAt: null,
             endedAt: null,
             error: null,
+            events: [],
+            result: null,
             steps,
             nextStep: steps ? 0 : undefined,
         };
         this.jobs.set(id, job);
         this.prune();
+        this.appendEvent(job, 'submitted', { note: `${kind} job staged, awaiting human confirmation` });
         log.info(`MCP job submitted: ${id} (${safeName}), awaiting human confirmation`);
         return job;
+    }
+
+    /** Record something that happened to a job (state change, phase, gcode, progress). */
+    public appendEvent(job: McpJob, phase: string, detail: { [key: string]: unknown } = {}): void {
+        job.events.push({ at: Date.now(), phase, ...detail });
+        if (job.events.length > MAX_JOB_EVENTS) {
+            // Keep the head (submission/approval/start) and the most recent tail.
+            job.events.splice(20, job.events.length - MAX_JOB_EVENTS);
+        }
+    }
+
+    /**
+     * The job currently driving the machine (a procedure runner, a direct
+     * step, a running file job). Activity broadcast while it is active is
+     * attached to its event log - see recordActivity.
+     */
+    public setActive(job: McpJob | null): void {
+        this.activeJob = job;
+    }
+
+    public getActive(): McpJob | null {
+        return this.activeJob;
+    }
+
+    /**
+     * Hook for mcpBroadcast: phase-style tool activity (runner announcements,
+     * probe feed readings/alarms) and gcode traffic land on the active job's
+     * event log. Tool-call summaries (ok/duration) are not job events.
+     */
+    public recordActivity(eventName: string, options?: object): void {
+        const job = this.activeJob;
+        if (!job || !options) {
+            return;
+        }
+        const payload = options as { [key: string]: unknown };
+        if (eventName === 'mcp:activity' && payload.phase !== undefined) {
+            const { phase, ...rest } = payload;
+            this.appendEvent(job, String(phase), rest);
+        } else if (eventName === 'mcp:gcode') {
+            const gcode = payload.gcode !== undefined ? String(payload.gcode).slice(0, 300) : undefined;
+            const response = payload.response !== undefined ? String(payload.response).slice(0, 300) : undefined;
+            this.appendEvent(job, 'gcode', { tool: payload.tool, gcode, response });
+        }
+    }
+
+    public isTerminal(job: McpJob): boolean {
+        return TERMINAL_JOB_STATES.includes(job.state);
     }
 
     public get(id: string): McpJob | null {
@@ -173,6 +247,10 @@ export class JobManager {
             startedAt: job.startedAt,
             endedAt: job.endedAt,
             error: job.error,
+            terminal: this.isTerminal(job),
+            result: job.result,
+            eventCount: job.events.length,
+            lastEvent: job.events.length ? job.events[job.events.length - 1] : null,
             totalSteps: job.steps ? job.steps.length : undefined,
             nextStep: job.steps ? job.nextStep : undefined,
             validation: job.validation,
@@ -232,6 +310,7 @@ export class JobManager {
             job.confirmToken = crypto.randomBytes(4).toString('hex');
             job.approvedAt = Date.now();
             job.state = 'approved';
+            this.appendEvent(job, 'approved', { note: 'operator approved on the confirm page' });
             log.info(`MCP job ${job.id} approved by operator`);
             this.page(res, 200, this.approvedPage(job));
             return;
@@ -239,6 +318,7 @@ export class JobManager {
         if (req.method === 'POST' && action === 'reject') {
             job.state = 'rejected';
             job.confirmToken = null;
+            this.appendEvent(job, 'rejected', { note: 'operator rejected on the confirm page' });
             log.info(`MCP job ${job.id} rejected by operator`);
             this.page(res, 200, '<h2>Rejected</h2><p>The job will not run.</p>');
             return;

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -115,6 +115,10 @@ const log = logger('service:mcp:gcode-jobs');
 // the heartbeat: once the job has been seen active, a debounced return to
 // idle is completion. A job too short to ever show as active is completed
 // after the heartbeat holds idle for a longer fallback window.
+const sleep = async (ms: number) => new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+});
+
 const FILE_JOB_POLL_MS = 1000;
 const FILE_JOB_IDLE_DEBOUNCE_POLLS = 3;
 const FILE_JOB_NEVER_SEEN_ACTIVE_IDLE_POLLS = 20;
@@ -125,10 +129,17 @@ function watchFileJobCompletion(job: McpJob): void {
     let sawActive = false;
     let idleStreak = 0;
     let unreadableStreak = 0;
+    let lastProgress = -1;
+    const release = () => {
+        if (jobManager.getActive() === job) {
+            jobManager.setActive(null);
+        }
+    };
     const timer = setInterval(() => {
         if (job.state !== 'started') {
             // Stopped (or otherwise finalised) through another path.
             clearInterval(timer);
+            release();
             return;
         }
         const status = machineStatus();
@@ -139,7 +150,9 @@ function watchFileJobCompletion(job: McpJob): void {
                 clearInterval(timer);
                 job.error = 'Completion unverified: machine state became unreadable after the job '
                     + 'started (connection lost?). The job may still be running on the machine.';
+                jobManager.appendEvent(job, 'completion_unverified', { note: job.error });
                 log.warn(`MCP file job ${job.id}: ${job.error}`);
+                release();
             }
             return;
         }
@@ -147,6 +160,17 @@ function watchFileJobCompletion(job: McpJob): void {
         if (FILE_JOB_ACTIVE_STATUSES.includes(status)) {
             sawActive = true;
             idleStreak = 0;
+            // Progress from the heartbeat, recorded every 5 % so the event
+            // log shows the job advancing without a reader having to poll.
+            const state = connectionManager.getLatestMachineState() as { gcodePrintingInfo?: { progress?: number } } | null;
+            const raw = state && state.gcodePrintingInfo ? Number(state.gcodePrintingInfo.progress) : NaN;
+            if (Number.isFinite(raw)) {
+                const percent = Math.round((raw <= 1 ? raw * 100 : raw));
+                if (percent >= lastProgress + 5) {
+                    lastProgress = percent;
+                    jobManager.appendEvent(job, 'progress', { percent, machineStatus: status });
+                }
+            }
             return;
         }
         if (status === 'idle') {
@@ -156,8 +180,12 @@ function watchFileJobCompletion(job: McpJob): void {
                 clearInterval(timer);
                 job.state = 'completed';
                 job.endedAt = Date.now();
+                jobManager.appendEvent(job, 'completed', {
+                    note: `heartbeat idle for ${idleStreak}s${sawActive ? '' : ' (job too short for an active heartbeat to be observed)'}`,
+                });
                 log.info(`MCP file job ${job.id} completed: heartbeat idle for ${idleStreak}s`
                     + `${sawActive ? '' : ' (job too short for an active heartbeat to be observed)'}`);
+                release();
             }
             return;
         }
@@ -283,10 +311,16 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 }
                 job.state = 'started';
                 job.startedAt = Date.now();
+                jobManager.appendEvent(job, 'started', { note: 'procedure runner started' });
+                jobManager.setActive(job);
                 try {
                     const outcome = await job.runner();
+                    // On the record first: a client that timed out waiting here
+                    // still finds the result in get_gcode_job_status.
+                    job.result = outcome;
                     job.state = 'completed';
                     job.endedAt = Date.now();
+                    jobManager.appendEvent(job, 'completed', { note: 'procedure finished; result stored on the job' });
                     return {
                         job: jobManager.describe(job),
                         result: outcome,
@@ -294,7 +328,11 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 } catch (err) {
                     job.state = 'start_failed';
                     job.error = err.message;
+                    job.endedAt = Date.now();
+                    jobManager.appendEvent(job, 'failed', { note: err.message });
                     throw err;
+                } finally {
+                    jobManager.setActive(null);
                 }
             }
 
@@ -324,23 +362,33 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                         return trimmed.length > 0 && !trimmed.startsWith(';');
                     })
                     .join('\n');
-                const executed = await sendGcodeVisible(channel as GcodeChannel, `direct:${job.name}`, executable);
-                if (executed.result !== 0) {
-                    job.state = 'start_failed';
-                    job.error = `Controller rejected the move: ${executed.text || executed.result}`;
-                    throw new McpToolError(job.error);
-                }
-                const shouldWait = args.wait_until_moved !== undefined
-                    ? args.wait_until_moved !== false
-                    : job.waitUntilMoved !== false;
-                const settle = !shouldWait
-                    ? {
-                        position: null,
-                        verified: false,
-                        warning: 'wait_until_moved was false: the move was accepted but not awaited - '
-                            + 'poll get_position (or query_firmware_position) before relying on position.',
+                jobManager.appendEvent(job, 'started', { note: isBatch ? `direct step ${job.nextStep + 1}/${job.steps.length}` : 'direct move' });
+                jobManager.setActive(job);
+                let settle;
+                try {
+                    const executed = await sendGcodeVisible(channel as GcodeChannel, `direct:${job.name}`, executable);
+                    if (executed.result !== 0) {
+                        job.state = 'start_failed';
+                        job.error = `Controller rejected the move: ${executed.text || executed.result}`;
+                        job.endedAt = Date.now();
+                        jobManager.appendEvent(job, 'failed', { note: job.error });
+                        throw new McpToolError(job.error);
                     }
-                    : await waitForStableHeartbeat(issuedAt, parseZTarget(executable));
+                    const shouldWait = args.wait_until_moved !== undefined
+                        ? args.wait_until_moved !== false
+                        : job.waitUntilMoved !== false;
+                    settle = !shouldWait
+                        ? {
+                            position: null,
+                            verified: false,
+                            warning: 'wait_until_moved was false: the move was accepted but not awaited - '
+                                + 'poll get_position (or query_firmware_position) before relying on position.',
+                        }
+                        : await waitForStableHeartbeat(issuedAt, parseZTarget(executable));
+                    jobManager.appendEvent(job, 'settled', { position: settle.position, verified: settle.verified });
+                } finally {
+                    jobManager.setActive(null);
+                }
                 if (isBatch) {
                     job.nextStep += 1;
                     if (job.nextStep < job.steps.length) {
@@ -361,6 +409,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 }
                 job.state = 'completed';
                 job.endedAt = Date.now();
+                jobManager.appendEvent(job, 'completed', { note: 'direct move(s) done' });
                 return {
                     job: jobManager.describe(job),
                     position: settle.position,
@@ -379,24 +428,32 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             if (uploadError) {
                 job.state = 'start_failed';
                 job.error = `Upload failed: ${uploadError}`;
+                job.endedAt = Date.now();
+                jobManager.appendEvent(job, 'failed', { note: job.error });
                 throw new McpToolError(job.error);
             }
+            jobManager.appendEvent(job, 'uploaded', { note: `${job.name}.nc uploaded to the machine` });
 
             const started = await channel.startGcodeJob();
             if (!started.ok) {
                 job.state = 'start_failed';
                 job.error = `Start failed: ${started.text || started.code || 'unknown error'}`;
+                job.endedAt = Date.now();
+                jobManager.appendEvent(job, 'failed', { note: job.error });
                 throw new McpToolError(job.error);
             }
 
             job.state = 'started';
             job.startedAt = Date.now();
+            jobManager.appendEvent(job, 'started', { note: 'machine interpreter running the file (door interlock applies)' });
+            jobManager.setActive(job);
             watchFileJobCompletion(job);
             return {
                 job: jobManager.describe(job),
-                note: 'Job started. Poll get_gcode_job_status; the controller, its door interlock '
-                    + 'and the machine UI remain in control. The job is marked completed when the '
-                    + 'heartbeat settles back to idle.',
+                note: 'Job started. Poll get_gcode_job_status with wait_ms to long-poll for progress '
+                    + 'events and completion (no need to read server logs); the controller, its door '
+                    + 'interlock and the machine UI remain in control. The job is marked completed when '
+                    + 'the heartbeat settles back to idle.',
             };
         },
     });
@@ -563,23 +620,52 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
 
     registry.register({
         name: 'get_gcode_job_status',
-        description: 'Job record plus live progress from the machine heartbeat. Read-only.',
+        description: 'Job record, its event log (state changes, runner phases, gcode traffic while '
+            + 'active, file-job progress), the stored procedure result, and live machine progress. '
+            + 'LONG-POLL: pass wait_ms (up to 120000) and it returns as soon as the job reaches a '
+            + 'terminal state or new events arrive past since_event - use this instead of tight '
+            + 'polling or reading server logs. Read-only.',
         inputSchema: {
             type: 'object',
             properties: {
                 job_id: { type: 'string' },
+                wait_ms: {
+                    type: 'number',
+                    description: 'Block up to this long (0-120000) for a terminal state or new events. Default 0 = return now.',
+                },
+                since_event: {
+                    type: 'number',
+                    description: 'Return only events at index >= this (the previous response\'s next_event_index); '
+                        + 'new events past it also end a wait early. Default 0 = all events.',
+                },
             },
             required: ['job_id'],
             additionalProperties: false,
         },
-        handler: async (args: { job_id?: string }) => {
+        handler: async (args: { job_id?: string; wait_ms?: number; since_event?: number }) => {
             const job = jobManager.get(String(args.job_id || ''));
             if (!job) {
                 throw new McpToolError('Unknown job_id.');
             }
+            const waitMs = Math.min(Math.max(Number(args.wait_ms) || 0, 0), 120000);
+            const since = Math.max(0, Math.floor(Number(args.since_event) || 0));
+            const startedWaiting = Date.now();
+            let timedOut = false;
+            while (!jobManager.isTerminal(job) && job.events.length <= since) {
+                if (Date.now() - startedWaiting >= waitMs) {
+                    timedOut = waitMs > 0;
+                    break;
+                }
+                await sleep(Math.min(250, waitMs - (Date.now() - startedWaiting)));
+            }
             const state = connectionManager.getLatestMachineState();
             return {
                 job: jobManager.describe(job),
+                result: job.result,
+                events: job.events.slice(since),
+                next_event_index: job.events.length,
+                waited_ms: Date.now() - startedWaiting,
+                timed_out: timedOut,
                 machineStatus: machineStatus(),
                 printingInfo: state ? ((state as { gcodePrintingInfo?: object }).gcodePrintingInfo || null) : null,
                 reportAgeMs: state ? Date.now() - state.timestamp : null,
@@ -611,6 +697,10 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             if (stopped.ok) {
                 job.state = 'stopped';
                 job.endedAt = Date.now();
+                jobManager.appendEvent(job, 'stopped', { note: `stop sent by the agent${stopped.text ? `: ${stopped.text}` : ''}` });
+                if (jobManager.getActive() === job) {
+                    jobManager.setActive(null);
+                }
             }
             return {
                 ok: stopped.ok,

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -315,7 +315,7 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
         inputSchema: {
             type: 'object',
             properties: {
-                pitch_mm: { type: 'number', description: 'Grid spacing, default 80 (40-160).' },
+                pitch_mm: { type: 'number', description: 'MAXIMUM grid spacing, default 80 (20-160). Each axis span is divided into equal steps no larger than this, so rows and columns are uniform and both edges are covered - no fixed-pitch stub at the far end.' },
                 margin_mm: { type: 'number', description: 'Inset from the default bounds, default 10.' },
                 x_min: { type: 'number', description: 'Machine-coord grid bounds. Defaults: margin..(size-margin).' },
                 x_max: { type: 'number', description: 'Set beyond the nominal size to cover reachable overtravel (e.g. the far-X column the camera angle otherwise misses - setup-specific, so state it explicitly).' },
@@ -357,14 +357,15 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
             if (!size) {
                 throw new McpToolError('Unknown machine size; cannot plan the grid.');
             }
-            const pitch = Math.min(Math.max(Number(args.pitch_mm) || 80, 40), 160);
+            const pitch = Math.min(Math.max(Number(args.pitch_mm) || 80, 20), 160);
             const margin = Math.min(Math.max(Number(args.margin_mm) || 10, 0), 50);
 
             // Serpentine at the current Z. Bounds are explicit (clamped to the
-            // direct-move envelope) and BOTH endpoints are always covered - a
-            // pitch that undershoots gets a final row/column at the far edge,
-            // because what the camera sees at the extremes is setup-specific
-            // and the far reach is often the only view of its region.
+            // direct-move envelope) and BOTH endpoints are always covered.
+            // Each axis is divided EVENLY into steps no larger than the pitch
+            // (operator, 2026-09-05: the old fixed pitch gave 80 mm jumps and
+            // then a 9-10 mm stub at the far edge - uneven coverage on both
+            // axes); the far reach is often the only view of its region.
             const clampAxis = (value: number, max: number) => Math.min(Math.max(value, -25), max + 40);
             const bounds = {
                 xMin: clampAxis(args.x_min !== undefined ? Number(args.x_min) : margin, size.x),
@@ -375,18 +376,20 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
             if (!(bounds.xMax > bounds.xMin) || !(bounds.yMax > bounds.yMin)) {
                 throw new McpToolError('Survey bounds are empty after clamping; check x/y min/max.');
             }
-            const axisPoints = (min: number, max: number): number[] => {
+            const axisPoints = (min: number, max: number): { points: number[]; step: number } => {
+                const span = max - min;
+                const intervals = Math.max(1, Math.ceil(span / pitch - 1e-9));
+                const step = span / intervals;
                 const points: number[] = [];
-                for (let value = min; value <= max + 1e-9; value += pitch) {
-                    points.push(Number(value.toFixed(1)));
+                for (let i = 0; i <= intervals; i++) {
+                    points.push(Number((min + (step * i)).toFixed(1)));
                 }
-                if (points[points.length - 1] < max - 1) {
-                    points.push(Number(max.toFixed(1)));
-                }
-                return points;
+                return { points, step: Number(step.toFixed(2)) };
             };
-            const xs = axisPoints(bounds.xMin, bounds.xMax);
-            const ys = axisPoints(bounds.yMin, bounds.yMax);
+            const xAxis = axisPoints(bounds.xMin, bounds.xMax);
+            const yAxis = axisPoints(bounds.yMin, bounds.yMax);
+            const xs = xAxis.points;
+            const ys = yAxis.points;
             const waypoints: { x: number; y: number }[] = [];
             ys.forEach((wy, row) => {
                 const ordered = row % 2 === 0 ? xs : [...xs].reverse();
@@ -394,7 +397,7 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
             });
 
             const envelope = [
-                `; BED SURVEY: ${waypoints.length} waypoints on a ${pitch} mm serpentine grid at CURRENT machine Z ${z.toFixed(1)}`,
+                `; BED SURVEY: ${waypoints.length} waypoints, serpentine grid step X ${xAxis.step} / Y ${yAxis.step} mm (max ${pitch}) at CURRENT machine Z ${z.toFixed(1)}`,
                 '; one frame captured per waypoint after the move settles; frames saved to disk with a',
                 '; machine-position index. Each line is sent individually. Aborts on the first capture failure.',
                 'G90',
@@ -447,7 +450,7 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
             return {
                 job: jobManager.describe(job),
                 waypoints: waypoints.length,
-                grid: { pitch_mm: pitch, machine_z: z, columns: xs.length, rows: ys.length },
+                grid: { max_pitch_mm: pitch, step_x_mm: xAxis.step, step_y_mm: yAxis.step, xs, ys, machine_z: z, columns: xs.length, rows: ys.length },
                 confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
                 next_step: 'Ask the operator to open confirm_url, check the Z clears everything on the '
                     + 'bed (rotary included), and approve. start_gcode_job then drives the whole grid '


### PR DESCRIPTION
Stacked on `mcp/41-sensor-toggles-lan`.

- **Job event log + stored result**: every job records state changes, runner phase announcements and probe-feed readings/alarms broadcast while it is the active job, gcode sent/replies, and file-job progress (every 5 %); procedure outcomes are stored as `job.result` so a client timeout on `start_gcode_job` no longer loses them.
- **Long-poll status**: `get_gcode_job_status` takes `wait_ms` (≤120 s) and `since_event`, returning as soon as the job is terminal or new events arrive — one call replaces a polling loop, and nobody needs the server log.
- **Even survey grid**: `survey_bed`'s `pitch_mm` is now a maximum; each axis is divided into equal steps (min 20) so rows/columns are uniform with both edges covered — no more 80 mm jumps followed by a 10 mm stub (surveys 25c4f87a / b123d156). Response reports the effective step per axis and the coordinates.
- README + `cnc-probing` skill updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
