### PR TITLE
Fix: origin-offset transient aborted a verified march; procedures run detached

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -129,7 +129,9 @@ the whole story: `job.state` (+ `terminal`), the procedure `result` once stored,
 job was active, file-job progress every 5 %. Long-poll it: `wait_ms: 60000` returns as soon
 as the state turns terminal or new events arrive past `since_event` (pass back
 `next_event_index`), so one call replaces a polling loop. `start_gcode_job` on a procedure
-still returns the result directly; if that call times out, the result is on the record.
+waits up to `wait_ms` (default 25 s) and returns the result if it arrived, otherwise a
+`running: true` status - the runner keeps going on the server; long-poll for the result,
+never resubmit. If your MCP client times out anyway, the result is still on the record.
 
 `survey_bed`'s `pitch_mm` is a MAXIMUM: each axis is divided evenly into steps no larger
 than it (min 20), so rows and columns are uniform and both edges are covered — no more 80 mm

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -251,6 +251,15 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
   emergency stop; MCP direct single-command ops do NOT.
 - Heartbeat period ~1 s; a settled-looking heartbeat can predate the motion (hence the
   verified-settle contract). `query_firmware_position` (M114) is the authoritative check.
+- **Origin-offset transient (2026-09-05, job 44abebd9bab3)**: the SSTP status poll rebuilds
+  `originOffset` from `offsetX/Y/Z` on every beat, and a beat inside a move's `G53…G54`
+  window can carry none — `getPositionSnapshot` used to fall through to zero and reframe
+  machine coordinates as work coordinates ((170, 199, 240) read as (119, 77, −88)), which
+  aborted a probe_sequence march re-check after every step had verifiably settled. Now a
+  missing offset reuses the last complete one (`originOffsetSource: cached`, with a
+  warning), and position re-checks re-read once after a heartbeat period before aborting.
+  This session's work origin sat at machine (51, 122, 328) — negative offsets in the
+  heartbeat; `machine = work − originOffset` holds.
 - Camera is **toolhead-mounted** (rides X/Z; the platform moves under it in Y): pixel→mm
   calibration is keyed by machine Y AND Z. The board-viewing anchor pose is the pre-home
   park (machine X0/Y0), not machine home. The **gold cylinder at machine Y≈176–340 is the
@@ -309,8 +318,9 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
 `get_connection_status` · `get_machine_profile` (kinematics, module offsets) ·
 `get_position` (both frames, warnings on incoherent reporting) ·
 `query_firmware_position` (raw M114) · `validate_gcode` · `submit_gcode_job` →
-`start_gcode_job` → `get_gcode_job_status` (event log + stored result; long-poll with
-`wait_ms`/`since_event`) / `stop_gcode_job` · `move_z` (single or
+`start_gcode_job` (procedures run detached: returns the result if it arrives within
+`wait_ms`, default 25 s, else a `running` status) → `get_gcode_job_status` (event log +
+stored result; long-poll with `wait_ms`/`since_event`) / `stop_gcode_job` · `move_z` (single or
 `z_targets` batch) · `home` · `goto_work_origin` · `move_and_capture` · `list_cameras` ·
 `capture_frame` (position-stamped, `frameId`, `expectedToolRegion`) · `set_tool_region` ·
 `track_feature` (NCC between cached frames — use instead of eyeballing pixels) ·

--- a/src/server/services/mcp/probeSequence.ts
+++ b/src/server/services/mcp/probeSequence.ts
@@ -227,7 +227,7 @@ export function describeProbeSequencePlanAsGcode(plan: ProbeSequencePlan): strin
             lines.push(`G1 X${step.x.toFixed(3)} Y${step.y.toFixed(3)} F${TRAVEL_FEED}; hop`);
         } else if (step.kind === 'descend') {
             lines.push(`G1 Z${(step.z + DESCENT_GUARD_MM).toFixed(3)} F${TRAVEL_FEED}; descend fast to ${DESCENT_GUARD_MM} mm above target`);
-            lines.push(`; ...guarded final approach (operator, 2026-09-02): 1 mm steps, sensor-checked after each -`);
+            lines.push('; ...guarded final approach (operator, 2026-09-02): 1 mm steps, sensor-checked after each -');
             lines.push('; ANY contact during a descent aborts and latches the CRASH alarm.');
             for (let gz = step.z + DESCENT_GUARD_MM - 1; gz > step.z - 1e-9; gz -= 1) {
                 const zz = Math.max(gz, step.z);
@@ -259,6 +259,10 @@ export function describeProbeSequencePlanAsGcode(plan: ProbeSequencePlan): strin
     lines.push('G54;');
     return lines.join('\n');
 }
+
+const sleep = async (ms: number) => new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+});
 
 export async function runProbeSequenceProcedure(plan: ProbeSequencePlan): Promise<object> {
     assertChannelReady('probe', 'probe sequence');
@@ -319,14 +323,30 @@ export async function runProbeSequenceProcedure(plan: ProbeSequencePlan): Promis
                 announce(`descend-${stepIndex}`, `Z${step.z} (guarded final ${DESCENT_GUARD_MM} mm)`);
             } else {
                 // Re-verify the walk matches the simulation before marching.
-                const now = getPositionSnapshot().machine;
-                if (now.x === null || now.y === null || now.z === null
-                    || Math.abs(now.x - step.start.x) > 0.5
-                    || Math.abs(now.y - step.start.y) > 0.5
-                    || Math.abs(now.z - step.start.z) > 0.5) {
-                    throw new ProcedureAbort(`March "${step.name}": machine at `
-                        + `(${now.x}, ${now.y}, ${now.z}) but the plan expects `
-                        + `(${step.start.x}, ${step.start.y}, ${step.start.z}).`);
+                // Every preceding move already verified its own arrival, so a
+                // mismatch here is either real drift or a transient heartbeat
+                // (a beat inside a G53...G54 window reporting no/zero origin
+                // offset - job 44abebd9bab3, 2026-09-05). Re-read once after a
+                // heartbeat period before believing it.
+                const expected = step.start;
+                const matches = (p: { x: number | null; y: number | null; z: number | null }) => (
+                    p.x !== null && p.y !== null && p.z !== null
+                    && Math.abs(p.x - expected.x) <= 0.5
+                    && Math.abs(p.y - expected.y) <= 0.5
+                    && Math.abs(p.z - expected.z) <= 0.5
+                );
+                let snapshot = getPositionSnapshot();
+                if (!matches(snapshot.machine)) {
+                    const first = snapshot;
+                    await sleep(1200);
+                    snapshot = getPositionSnapshot();
+                    if (!matches(snapshot.machine)) {
+                        const fmt = (s: typeof snapshot) => `(${s.machine.x}, ${s.machine.y}, ${s.machine.z}) [work (${s.work.x}, ${s.work.y}, ${s.work.z}), offset (${s.originOffset.x}, ${s.originOffset.y}, ${s.originOffset.z}) from ${s.originOffsetSource}]`;
+                        throw new ProcedureAbort(`March "${step.name}": machine at ${fmt(snapshot)} `
+                            + `(first read ${fmt(first)}) but the plan expects `
+                            + `(${expected.x}, ${expected.y}, ${expected.z}).`);
+                    }
+                    announce(`recheck-${stepIndex}`, 'position re-check passed on the second heartbeat (first read was transient)');
                 }
                 probeFeedService.setExpectedContact(['probe']);
                 const move = async (tool: string, s: number, feed: number) => {

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -119,6 +119,9 @@ const sleep = async (ms: number) => new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
 });
 
+// How long start_gcode_job waits for a procedure before handing off to
+// get_gcode_job_status long-polling (well inside typical MCP client timeouts).
+const PROCEDURE_START_WAIT_MS = 25000;
 const FILE_JOB_POLL_MS = 1000;
 const FILE_JOB_IDLE_DEBOUNCE_POLLS = 3;
 const FILE_JOB_NEVER_SEEN_ACTIVE_IDLE_POLLS = 20;
@@ -266,6 +269,10 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             type: 'object',
             properties: {
                 job_id: { type: 'string' },
+                wait_ms: {
+                    type: 'number',
+                    description: 'Procedure jobs only: how long to wait for the result before returning a running status (0-120000, default 25000). The runner continues either way; long-poll get_gcode_job_status.',
+                },
                 confirm_token: { type: 'string', description: 'One-time code from the operator.' },
                 wait_until_moved: {
                     type: 'boolean',
@@ -277,7 +284,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
             required: ['job_id', 'confirm_token'],
             additionalProperties: false,
         },
-        handler: async (args: { job_id?: string; confirm_token?: string; wait_until_moved?: boolean }) => {
+        handler: async (args: { job_id?: string; confirm_token?: string; wait_until_moved?: boolean; wait_ms?: number }) => {
             probeFeedService.assertNoOvertravel();
             const job = jobManager.get(String(args.job_id || ''));
             if (!job) {
@@ -313,27 +320,55 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 job.startedAt = Date.now();
                 jobManager.appendEvent(job, 'started', { note: 'procedure runner started' });
                 jobManager.setActive(job);
-                try {
-                    const outcome = await job.runner();
-                    // On the record first: a client that timed out waiting here
-                    // still finds the result in get_gcode_job_status.
-                    job.result = outcome;
-                    job.state = 'completed';
-                    job.endedAt = Date.now();
-                    jobManager.appendEvent(job, 'completed', { note: 'procedure finished; result stored on the job' });
+                // The runner is DETACHED from this request: a tool setter or
+                // probe circuit runs for minutes, longer than MCP clients wait
+                // (timeouts seen live 2026-09-04/05), and a client giving up
+                // must never abandon the machine mid-procedure or lose the
+                // result. The outcome lands on the job record; this call waits
+                // a bounded time and returns the result if it arrived, else a
+                // "running" status to long-poll with get_gcode_job_status.
+                const finished = job.runner()
+                    .then((outcome) => {
+                        job.result = outcome;
+                        job.state = 'completed';
+                        job.endedAt = Date.now();
+                        jobManager.appendEvent(job, 'completed', { note: 'procedure finished; result stored on the job' });
+                        return { ok: true as const, outcome };
+                    })
+                    .catch((err: Error) => {
+                        job.state = 'start_failed';
+                        job.error = err.message;
+                        job.endedAt = Date.now();
+                        jobManager.appendEvent(job, 'failed', { note: err.message });
+                        log.error(`Procedure job ${job.id} failed: ${err.message}`);
+                        return { ok: false as const, error: err.message };
+                    })
+                    .finally(() => {
+                        if (jobManager.getActive() === job) {
+                            jobManager.setActive(null);
+                        }
+                    });
+                const waitMs = Math.min(Math.max(Number(args.wait_ms) || PROCEDURE_START_WAIT_MS, 0), 120000);
+                const settledInTime = await Promise.race([
+                    finished,
+                    sleep(waitMs).then(() => null),
+                ]);
+                if (settledInTime === null) {
                     return {
                         job: jobManager.describe(job),
-                        result: outcome,
+                        running: true,
+                        note: `The procedure is still running after ${waitMs} ms and continues on the server. `
+                            + 'Long-poll get_gcode_job_status (wait_ms up to 120000, since_event) for phases and '
+                            + 'the result; do not resubmit.',
                     };
-                } catch (err) {
-                    job.state = 'start_failed';
-                    job.error = err.message;
-                    job.endedAt = Date.now();
-                    jobManager.appendEvent(job, 'failed', { note: err.message });
-                    throw err;
-                } finally {
-                    jobManager.setActive(null);
                 }
+                if (!settledInTime.ok) {
+                    throw new McpToolError(settledInTime.error);
+                }
+                return {
+                    job: jobManager.describe(job),
+                    result: settledInTime.outcome,
+                };
             }
 
             if (job.kind === 'direct') {

--- a/src/server/services/mcp/tools/machine.ts
+++ b/src/server/services/mcp/tools/machine.ts
@@ -116,6 +116,7 @@ export interface PositionSnapshot {
     work: { x: number | null; y: number | null; z: number | null };
     machine: { x: number | null; y: number | null; z: number | null };
     originOffset: { x: number; y: number; z: number };
+    originOffsetSource: 'heartbeat' | 'cached' | 'assumed-zero';
     b: number | null;
     isFourAxis: boolean;
     isHomed: boolean | null;
@@ -153,6 +154,8 @@ export function assertFreshHeartbeat(what: string): void {
  * Position from the latest heartbeat, shared by get_position and the
  * capture tools. Throws McpToolError when unavailable.
  */
+let lastKnownOriginOffset: { x: number; y: number; z: number; at: number } | null = null;
+
 export function getPositionSnapshot(): PositionSnapshot {
     const status = connectionManager.getConnectionStatus();
     if (!status.connected) {
@@ -174,11 +177,38 @@ export function getPositionSnapshot(): PositionSnapshot {
         y: axisValue(pos.y),
         z: axisValue(pos.z),
     };
-    const offset = {
-        x: axisValue(originOffset.x) || 0,
-        y: axisValue(originOffset.y) || 0,
-        z: axisValue(originOffset.z) || 0,
+    const warnings: string[] = [];
+    // The SSTP status poll rebuilds originOffset from data.offsetX/Y/Z on
+    // every beat. A beat that lands inside a move's G53...G54 window (or any
+    // beat the firmware sends without offsets) used to fall through `|| 0`
+    // and silently reframe machine coordinates as work coordinates - which
+    // aborted a probe_sequence march re-check on 2026-09-05 (job
+    // 44abebd9bab3: settled at machine (170,199,240), re-check read
+    // (119,77,-88)). Missing offsets now reuse the last complete offset seen
+    // on this connection and say so; callers that verify position should
+    // re-read once when a check fails (see probeSequence).
+    const reported = {
+        x: axisValue(originOffset.x),
+        y: axisValue(originOffset.y),
+        z: axisValue(originOffset.z),
     };
+    let offsetSource: 'heartbeat' | 'cached' | 'assumed-zero' = 'heartbeat';
+    let offset: { x: number; y: number; z: number };
+    if (reported.x !== null && reported.y !== null && reported.z !== null) {
+        offset = { x: reported.x, y: reported.y, z: reported.z };
+        lastKnownOriginOffset = { ...offset, at: state.timestamp };
+    } else if (lastKnownOriginOffset) {
+        offset = { x: lastKnownOriginOffset.x, y: lastKnownOriginOffset.y, z: lastKnownOriginOffset.z };
+        offsetSource = 'cached';
+        warnings.push('The latest heartbeat carried no work-origin offset; machine coordinates use the '
+            + `last complete offset (${offset.x}, ${offset.y}, ${offset.z}) seen ${((state.timestamp - lastKnownOriginOffset.at) / 1000).toFixed(1)}s earlier. `
+            + 'Re-read before trusting a position check.');
+    } else {
+        offset = { x: reported.x || 0, y: reported.y || 0, z: reported.z || 0 };
+        offsetSource = 'assumed-zero';
+        warnings.push('No work-origin offset has been reported on this connection yet; machine coordinates '
+            + 'ASSUME a zero offset and may be wrong - query_firmware_position and re-verify.');
+    }
     const machine = {
         x: work.x === null ? null : work.x - offset.x,
         y: work.y === null ? null : work.y - offset.y,
@@ -189,7 +219,6 @@ export function getPositionSnapshot(): PositionSnapshot {
     // reporting positions in an unselected workspace, so derived machine
     // coordinates land outside the build volume (e.g. Z 656 on a 325 mm
     // machine). Flag it rather than let an agent trust it.
-    const warnings: string[] = [];
     const reportAgeMs = Date.now() - state.timestamp;
     if (reportAgeMs > HEARTBEAT_STALE_MS) {
         warnings.push(`STALE: the last heartbeat is ${(reportAgeMs / 1000).toFixed(0)}s old `
@@ -217,6 +246,7 @@ export function getPositionSnapshot(): PositionSnapshot {
         work,
         machine,
         originOffset: offset,
+        originOffsetSource: offsetSource,
         b: axisValue(pos.b),
         isFourAxis: !!pos.isFourAxis,
         isHomed: (state as { isHomed?: boolean }).isHomed ?? null,


### PR DESCRIPTION
Stacked on `mcp/42-job-events-even-survey`.

- **Origin-offset transient**: `probe_sequence` job 44abebd9bab3 settled every step at machine (170, 199, 240) (controller echo work (119, 77, −88), work origin at machine (51, 122, 328)) and then aborted its march re-check "at (119, 77, −88)". The SSTP status poll rebuilds `originOffset` from `offsetX/Y/Z` each beat; a beat inside a move's `G53…G54` window carries none, and `getPositionSnapshot` fell through `|| 0`, reframing machine coordinates as work coordinates. Missing offsets now reuse the last complete offset on the connection (`originOffsetSource: cached`, warned; `assumed-zero` only before any offset was ever seen), and the runner's re-check re-reads once after a heartbeat period before aborting — with work/offset/source in the message.
- **Procedures run detached**: `start_gcode_job` no longer holds the request for the whole runner (minutes → MCP client timeouts, seen twice). The outcome always lands on the job record; the call waits `wait_ms` (default 25 s, max 120 s) and returns the result or a `running` status to long-poll via `get_gcode_job_status`.
- README machine facts + `cnc-probing` skill updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
