### PR TITLE
Feature: Surface flatness scans - probe_surface_path and probe_surface_grid

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cnc-probing
-description: "Measure work with the spindle touch probe and the whole-bed camera survey via the Luban MCP tools (probe_point, survey_bed, run_tool_setter with accept_probe_contact) — including the motion laws written in the aftermath of a probe-destroying crash. Use whenever the user wants to probe stock, find surfaces/edges, survey the bed, or calibrate the touch probe."
+description: "Measure work with the spindle touch probe and the whole-bed camera survey via the Luban MCP tools (probe_point, probe_vector, probe_sequence, probe_circle, probe_surface_path/grid flatness scans, survey_bed, run_tool_setter with accept_probe_contact) — including the motion laws written in the aftermath of a probe-destroying crash. Use whenever the user wants to probe stock, find surfaces/edges, check flatness or map a surface height, survey the bed, or calibrate the touch probe."
 ---
 
 # CNC probing: the probe, the survey, and the motion laws
@@ -149,6 +149,57 @@ inseparable unless one is known. Direction-dependent residuals expose an
 out-of-round tip (the post-unbending health check). Repositioning between
 points obeys law 2 in full: lift to the safe traverse height, hop, descend;
 a probe touch during a hop or descent latches the CRASH alarm.
+
+## Surface flatness and height maps
+
+Two staged procedures measure a TOP surface with many −Z marches under ONE
+operator approval; every commanded move is enumerated on the confirm page,
+all numbers are machine coordinates, and every contact Z is TOOLHEAD Z (the
+surface is that minus the probe length).
+
+- `probe_surface_path` — N stations along a straight line (`start_x/start_y`
+  plus `end_x/end_y` or `dx/dy` + `length_mm`; sampled by `stations` count or a
+  MAXIMUM `spacing_mm`). Use it for "is this stock level along Y", "how much
+  does the board rise toward the free end", a rotary-mounted flat. Result:
+  per-station XYZ (or `no_contact`), Z min/max/range, best-fit line slope (mm
+  per 100 mm and degrees, rise over the length), flatness = residual
+  peak-to-valley, a text profile.
+- `probe_surface_grid` — a serpentine grid over a region (`x_min..y_max` or
+  `center_x/center_y` + `size_x_mm[/size_y_mm]`; sampled by a MAXIMUM `pitch_mm`
+  or `x_count/y_count`, max 400 stations). Use it for a wasteboard, a pocketed
+  box, a log — anything whose height varies in two directions. Result:
+  `zMatrix` (rows = ys ascending, cols = xs ascending, null = no contact),
+  best-fit plane (tilt X/Y) with per-point residuals and flatness, and a text
+  `heightMap` printed with +Y at the top like the bed seen from above.
+
+`start_z_machine` is REQUIRED for both: the toolhead machine Z at which the
+first march starts with the tip just above the surface — measured (an earlier
+`probe_point -Z`, a previous scan) or operator-stated, never inferred from a
+photo (law 3). The runner reaches it law-2 style: raise to the traverse height,
+hop at gantry height to station 1, then a guarded 1 mm descent where any
+contact latches CRASH.
+
+**The envelope (operator law, 2026-09-05)** — the ONLY exception to motion law
+2, valid inside these two procedures only, between consecutive stations only.
+The operator's words: "no more than 20mm z safe delta from the top (within a
+horizontal change of 60mm)".
+
+| Parameter | Default | Hard limit | Meaning |
+|---|---|---|---|
+| `z_safe_delta_mm` | 20 | **cap 20**, min 3 | After each station the probe retracts to LAST CONTACT + this and hops at that height. |
+| `max_hop_mm` | 60 | **cap 60** | Largest allowed distance between consecutive stations. A spacing/pitch that breaks it is REFUSED at staging, naming the pair — pick a finer pitch; nothing is split for you. |
+| `max_drop_mm` | 40 | cap 80 | How far below the previous real contact a station may search. Also bounded by `floor_z_machine` (default `start_z_machine − max_drop_mm`), the deepest Z the scan can ever command — shown on the confirm page. |
+
+Reaching the floor without contact records the station `no_contact` and the
+scan CONTINUES with the reference height unchanged (a pocket, a hole, an edge
+overshoot); the first station finding nothing aborts. Hops run in ≤ 10 mm
+sensor-checked segments expecting NO contact — a touch during a hop means the
+surface rose more than `z_safe_delta_mm` and latches the CRASH alarm (law 5).
+Completion and abort both raise to the traverse height. Never ask for the caps
+to be widened and never approximate a scan with `probe_sequence` hops at a
+"measured safe" height — that is exactly what law 2 forbids. On the GPIO
+transport, `sensor_delay_ms: 50` and `coarse_step_mm: 2` on a known-flat surface
+roughly halve the time per station.
 
 ## Bed survey
 

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -95,6 +95,10 @@ mcp/
   gpioFeed.ts    GPIO backend: Blinka/U2IF python monitor subprocess (embedded
                  source, JSON lines: ready|reading|hb|fatal), stall watchdog
   toolSetter.ts  tool height measurement: config, envelope planner, staged runner
+  probing.ts     shared sensor-gated motion engine (moveMachineSettled, senseAfter, guards)
+  probeTool.ts / probeVector.ts / probeSequence.ts / probeCircle.ts   staged probe procedures
+  surfaceScan.ts pure station planning + flatness statistics (no imports; unit-tested alone)
+  probeSurface.ts probe_surface_path / probe_surface_grid plan builders + runner
   tools/         status, machine, gcode, camera, calibration, probe, toolsetter
 ```
 
@@ -200,6 +204,35 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
 8. **The MCP surface is the only interface** — no agent may touch the machine, its
    configstore, or the backend APIs directly while the app runs; every guard lives in the
    tools, so bypassing them bypasses all of it.
+
+### Surface scans — the one bounded exception to law 2 (operator-authorised 2026-09-05)
+
+`probe_surface_path` and `probe_surface_grid` measure a TOP surface with many −Z marches
+in one approved circuit. The operator's words: *"with the grid we need the point to point
+variation to not risk the probe toolhead so no more than 20mm z safe delta from the top
+(within a horizontal change of 60mm)"*. Hence, **inside these two procedures only, between
+consecutive stations only**, the probe retracts to `last contact + z_safe_delta_mm` and hops
+horizontally at that height instead of at the gantry. Nothing else inherits this. Bounds
+(`surfaceScan.ts`, refused at staging — never clamped or split silently):
+
+- `z_safe_delta_mm` default 20, **hard cap 20** (min 3) — the hop height above the last real
+  contact (`resolveEnvelope`).
+- `max_hop_mm` default 60, **hard cap 60** — every consecutive station pair must be within
+  it (`assertHopsWithin`); a spacing/pitch that violates it is refused naming the pair.
+- `max_drop_mm` default 40, cap 80 — a station's march may search at most this far below the
+  previous real contact, and never below `floor_z_machine` (default `start_z_machine −
+  max_drop_mm`, the deepest Z the scan can ever command — on the confirm page). Reaching the
+  floor without contact records the station `no_contact` and continues; the reference height
+  stays the last real contact. The FIRST station finding nothing aborts (no measured
+  reference to base the envelope on).
+- `start_z_machine` is REQUIRED — measured or operator-stated, never guessed. The approach to
+  station 1 is a full law-2 move: raise to the traverse height, hop, guarded 1 mm descent
+  (`probe_sequence` pattern; contact = CRASH). Completion and abort both raise to the
+  traverse height.
+- Runtime (`probeSurface.ts`): hops go through `moveMachineSettled` with
+  `clearExpectedContact()` in ≤ 10 mm sensor-checked segments, so a probe touch during a hop
+  latches CRASH (law 5); only marches run with `setExpectedContact(['probe'])`. The staged
+  position and every march start are re-checked (one re-read after ~1.2 s).
 
 ## Safety model (operator-defined, non-negotiable)
 
@@ -313,7 +346,7 @@ it with no decision point, when the operator had authorised "step 1" only. Laws:
   the agent click Approve for one bounded series of moves, that authority ends with that
   series ("no approvals carry forwards in CNC work").
 
-## Tool surface (33)
+## Tool surface (40)
 
 `get_connection_status` · `get_machine_profile` (kinematics, module offsets) ·
 `get_position` (both frames, warnings on incoherent reporting) ·
@@ -344,7 +377,15 @@ and untriggered; `store_as_reference` locks the measured Z in as the new referen
 `stay_at_trigger` / `start_from_current` support the touchscreen swap wizard) ·
 `goto_tool_change_position` (two approved steps: Z up, then X/Y to the operator-set park) ·
 `apply_tool_length_offset` (confirmed G92 shifting work-origin Z by the measured
-new−old tool length difference — flow A only).
+new−old tool length difference — flow A only) · **touch-probe procedures** (all staged,
+one approval per circuit, results in MACHINE coordinates): `probe_point` (one axis from the
+current position) · `probe_vector` (any downward/lateral unit vector) · `probe_sequence`
+(enumerated hop/descend/probe circuit, law-2 hops) · `probe_circle` (N radial marches +
+least-squares fit, outside or inside a hole) · `probe_surface_path` (N −Z stations along a
+line: per-station contact, best-fit line slope, flatness) · `probe_surface_grid` (serpentine
+−Z grid: Z matrix, best-fit plane + residuals, ASCII height map) — the two surface scans hop
+at `last contact + z_safe_delta_mm` (cap 20) within `max_hop_mm` (cap 60), see "Surface
+scans" above · `survey_bed` (camera grid at gantry height).
 
 ## Tool change workflows
 

--- a/src/server/services/mcp/probeSurface.ts
+++ b/src/server/services/mcp/probeSurface.ts
@@ -1,0 +1,701 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention (the plan builders take the
+// probe_surface_path / probe_surface_grid arguments verbatim).
+import { mcpBroadcast } from './index';
+import { probeFeedService } from './probeFeed';
+import { DESCENT_GUARD_MM } from './probeSequence';
+import {
+    COARSE_FEED,
+    FINE_FEED,
+    MAX_RETREAT_MM,
+    ProcedureAbort,
+    TRAVEL_FEED,
+    assertChannelReady,
+    assertMachineReadyForProcedure,
+    moveMachineSettled,
+    senseAfter,
+    senseReleaseAfter,
+    sleep,
+} from './probing';
+import { McpToolError } from './registry';
+import {
+    ContactSample,
+    HOP_SEGMENT_MM,
+    SurfacePlanError,
+    SurfaceStation,
+    assertHopsWithin,
+    buildZMatrix,
+    fitLine,
+    fitPlane,
+    hopSegments,
+    planGridStations,
+    planPathStations,
+    renderHeightMap,
+    renderPathProfile,
+    resolveEnvelope,
+    stationEnvelope,
+    summarizeZ,
+} from './surfaceScan';
+import { getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './tools/machine';
+import { connectionManager } from '../machine/ConnectionManager';
+
+// Top-surface scans with the spindle touch probe: N stations along a line
+// (probe_surface_path) or over a serpentine grid (probe_surface_grid), each
+// measured with a -Z sensor-gated march using the hardware-proven
+// coarse/release/fine/confirm mechanics of probe_vector / probe_sequence.
+// One operator approval covers the whole circuit; the confirm page
+// enumerates every commanded move with concrete numbers.
+//
+// THE LAW-2 EXCEPTION (operator-authorised, 2026-09-05). Motion law 2 says
+// every XY move over 1 mm happens at the safe traverse height. The operator's
+// words for these two procedures: "with the grid we need the point to point
+// variation to not risk the probe toolhead so no more than 20mm z safe delta
+// from the top (within a horizontal change of 60mm)". So, INSIDE THESE TWO
+// PROCEDURES ONLY, between CONSECUTIVE stations only, and only while the
+// horizontal hop is <= max_hop_mm (cap 60), the probe retracts to
+// lastContactZ + z_safe_delta_mm (cap 20) and hops AT THAT HEIGHT instead of
+// at the gantry. Nothing else inherits this: the approach to the FIRST
+// station is a full law-2 traverse (raise to the safe traverse height, hop,
+// guarded descent to the operator-stated start_z_machine), and the scan ends
+// raised at the traverse height. Caps are enforced by refusal at staging
+// (never clamped), the mechanics are enforced at runtime:
+//
+//   - hops run with NO expected contact, through moveMachineSettled (crash
+//     guard armed), in sensor-checked segments of <= HOP_SEGMENT_MM so a
+//     graze is caught within one segment: contact during a hop = collision.
+//   - each march may search down to max(lastContact - max_drop_mm, the
+//     plan's absolute floor); reaching the floor without contact records the
+//     station as no_contact (not an abort) and leaves the reference height
+//     at the last REAL contact. The first station finding nothing aborts -
+//     there would be no measured reference to base the envelope on.
+
+export type SurfaceScanKind = 'path' | 'grid';
+
+export interface ProbeSurfacePlan {
+    kind: SurfaceScanKind;
+    tool: 'probe_surface_path' | 'probe_surface_grid';
+    stations: SurfaceStation[];
+    /** Operator-stated toolhead machine Z at which the FIRST march starts (tip just above the surface). */
+    startZMachine: number;
+    /** Deepest toolhead Z any march may ever command (default start_z - max_drop). */
+    absoluteFloorZ: number;
+    zSafeDeltaMm: number;
+    maxHopMm: number;
+    maxDropMm: number;
+    /** Largest consecutive-station distance in this plan (already verified <= maxHopMm). */
+    worstHopMm: number;
+    /** Safe traverse height: approach to station 1 and the final raise. */
+    hopZ: number;
+    staged: { x: number; y: number; z: number };
+    coarseStepMm: number;
+    fineStepMm: number;
+    backoffMm: number;
+    sensorDelayMs: number;
+    confirmPasses: number;
+    path?: {
+        start: { x: number; y: number };
+        end: { x: number; y: number };
+        unit: { x: number; y: number };
+        lengthMm: number;
+        spacingMm: number;
+    };
+    grid?: {
+        xs: number[];
+        ys: number[];
+        pitchXMm: number;
+        pitchYMm: number;
+        bounds: { xMin: number; xMax: number; yMin: number; yMax: number };
+    };
+}
+
+interface CommonArgs {
+    start_z_machine?: unknown;
+    floor_z_machine?: unknown;
+    z_safe_delta_mm?: unknown;
+    max_hop_mm?: unknown;
+    max_drop_mm?: unknown;
+    coarse_step_mm?: number;
+    fine_step_mm?: number;
+    backoff_mm?: number;
+    sensor_delay_ms?: number;
+    confirm_passes?: number;
+}
+
+function toToolError<T>(fn: () => T): T {
+    try {
+        return fn();
+    } catch (err) {
+        if (err instanceof SurfacePlanError) {
+            throw new McpToolError(err.message);
+        }
+        throw err;
+    }
+}
+
+/** Everything both scans share once the stations exist. */
+function finishPlan(
+    kind: SurfaceScanKind,
+    stations: SurfaceStation[],
+    args: CommonArgs
+): Omit<ProbeSurfacePlan, 'path' | 'grid'> {
+    const env = toToolError(() => resolveEnvelope(args));
+    const worstHopMm = toToolError(() => assertHopsWithin(stations, env.maxHopMm));
+
+    const hopZ = safeTraverseZ();
+    const startZ = Number(args.start_z_machine);
+    if (args.start_z_machine === undefined || !Number.isFinite(startZ)) {
+        throw new McpToolError('start_z_machine is REQUIRED: the toolhead machine Z at which the first -Z march '
+            + 'starts, with the probe tip just above the surface - a measured or operator-stated number, never a guess.');
+    }
+    if (startZ <= 0 || startZ > hopZ) {
+        throw new McpToolError(`start_z_machine ${startZ} must be in 0..${hopZ} (the safe traverse height).`);
+    }
+    const floorZ = args.floor_z_machine === undefined ? startZ - env.maxDropMm : Number(args.floor_z_machine);
+    if (!Number.isFinite(floorZ) || floorZ < 0) {
+        throw new McpToolError('floor_z_machine must be a finite machine Z >= 0.');
+    }
+    if (floorZ >= startZ) {
+        throw new McpToolError(`floor_z_machine ${floorZ} must be below start_z_machine ${startZ}.`);
+    }
+    if (startZ - floorZ > 150) {
+        throw new McpToolError(`start_z_machine - floor_z_machine = ${(startZ - floorZ).toFixed(1)} mm exceeds 150 mm.`);
+    }
+
+    const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+    if (size) {
+        for (const st of stations) {
+            if (st.x < -25 || st.x > size.x + 40 || st.y < -25 || st.y > size.y + 40) {
+                throw new McpToolError(`Station ${st.label} (${st.x}, ${st.y}) is outside the machine envelope.`);
+            }
+        }
+    }
+
+    const position = getPositionSnapshot();
+    const { x, y, z } = position.machine;
+    if (x === null || y === null || z === null) {
+        throw new McpToolError('Current machine position unknown; cannot anchor the scan.');
+    }
+
+    return {
+        kind,
+        tool: kind === 'path' ? 'probe_surface_path' : 'probe_surface_grid',
+        stations,
+        startZMachine: Number(startZ.toFixed(3)),
+        absoluteFloorZ: Number(floorZ.toFixed(3)),
+        zSafeDeltaMm: env.zSafeDeltaMm,
+        maxHopMm: env.maxHopMm,
+        maxDropMm: env.maxDropMm,
+        worstHopMm,
+        hopZ,
+        staged: { x, y, z },
+        coarseStepMm: Math.min(Math.max(Number(args.coarse_step_mm) || 1, 0.2), 2),
+        fineStepMm: Math.min(Math.max(Number(args.fine_step_mm) || 0.1, 0.02), 0.5),
+        backoffMm: Math.min(Math.max(Number(args.backoff_mm) || 1, Number(args.fine_step_mm) || 0.1), 3),
+        sensorDelayMs: Math.min(Math.max(Number(args.sensor_delay_ms) || 300, 100), 10000),
+        confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 3), 1), 10),
+    };
+}
+
+export function planProbeSurfacePath(args: CommonArgs & {
+    start_x?: unknown;
+    start_y?: unknown;
+    end_x?: unknown;
+    end_y?: unknown;
+    dx?: unknown;
+    dy?: unknown;
+    length_mm?: unknown;
+    stations?: unknown;
+    spacing_mm?: unknown;
+}): ProbeSurfacePlan {
+    const path = toToolError(() => planPathStations({
+        start_x: args.start_x,
+        start_y: args.start_y,
+        end_x: args.end_x,
+        end_y: args.end_y,
+        dx: args.dx,
+        dy: args.dy,
+        length_mm: args.length_mm,
+        stations: args.stations,
+        spacing_mm: args.spacing_mm,
+    }));
+    return {
+        ...finishPlan('path', path.stations, args),
+        path: { start: path.start, end: path.end, unit: path.unit, lengthMm: path.lengthMm, spacingMm: path.spacingMm },
+    };
+}
+
+export function planProbeSurfaceGrid(args: CommonArgs & {
+    x_min?: unknown;
+    x_max?: unknown;
+    y_min?: unknown;
+    y_max?: unknown;
+    center_x?: unknown;
+    center_y?: unknown;
+    size_x_mm?: unknown;
+    size_y_mm?: unknown;
+    pitch_mm?: unknown;
+    x_count?: unknown;
+    y_count?: unknown;
+}): ProbeSurfacePlan {
+    const grid = toToolError(() => planGridStations(args));
+    return {
+        ...finishPlan('grid', grid.stations, args),
+        grid: { xs: grid.xs, ys: grid.ys, pitchXMm: grid.pitchXMm, pitchYMm: grid.pitchYMm, bounds: grid.bounds },
+    };
+}
+
+/** Confirm-page gcode: the whole scan, every commanded move enumerated with its bounds. */
+export function describeProbeSurfacePlanAsGcode(plan: ProbeSurfacePlan): string {
+    const n = plan.stations.length;
+    const first = plan.stations[0];
+    let shape = `${n} stations`;
+    if (plan.kind === 'path' && plan.path) {
+        shape = `${n} stations along (${plan.path.start.x}, ${plan.path.start.y}) -> (${plan.path.end.x}, ${plan.path.end.y}), `
+            + `spacing ${plan.path.spacingMm} mm`;
+    } else if (plan.grid) {
+        shape = `${plan.grid.xs.length} x ${plan.grid.ys.length} = ${n} stations, pitch X ${plan.grid.pitchXMm} / Y ${plan.grid.pitchYMm} mm, `
+            + `X ${plan.grid.bounds.xMin}..${plan.grid.bounds.xMax}, Y ${plan.grid.bounds.yMin}..${plan.grid.bounds.yMax}, serpentine`;
+    }
+    const firstEnv = stationEnvelope(plan.startZMachine, true, plan.startZMachine, {
+        zSafeDeltaMm: plan.zSafeDeltaMm, maxDropMm: plan.maxDropMm, absoluteFloorZ: plan.absoluteFloorZ,
+    });
+    // The guarded descent starts at min(start_z + guard, traverse height): the
+    // runner never commands a Z above the height it is already at.
+    const guardTop = Math.min(plan.startZMachine + DESCENT_GUARD_MM, plan.hopZ);
+    const lines = [
+        `; SURFACE ${plan.kind.toUpperCase()} SCAN: ${shape}`,
+        '; every station = a -Z sensor-gated march on the probe channel (coarse to contact, release,',
+        `; ${plan.fineStepMm} mm fine approach, ${plan.confirmPasses} confirm pass(es), median); all coordinates MACHINE frame.`,
+        `; anchored at machine (${plan.staged.x.toFixed(2)}, ${plan.staged.y.toFixed(2)}, ${plan.staged.z.toFixed(2)})`
+            + ' - re-verified before any motion, and before EVERY march',
+        ';',
+        '; ENVELOPE (operator, 2026-09-05: "no more than 20mm z safe delta from the top (within a horizontal',
+        '; change of 60mm)") - the operator-authorised EXCEPTION to motion law 2, valid ONLY inside this',
+        '; procedure, ONLY between consecutive stations, ONLY for hops <= max_hop_mm:',
+        `;   * between stations the probe retracts to LAST CONTACT + ${plan.zSafeDeltaMm} mm (z_safe_delta_mm, cap 20) and hops`,
+        `;     horizontally AT THAT HEIGHT in <= ${HOP_SEGMENT_MM} mm sensor-checked segments - ANY probe contact during a hop`,
+        ';     is a collision: CRASH alarm latches (job stop + connection close), operator clears it.',
+        `;   * largest hop in this plan: ${plan.worstHopMm} mm (max_hop_mm ${plan.maxHopMm}, cap 60) - refused at staging otherwise.`,
+        `;   * each march searches from the hop height down to max(last contact - ${plan.maxDropMm} mm, FLOOR Z${plan.absoluteFloorZ});`,
+        ';     nothing by the floor = station recorded no_contact, reference height unchanged, scan continues',
+        ';     (the FIRST station finding nothing aborts - no measured reference).',
+        `;   * the deepest toolhead Z this scan can EVER command is Z${plan.absoluteFloorZ} (floor_z_machine).`,
+        '; The approach to station 1 and the final raise are full law-2 moves at the traverse height.',
+        '; overtravel feed trips -> job stop + connection close + latched alarm',
+        'G90',
+        'G53;',
+        `G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; raise to the safe traverse height (law 2)`,
+        `G1 X${first.x.toFixed(3)} Y${first.y.toFixed(3)} F${TRAVEL_FEED}; hop at gantry height to station 1 "${first.label}"`,
+        `G1 Z${guardTop.toFixed(3)} F${TRAVEL_FEED}; descend fast to ${(guardTop - plan.startZMachine).toFixed(1)} mm above start_z_machine`,
+        '; ...guarded final approach: 1 mm steps, sensor-checked after each - ANY contact here aborts (CRASH).',
+    ];
+    for (let gz = guardTop - 1; gz > plan.startZMachine - 1e-9; gz -= 1) {
+        lines.push(`G1 Z${Math.max(gz, plan.startZMachine).toFixed(3)} F${COARSE_FEED}; guarded descent step`);
+    }
+    lines.push(`; --- station 1 "${first.label}" (${first.x}, ${first.y}): march -Z from Z${firstEnv.marchStartZ} to floor Z${firstEnv.floorZ} ---`);
+    let s = 0;
+    let k = 0;
+    while (firstEnv.travelMm - s > 1e-9) {
+        s = Math.min(s + plan.coarseStepMm, firstEnv.travelMm);
+        k += 1;
+        lines.push(`G1 Z${(firstEnv.marchStartZ - s).toFixed(3)} F${COARSE_FEED}; coarse ${k} - settle, check probe, stop at contact`);
+    }
+    lines.push(`; ...on contact: release, ${plan.fineStepMm} mm fine approach, ${plan.confirmPasses} confirm cycle(s) (lift ${plan.backoffMm} mm)`);
+    lines.push(`; retract to contact + ${plan.zSafeDeltaMm} mm (runtime number, never above Z${plan.hopZ})`);
+    for (let i = 1; i < n; i++) {
+        const prev = plan.stations[i - 1];
+        const st = plan.stations[i];
+        lines.push(`; --- station ${i + 1} "${st.label}" (${st.x}, ${st.y}): hop ${st.hopFromPreviousMm} mm at Z = last contact + ${plan.zSafeDeltaMm} ---`);
+        const segs = hopSegments({ x: prev.x, y: prev.y }, { x: st.x, y: st.y });
+        segs.forEach((seg, j) => {
+            lines.push(`G1 X${seg.x.toFixed(3)} Y${seg.y.toFixed(3)} F${TRAVEL_FEED}; hop segment ${j + 1}/${segs.length} - settle, probe must NOT be in contact`);
+        });
+        lines.push(`; march -Z in ${plan.coarseStepMm} mm steps from the hop height to max(last contact - ${plan.maxDropMm}, Z${plan.absoluteFloorZ})`);
+        lines.push(`G1 Z${plan.absoluteFloorZ.toFixed(3)} F${COARSE_FEED}; deepest allowed at this station (absolute floor) - no contact by here = no_contact`);
+        lines.push(`; ...on contact: release, fine, confirm; retract to contact + ${plan.zSafeDeltaMm} mm`);
+    }
+    lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; finish at the safe traverse height (also on any abort)`);
+    lines.push('G54;');
+    return lines.join('\n');
+}
+
+export interface SurfaceStationResult {
+    index: number;
+    label: string;
+    x: number;
+    y: number;
+    s?: number;
+    row?: number;
+    col?: number;
+    status: 'contact' | 'no_contact';
+    /** Toolhead machine Z at contact (null when no_contact). */
+    z: number | null;
+    marchStartZ: number;
+    floorZ: number;
+    confirmPassContacts?: number[];
+    spreadMm?: number;
+}
+
+/**
+ * One -Z march from startZ down to floorZ at the station's XY: the exact
+ * probe_vector / probe_sequence mechanics along the -Z unit vector, except
+ * that reaching the floor without contact RETURNS null instead of aborting
+ * (a surface scan must record a missing station and carry on).
+ */
+async function marchDownZ(
+    plan: ProbeSurfacePlan,
+    station: SurfaceStation,
+    startZ: number,
+    floorZ: number,
+    announce: (phase: string, note?: string) => void
+): Promise<{ contactZ: number; passContacts: number[]; spreadMm: number } | null> {
+    const travel = Number((startZ - floorZ).toFixed(3));
+    const releaseTimeoutMs = Math.max(plan.sensorDelayMs * 4, 3500);
+    const zAt = (s: number) => Number((startZ - s).toFixed(3));
+    const move = async (tool: string, s: number, feed: number) => {
+        await moveMachineSettled(tool, { z: zAt(s) }, feed);
+    };
+    const tag = `${plan.tool}:${station.label}`;
+
+    let s = 0;
+    let coarseContactS: number | null = null;
+    while (travel - s > 1e-9) {
+        const t0 = Date.now();
+        s = Math.min(s + plan.coarseStepMm, travel);
+        await move(`${tag}:coarse`, s, COARSE_FEED);
+        const sensed = await senseAfter('probe', t0, plan.sensorDelayMs);
+        if (sensed.contact) {
+            coarseContactS = s;
+            announce(`coarse-contact-${station.label}`, `Z${zAt(s)}`);
+            break;
+        }
+    }
+    if (coarseContactS === null) {
+        return null;
+    }
+    let released = false;
+    while (s > 1e-9 && coarseContactS - s < MAX_RETREAT_MM + 1e-9) {
+        const t0 = Date.now();
+        s = Math.max(s - plan.coarseStepMm, 0);
+        await move(`${tag}:release`, s, COARSE_FEED);
+        const sensed = await senseReleaseAfter('probe', t0, releaseTimeoutMs);
+        if (!sensed.contact) {
+            released = true;
+            break;
+        }
+    }
+    if (!released) {
+        throw new ProcedureAbort(`Station "${station.label}": probe still triggered ${MAX_RETREAT_MM} mm back from first contact - stuck probe or feed fault.`);
+    }
+    let fineContactS: number | null = null;
+    while (travel - s > 1e-9) {
+        const t0 = Date.now();
+        s = Math.min(s + plan.fineStepMm, travel);
+        await move(`${tag}:fine`, s, FINE_FEED);
+        const sensed = await senseAfter('probe', t0, plan.sensorDelayMs);
+        if (sensed.contact) {
+            fineContactS = s;
+            break;
+        }
+    }
+    if (fineContactS === null) {
+        throw new ProcedureAbort(`Station "${station.label}": fine approach lost the contact.`);
+    }
+    const passContacts: number[] = [];
+    const cycleLimit = Math.min(fineContactS + Math.max(0.5, plan.backoffMm), travel);
+    let reference = fineContactS;
+    for (let pass = 1; pass <= plan.confirmPasses; pass++) {
+        const t0 = Date.now();
+        s = Math.max(reference - plan.backoffMm, 0);
+        await move(`${tag}:backoff`, s, FINE_FEED);
+        const lifted = await senseReleaseAfter('probe', t0, releaseTimeoutMs);
+        if (lifted.contact) {
+            throw new ProcedureAbort(`Station "${station.label}": hysteresis exceeds the backoff ${plan.backoffMm} mm.`);
+        }
+        let passContact: number | null = null;
+        while (cycleLimit - s > 1e-9) {
+            const t1 = Date.now();
+            s = Math.min(s + plan.fineStepMm, cycleLimit);
+            await move(`${tag}:confirm`, s, FINE_FEED);
+            const sensed = await senseAfter('probe', t1, plan.sensorDelayMs);
+            if (sensed.contact) {
+                passContact = s;
+                break;
+            }
+        }
+        if (passContact === null) {
+            throw new ProcedureAbort(`Station "${station.label}": confirm pass ${pass} lost the contact.`);
+        }
+        passContacts.push(zAt(passContact));
+        reference = passContact;
+    }
+    const sorted = [...passContacts].sort((a, b) => a - b);
+    const contactZ = sorted[Math.floor((sorted.length - 1) / 2)];
+    const spreadMm = Number((sorted[sorted.length - 1] - sorted[0]).toFixed(3));
+    return { contactZ, passContacts, spreadMm };
+}
+
+/** Structured procedure result (lands on job.result): stations, statistics, renderings. */
+function buildResult(plan: ProbeSurfacePlan, results: SurfaceStationResult[], phases: { phase: string; note?: string }[]): object {
+    const contacts: ContactSample[] = results
+        .filter((r): r is SurfaceStationResult & { z: number } => r.z !== null)
+        .map((r) => ({ x: r.x, y: r.y, z: r.z, s: r.s, label: r.label }));
+    const summary = summarizeZ(contacts);
+    const noContact = results.filter((r) => r.status === 'no_contact').map((r) => r.label);
+    const worstSpread = Math.max(0, ...results.map((r) => r.spreadMm || 0));
+    const common = {
+        kind: plan.kind,
+        tool: plan.tool,
+        stations: results,
+        contactCount: contacts.length,
+        noContactStations: noContact,
+        summary,
+        worstConfirmSpreadMm: Number(worstSpread.toFixed(3)),
+        envelope: {
+            zSafeDeltaMm: plan.zSafeDeltaMm,
+            maxHopMm: plan.maxHopMm,
+            worstHopMm: plan.worstHopMm,
+            maxDropMm: plan.maxDropMm,
+            absoluteFloorZ: plan.absoluteFloorZ,
+            startZMachine: plan.startZMachine,
+        },
+        coordinateNote: 'All Z values are TOOLHEAD machine Z at probe contact; the physical surface height is Z minus '
+            + 'the probe\'s effective length (measure it with run_tool_setter accept_probe_contact - never assume).',
+        phases,
+        warning: worstSpread > plan.fineStepMm + 1e-9
+            ? `Worst confirm spread ${worstSpread.toFixed(3)} mm exceeds one fine step - feed timing was unstable; `
+                + 'consider more confirm_passes or a longer sensor_delay_ms.'
+            : undefined,
+    };
+    if (plan.kind === 'path' && plan.path) {
+        const line = fitLine(contacts);
+        const profile = renderPathProfile(results.map((r) => ({ label: r.label, s: r.s || 0, z: r.z })));
+        return {
+            ...common,
+            path: plan.path,
+            lineFit: line,
+            profile,
+            note: summary
+                ? `Surface path: ${contacts.length}/${results.length} contacts, Z ${summary.zMin}..${summary.zMax} `
+                    + `(range ${summary.zRange} mm)${line ? `; best-fit slope ${line.slopeMmPer100Mm} mm per 100 mm (${line.slopeDeg} deg), `
+                    + `flatness about the line ${line.flatnessMm} mm (rms residual ${line.rmsResidualMm})` : ''}. MACHINE coordinates.`
+                : 'Surface path: no contacts.',
+        };
+    }
+    const grid = plan.grid as NonNullable<ProbeSurfacePlan['grid']>;
+    const plane = fitPlane(contacts);
+    const zMatrix = buildZMatrix(grid.xs, grid.ys, results.map((r) => ({ row: r.row as number, col: r.col as number, z: r.z })));
+    return {
+        ...common,
+        grid: { xs: grid.xs, ys: grid.ys, pitchXMm: grid.pitchXMm, pitchYMm: grid.pitchYMm, bounds: grid.bounds },
+        zMatrix,
+        heightMap: renderHeightMap(grid.xs, grid.ys, zMatrix),
+        planeFit: plane,
+        note: summary
+            ? `Surface grid: ${contacts.length}/${results.length} contacts, Z ${summary.zMin}..${summary.zMax} `
+                + `(range ${summary.zRange} mm, highest ${summary.highest}, lowest ${summary.lowest})`
+                + `${plane ? `; best-fit plane tilt X ${plane.tiltXMmPer100Mm} / Y ${plane.tiltYMmPer100Mm} mm per 100 mm, `
+                    + `flatness about the plane ${plane.flatnessMm} mm (rms residual ${plane.rmsResidualMm})` : ''}. `
+                + 'MACHINE coordinates; zMatrix rows = ys ascending, cols = xs ascending; heightMap prints +Y at the top.'
+            : 'Surface grid: no contacts.',
+    };
+}
+
+export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<object> {
+    assertChannelReady('probe', `surface ${plan.kind} scan`);
+    assertMachineReadyForProcedure();
+
+    const phases: { phase: string; note?: string }[] = [];
+    const announce = (phase: string, note?: string) => {
+        phases.push({ phase, note });
+        mcpBroadcast('mcp:activity', { tool: plan.tool, phase, note });
+    };
+
+    // Position checks: every preceding move verified its own arrival, so a
+    // mismatch is drift or a transient heartbeat (a beat inside a G53...G54
+    // window carrying no origin offset - job 44abebd9bab3, 2026-09-05).
+    // Re-read once after a heartbeat period before believing it.
+    const fmt = (sn: ReturnType<typeof getPositionSnapshot>) => `(${sn.machine.x}, ${sn.machine.y}, ${sn.machine.z}) `
+        + `[work (${sn.work.x}, ${sn.work.y}, ${sn.work.z}), offset (${sn.originOffset.x}, ${sn.originOffset.y}, ${sn.originOffset.z}) `
+        + `from ${sn.originOffsetSource}]`;
+    const expectPosition = async (
+        expected: { x: number; y: number; z: number },
+        what: string,
+        onMismatch: (message: string) => Error
+    ) => {
+        const matches = (p: { x: number | null; y: number | null; z: number | null }) => (
+            p.x !== null && p.y !== null && p.z !== null
+            && Math.abs(p.x - expected.x) <= 0.5
+            && Math.abs(p.y - expected.y) <= 0.5
+            && Math.abs(p.z - expected.z) <= 0.5
+        );
+        let snapshot = getPositionSnapshot();
+        if (matches(snapshot.machine)) {
+            return;
+        }
+        const firstRead = snapshot;
+        await sleep(1200);
+        snapshot = getPositionSnapshot();
+        if (!matches(snapshot.machine)) {
+            throw onMismatch(`${what}: machine at ${fmt(snapshot)} (first read ${fmt(firstRead)}) but the plan expects `
+                + `(${expected.x}, ${expected.y}, ${expected.z}).`);
+        }
+        announce('position-recheck', `${what}: passed on the second heartbeat (first read was transient)`);
+    };
+
+    await expectPosition(plan.staged, 'staged position', (message) => new McpToolError(
+        `The machine is not at the position this scan was staged from. ${message} Stage ${plan.tool} again.`
+    ));
+
+    const results: SurfaceStationResult[] = [];
+    // Reference height for the envelope: the last REAL contact (toolhead Z).
+    let reference: number | null = null;
+    const hopHeightFor = (ref: number) => Number(Math.min(ref + plan.zSafeDeltaMm, plan.hopZ).toFixed(3));
+
+    let stationIndex = 0;
+    try {
+        // Approach to station 1: full motion law 2 (raise, traverse at the
+        // gantry height, guarded descent to the operator-stated start Z).
+        const first = plan.stations[0];
+        probeFeedService.clearExpectedContact();
+        await moveMachineSettled(`${plan.tool}:raise`, { z: plan.hopZ }, TRAVEL_FEED);
+        await moveMachineSettled(`${plan.tool}:traverse`, { x: first.x, y: first.y }, TRAVEL_FEED);
+        announce('traverse', `(${first.x}, ${first.y}) at Z${plan.hopZ} (law 2)`);
+        const guardTop = plan.startZMachine + DESCENT_GUARD_MM;
+        const zNow = getPositionSnapshot().machine.z;
+        if (zNow !== null && zNow > guardTop + 1e-9) {
+            await moveMachineSettled(`${plan.tool}:descend`, { z: guardTop }, TRAVEL_FEED);
+        }
+        let gz = Math.min(zNow === null ? guardTop : Math.max(zNow, plan.startZMachine), guardTop);
+        while (gz - plan.startZMachine > 1e-9) {
+            const t0 = Date.now();
+            gz = Math.max(gz - 1, plan.startZMachine);
+            await moveMachineSettled(`${plan.tool}:descend-guard`, { z: gz }, COARSE_FEED);
+            const sensed = await senseAfter('probe', t0, plan.sensorDelayMs);
+            if (sensed.contact) {
+                throw new ProcedureAbort(`UNEXPECTED CONTACT during the guarded descent at Z${gz.toFixed(3)} - the surface `
+                    + `is above start_z_machine ${plan.startZMachine}. Machine held.`);
+            }
+        }
+        announce('descend', `Z${plan.startZMachine} (guarded final ${DESCENT_GUARD_MM} mm)`);
+
+        let currentZ = plan.startZMachine;
+        for (const station of plan.stations) {
+            stationIndex = station.index;
+            const isFirst = station.index === 1;
+            if (!isFirst) {
+                // THE LAW-2 EXCEPTION: hop at lastContact + z_safe_delta, in
+                // sensor-checked segments, expecting NO contact. See the file
+                // header for the operator's authorisation and its bounds.
+                const previous = plan.stations[station.index - 2];
+                probeFeedService.clearExpectedContact();
+                const segs = hopSegments({ x: previous.x, y: previous.y }, { x: station.x, y: station.y });
+                for (let j = 0; j < segs.length; j++) {
+                    const t0 = Date.now();
+                    await moveMachineSettled(`${plan.tool}:hop:${station.label}`, { x: segs[j].x, y: segs[j].y }, TRAVEL_FEED);
+                    const sensed = await senseAfter('probe', t0, plan.sensorDelayMs);
+                    if (sensed.contact) {
+                        throw new ProcedureAbort(`UNEXPECTED CONTACT during the hop to "${station.label}" at `
+                            + `(${segs[j].x}, ${segs[j].y}, ${currentZ}) - the surface rises more than ${plan.zSafeDeltaMm} mm `
+                            + 'above the last contact. Machine held.');
+                    }
+                }
+                announce(`hop-${station.label}`, `${station.hopFromPreviousMm} mm to (${station.x}, ${station.y}) at Z${currentZ} `
+                    + `(last contact + ${plan.zSafeDeltaMm})`);
+            }
+
+            const env = stationEnvelope(reference === null ? plan.startZMachine : reference, isFirst, plan.startZMachine, {
+                zSafeDeltaMm: plan.zSafeDeltaMm, maxDropMm: plan.maxDropMm, absoluteFloorZ: plan.absoluteFloorZ,
+            });
+            // The march starts where the walk left us (start_z for station 1,
+            // the hop height otherwise). Re-verify before trusting the sensor.
+            const marchStartZ = isFirst ? plan.startZMachine : currentZ;
+            await expectPosition({ x: station.x, y: station.y, z: marchStartZ }, `station "${station.label}"`,
+                (message) => new ProcedureAbort(message));
+
+            probeFeedService.setExpectedContact(['probe']);
+            const outcome = await marchDownZ(plan, station, marchStartZ, env.floorZ, announce);
+            let retractTo: number;
+            if (outcome === null) {
+                if (reference === null) {
+                    throw new ProcedureAbort(`Station "${station.label}" (the first) found no surface between Z${marchStartZ} and the floor `
+                        + `Z${env.floorZ} - no measured reference to base the envelope on. Check start_z_machine / floor_z_machine.`);
+                }
+                results.push({
+                    index: station.index,
+                    label: station.label,
+                    x: station.x,
+                    y: station.y,
+                    s: station.s,
+                    row: station.row,
+                    col: station.col,
+                    status: 'no_contact',
+                    z: null,
+                    marchStartZ,
+                    floorZ: env.floorZ,
+                });
+                retractTo = hopHeightFor(reference);
+                announce(`no-contact-${station.label}`, `nothing between Z${marchStartZ} and the floor Z${env.floorZ}; reference stays Z${reference}`);
+            } else {
+                reference = outcome.contactZ;
+                results.push({
+                    index: station.index,
+                    label: station.label,
+                    x: station.x,
+                    y: station.y,
+                    s: station.s,
+                    row: station.row,
+                    col: station.col,
+                    status: 'contact',
+                    z: outcome.contactZ,
+                    marchStartZ,
+                    floorZ: env.floorZ,
+                    confirmPassContacts: outcome.passContacts,
+                    spreadMm: outcome.spreadMm,
+                });
+                retractTo = hopHeightFor(outcome.contactZ);
+                announce(`measured-${station.label}`, `(${station.x}, ${station.y}, ${outcome.contactZ}) spread ${outcome.spreadMm}`);
+            }
+
+            // Retract to the hop height (contact still expected while leaving
+            // the surface), prove the probe released, then hand over to the
+            // crash guard for the hop.
+            const t0 = Date.now();
+            await moveMachineSettled(`${plan.tool}:retract:${station.label}`, { z: retractTo }, TRAVEL_FEED);
+            const released = await senseReleaseAfter('probe', t0, Math.max(plan.sensorDelayMs * 4, 3500));
+            if (released.contact) {
+                throw new ProcedureAbort(`Station "${station.label}": probe still triggered after retracting to Z${retractTo} - stuck probe or feed fault.`);
+            }
+            probeFeedService.clearExpectedContact();
+            currentZ = retractTo;
+        }
+
+        await moveMachineSettled(`${plan.tool}:final-raise`, { z: plan.hopZ }, TRAVEL_FEED);
+        announce('scan-complete', `${results.filter((r) => r.status === 'contact').length}/${results.length} contacts, raised to Z${plan.hopZ}`);
+    } catch (err) {
+        const isTrip = !!probeFeedService.getTrip();
+        if (!isTrip) {
+            try {
+                const reading = probeFeedService.getReading('probe');
+                if (!reading || !reading.triggered) {
+                    probeFeedService.clearExpectedContact();
+                    await moveMachineSettled(`${plan.tool}:abort-raise`, { z: plan.hopZ }, TRAVEL_FEED);
+                    announce('abort-raised', `Z${plan.hopZ}`);
+                } else {
+                    announce('abort-held', 'probe still triggered - holding position for the operator');
+                }
+            } catch (retreatErr) {
+                // Logged by the activity stream.
+            }
+        }
+        if (err instanceof ProcedureAbort) {
+            throw new McpToolError(`Surface ${plan.kind} scan aborted at station ${stationIndex}: ${err.message} `
+                + `Completed stations: ${JSON.stringify(results)} Phases: ${JSON.stringify(phases)}`);
+        }
+        throw err;
+    } finally {
+        probeFeedService.clearExpectedContact();
+    }
+
+    return buildResult(plan, results, phases);
+}

--- a/src/server/services/mcp/surfaceScan.ts
+++ b/src/server/services/mcp/surfaceScan.ts
@@ -1,0 +1,602 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention (the planners take the
+// probe_surface_path / probe_surface_grid arguments verbatim).
+//
+// Pure planning and statistics for the top-surface scans (probe_surface_path
+// / probe_surface_grid). NO imports on purpose: this module has no machine,
+// feed or config dependency so it can be compiled alone and unit-tested under
+// plain node (see the development workflow in README.md). The machine-facing
+// plan builders and the runner live in probeSurface.ts.
+//
+// The safety envelope these helpers enforce is the operator's, verbatim
+// (2026-09-05): "with the grid we need the point to point variation to not
+// risk the probe toolhead so no more than 20mm z safe delta from the top
+// (within a horizontal change of 60mm)". Hence the two hard caps below - a
+// request beyond them is refused, never clamped silently.
+
+/** Operator-authorised ceiling for the between-station retract (mm above the last contact). */
+export const Z_SAFE_DELTA_MAX_MM = 20;
+export const Z_SAFE_DELTA_DEFAULT_MM = 20;
+export const Z_SAFE_DELTA_MIN_MM = 3;
+/** Operator-authorised ceiling for the horizontal distance between consecutive stations. */
+export const MAX_HOP_CAP_MM = 60;
+export const MAX_HOP_DEFAULT_MM = 60;
+/** How far below the previous contact one station's march may search (a pocket floor). */
+export const MAX_DROP_CAP_MM = 80;
+export const MAX_DROP_DEFAULT_MM = 40;
+/** Hops are executed in sensor-checked segments no longer than this. */
+export const HOP_SEGMENT_MM = 10;
+
+export interface SurfaceStation {
+    /** 1-based execution order. */
+    index: number;
+    /** Human key: "s3" on a path, "r2c4" on a grid (row = Y line, col = X line). */
+    label: string;
+    x: number;
+    y: number;
+    /** Path stations: distance along the path from the start (mm). */
+    s?: number;
+    /** Grid stations: zero-based row (Y index) / col (X index). */
+    row?: number;
+    col?: number;
+    /** Horizontal distance from the previous station (0 for the first). */
+    hopFromPreviousMm: number;
+}
+
+export class SurfacePlanError extends Error {}
+
+const round3 = (v: number): number => Number(v.toFixed(3));
+
+function requireFinite(value: unknown, name: string): number {
+    const n = Number(value);
+    if (!Number.isFinite(n)) {
+        throw new SurfacePlanError(`${name} must be a finite number.`);
+    }
+    return n;
+}
+
+/**
+ * Resolve the three envelope parameters against their hard caps. Anything
+ * above a cap is REFUSED (the operator picks the numbers, the code never
+ * widens them), anything below the sensible minimum too.
+ */
+export function resolveEnvelope(args: {
+    z_safe_delta_mm?: unknown;
+    max_hop_mm?: unknown;
+    max_drop_mm?: unknown;
+}): { zSafeDeltaMm: number; maxHopMm: number; maxDropMm: number } {
+    const zSafe = args.z_safe_delta_mm === undefined ? Z_SAFE_DELTA_DEFAULT_MM : requireFinite(args.z_safe_delta_mm, 'z_safe_delta_mm');
+    if (zSafe > Z_SAFE_DELTA_MAX_MM + 1e-9) {
+        throw new SurfacePlanError(`z_safe_delta_mm ${zSafe} exceeds the operator-authorised maximum of `
+            + `${Z_SAFE_DELTA_MAX_MM} mm (hop height above the last contact).`);
+    }
+    if (zSafe < Z_SAFE_DELTA_MIN_MM) {
+        throw new SurfacePlanError(`z_safe_delta_mm must be at least ${Z_SAFE_DELTA_MIN_MM} mm.`);
+    }
+    const maxHop = args.max_hop_mm === undefined ? MAX_HOP_DEFAULT_MM : requireFinite(args.max_hop_mm, 'max_hop_mm');
+    if (maxHop > MAX_HOP_CAP_MM + 1e-9) {
+        throw new SurfacePlanError(`max_hop_mm ${maxHop} exceeds the operator-authorised maximum of `
+            + `${MAX_HOP_CAP_MM} mm between consecutive stations.`);
+    }
+    if (maxHop < 1) {
+        throw new SurfacePlanError('max_hop_mm must be at least 1 mm.');
+    }
+    const maxDrop = args.max_drop_mm === undefined ? MAX_DROP_DEFAULT_MM : requireFinite(args.max_drop_mm, 'max_drop_mm');
+    if (maxDrop > MAX_DROP_CAP_MM + 1e-9) {
+        throw new SurfacePlanError(`max_drop_mm ${maxDrop} exceeds the cap of ${MAX_DROP_CAP_MM} mm below the previous contact.`);
+    }
+    if (maxDrop < 1) {
+        throw new SurfacePlanError('max_drop_mm must be at least 1 mm.');
+    }
+    return { zSafeDeltaMm: zSafe, maxHopMm: maxHop, maxDropMm: maxDrop };
+}
+
+/** Every consecutive pair must be within maxHopMm - refuse otherwise, naming the pair. */
+export function assertHopsWithin(stations: SurfaceStation[], maxHopMm: number): number {
+    let worst = 0;
+    for (let i = 1; i < stations.length; i++) {
+        const d = stations[i].hopFromPreviousMm;
+        worst = Math.max(worst, d);
+        if (d > maxHopMm + 1e-6) {
+            throw new SurfacePlanError(`Stations ${stations[i - 1].label} -> ${stations[i].label} are ${d.toFixed(2)} mm apart, `
+                + `over max_hop_mm ${maxHopMm}. The operator picks a closer spacing/pitch; the plan is never split silently.`);
+        }
+    }
+    return round3(worst);
+}
+
+/**
+ * Stations along a straight line. Either an end point or a direction +
+ * length defines the segment; either a station count or a spacing defines
+ * the sampling. Both ends are always stations.
+ */
+export function planPathStations(args: {
+    start_x: unknown;
+    start_y: unknown;
+    end_x?: unknown;
+    end_y?: unknown;
+    dx?: unknown;
+    dy?: unknown;
+    length_mm?: unknown;
+    stations?: unknown;
+    spacing_mm?: unknown;
+}): {
+    stations: SurfaceStation[];
+    start: { x: number; y: number };
+    end: { x: number; y: number };
+    unit: { x: number; y: number };
+    lengthMm: number;
+    spacingMm: number;
+} {
+    const sx = requireFinite(args.start_x, 'start_x');
+    const sy = requireFinite(args.start_y, 'start_y');
+    let ex: number;
+    let ey: number;
+    if (args.end_x !== undefined || args.end_y !== undefined) {
+        ex = requireFinite(args.end_x, 'end_x');
+        ey = requireFinite(args.end_y, 'end_y');
+    } else {
+        const dx = Number(args.dx) || 0;
+        const dy = Number(args.dy) || 0;
+        const norm = Math.hypot(dx, dy);
+        if (norm < 1e-9) {
+            throw new SurfacePlanError('Give either end_x/end_y or a direction dx/dy (at least one non-zero) with length_mm.');
+        }
+        const length = requireFinite(args.length_mm, 'length_mm');
+        if (length <= 0) {
+            throw new SurfacePlanError('length_mm must be positive.');
+        }
+        ex = sx + (dx / norm) * length;
+        ey = sy + (dy / norm) * length;
+    }
+    const lengthMm = Math.hypot(ex - sx, ey - sy);
+    if (lengthMm < 1) {
+        throw new SurfacePlanError('The path is under 1 mm long.');
+    }
+    if (lengthMm > 400) {
+        throw new SurfacePlanError('The path is over 400 mm long - longer than the bed.');
+    }
+    const unit = { x: (ex - sx) / lengthMm, y: (ey - sy) / lengthMm };
+
+    let count: number;
+    if (args.stations !== undefined) {
+        count = Math.round(requireFinite(args.stations, 'stations'));
+        if (count < 2 || count > 60) {
+            throw new SurfacePlanError('stations must be 2-60.');
+        }
+    } else if (args.spacing_mm !== undefined) {
+        const spacing = requireFinite(args.spacing_mm, 'spacing_mm');
+        if (spacing <= 0) {
+            throw new SurfacePlanError('spacing_mm must be positive.');
+        }
+        // Spacing is a MAXIMUM: the length is divided evenly into steps no
+        // larger than it, so both ends are covered (same rule as survey_bed).
+        count = Math.max(1, Math.ceil(lengthMm / spacing - 1e-9)) + 1;
+        if (count > 60) {
+            throw new SurfacePlanError(`spacing_mm ${spacing} over ${lengthMm.toFixed(1)} mm gives ${count} stations (max 60).`);
+        }
+    } else {
+        throw new SurfacePlanError('Give either stations (count) or spacing_mm.');
+    }
+    const spacingMm = lengthMm / (count - 1);
+    const stations: SurfaceStation[] = [];
+    for (let i = 0; i < count; i++) {
+        const s = spacingMm * i;
+        stations.push({
+            index: i + 1,
+            label: `s${i + 1}`,
+            x: round3(sx + unit.x * s),
+            y: round3(sy + unit.y * s),
+            s: round3(s),
+            hopFromPreviousMm: i === 0 ? 0 : round3(spacingMm),
+        });
+    }
+    return {
+        stations,
+        start: { x: round3(sx), y: round3(sy) },
+        end: { x: round3(ex), y: round3(ey) },
+        unit: { x: Number(unit.x.toFixed(6)), y: Number(unit.y.toFixed(6)) },
+        lengthMm: round3(lengthMm),
+        spacingMm: round3(spacingMm),
+    };
+}
+
+function axisLines(min: number, max: number, pitch: unknown, count: unknown, axis: string): { values: number[]; pitchMm: number } {
+    const span = max - min;
+    if (!(span > 0)) {
+        throw new SurfacePlanError(`${axis} extent is empty (min ${min}, max ${max}).`);
+    }
+    let intervals: number;
+    if (count !== undefined) {
+        const n = Math.round(requireFinite(count, `${axis}_count`));
+        if (n < 2 || n > 40) {
+            throw new SurfacePlanError(`${axis}_count must be 2-40.`);
+        }
+        intervals = n - 1;
+    } else if (pitch !== undefined) {
+        const p = requireFinite(pitch, 'pitch_mm');
+        if (p <= 0) {
+            throw new SurfacePlanError('pitch_mm must be positive.');
+        }
+        // Pitch is a MAXIMUM: even division, both edges covered.
+        intervals = Math.max(1, Math.ceil(span / p - 1e-9));
+        if (intervals + 1 > 40) {
+            throw new SurfacePlanError(`pitch_mm ${p} over the ${axis} extent ${span.toFixed(1)} mm gives ${intervals + 1} lines (max 40).`);
+        }
+    } else {
+        throw new SurfacePlanError(`Give pitch_mm or ${axis}_count.`);
+    }
+    const step = span / intervals;
+    const values: number[] = [];
+    for (let i = 0; i <= intervals; i++) {
+        values.push(round3(min + step * i));
+    }
+    return { values, pitchMm: round3(step) };
+}
+
+/**
+ * Serpentine grid: rows are lines of constant Y (ascending), each row walked
+ * along X in alternating direction so consecutive stations are always one
+ * pitch apart - including the row-to-row turn.
+ */
+export function planGridStations(args: {
+    x_min?: unknown;
+    x_max?: unknown;
+    y_min?: unknown;
+    y_max?: unknown;
+    center_x?: unknown;
+    center_y?: unknown;
+    size_x_mm?: unknown;
+    size_y_mm?: unknown;
+    pitch_mm?: unknown;
+    x_count?: unknown;
+    y_count?: unknown;
+}): {
+    stations: SurfaceStation[];
+    xs: number[];
+    ys: number[];
+    pitchXMm: number;
+    pitchYMm: number;
+    bounds: { xMin: number; xMax: number; yMin: number; yMax: number };
+} {
+    let xMin: number;
+    let xMax: number;
+    let yMin: number;
+    let yMax: number;
+    const hasExtents = args.x_min !== undefined || args.x_max !== undefined || args.y_min !== undefined || args.y_max !== undefined;
+    const hasCentre = args.center_x !== undefined || args.center_y !== undefined || args.size_x_mm !== undefined || args.size_y_mm !== undefined;
+    if (hasExtents && hasCentre) {
+        throw new SurfacePlanError('Give EITHER x_min/x_max/y_min/y_max OR center_x/center_y/size_x_mm/size_y_mm, not both.');
+    }
+    if (hasExtents) {
+        xMin = requireFinite(args.x_min, 'x_min');
+        xMax = requireFinite(args.x_max, 'x_max');
+        yMin = requireFinite(args.y_min, 'y_min');
+        yMax = requireFinite(args.y_max, 'y_max');
+    } else if (hasCentre) {
+        const cx = requireFinite(args.center_x, 'center_x');
+        const cy = requireFinite(args.center_y, 'center_y');
+        const sxm = requireFinite(args.size_x_mm, 'size_x_mm');
+        const sym = args.size_y_mm === undefined ? sxm : requireFinite(args.size_y_mm, 'size_y_mm');
+        if (sxm <= 0 || sym <= 0) {
+            throw new SurfacePlanError('size_x_mm / size_y_mm must be positive.');
+        }
+        xMin = cx - sxm / 2;
+        xMax = cx + sxm / 2;
+        yMin = cy - sym / 2;
+        yMax = cy + sym / 2;
+    } else {
+        throw new SurfacePlanError('Give the region: x_min/x_max/y_min/y_max, or center_x/center_y/size_x_mm[/size_y_mm].');
+    }
+    const xAxis = axisLines(xMin, xMax, args.pitch_mm, args.x_count, 'x');
+    const yAxis = axisLines(yMin, yMax, args.pitch_mm, args.y_count, 'y');
+    if (xAxis.values.length * yAxis.values.length > 400) {
+        throw new SurfacePlanError(`${xAxis.values.length} x ${yAxis.values.length} = ${xAxis.values.length * yAxis.values.length} stations (max 400).`);
+    }
+    const stations: SurfaceStation[] = [];
+    let previous: { x: number; y: number } | null = null;
+    yAxis.values.forEach((y, row) => {
+        const cols = xAxis.values.map((x, col) => ({ x, col }));
+        const ordered = row % 2 === 0 ? cols : [...cols].reverse();
+        for (const { x, col } of ordered) {
+            stations.push({
+                index: stations.length + 1,
+                label: `r${row + 1}c${col + 1}`,
+                x,
+                y,
+                row,
+                col,
+                hopFromPreviousMm: previous ? round3(Math.hypot(x - previous.x, y - previous.y)) : 0,
+            });
+            previous = { x, y };
+        }
+    });
+    return {
+        stations,
+        xs: xAxis.values,
+        ys: yAxis.values,
+        pitchXMm: xAxis.pitchMm,
+        pitchYMm: yAxis.pitchMm,
+        bounds: { xMin: round3(xMin), xMax: round3(xMax), yMin: round3(yMin), yMax: round3(yMax) },
+    };
+}
+
+/**
+ * Where a station's -Z march may search: from the hop height (reference +
+ * z_safe_delta) down to reference - max_drop, but never below the plan's
+ * absolute floor. `reference` is the last real contact (or start_z_machine
+ * for the first station, whose march starts AT start_z, not above it).
+ */
+export function stationEnvelope(
+    reference: number,
+    isFirst: boolean,
+    startZ: number,
+    env: { zSafeDeltaMm: number; maxDropMm: number; absoluteFloorZ: number }
+): { marchStartZ: number; floorZ: number; travelMm: number } {
+    const marchStartZ = isFirst ? startZ : round3(reference + env.zSafeDeltaMm);
+    const floorZ = round3(Math.max(reference - env.maxDropMm, env.absoluteFloorZ));
+    return { marchStartZ, floorZ, travelMm: round3(marchStartZ - floorZ) };
+}
+
+/** Split a hop into equal segments no longer than HOP_SEGMENT_MM (sensor-checked between). */
+export function hopSegments(
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+    segmentMm: number = HOP_SEGMENT_MM
+): { x: number; y: number }[] {
+    const d = Math.hypot(to.x - from.x, to.y - from.y);
+    if (d < 1e-9) {
+        return [];
+    }
+    const n = Math.max(1, Math.ceil(d / segmentMm - 1e-9));
+    const out: { x: number; y: number }[] = [];
+    for (let i = 1; i <= n; i++) {
+        const t = i / n;
+        out.push(i === n
+            ? { x: to.x, y: to.y }
+            : { x: round3(from.x + (to.x - from.x) * t), y: round3(from.y + (to.y - from.y) * t) });
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------- statistics
+
+export interface ContactSample {
+    x: number;
+    y: number;
+    z: number;
+    s?: number;
+    label: string;
+}
+
+export interface ZSummary {
+    count: number;
+    zMin: number;
+    zMax: number;
+    zRange: number;
+    zMean: number;
+    highest: string;
+    lowest: string;
+}
+
+export function summarizeZ(samples: ContactSample[]): ZSummary | null {
+    if (samples.length === 0) {
+        return null;
+    }
+    let lo = samples[0];
+    let hi = samples[0];
+    let sum = 0;
+    for (const p of samples) {
+        sum += p.z;
+        if (p.z < lo.z) {
+            lo = p;
+        }
+        if (p.z > hi.z) {
+            hi = p;
+        }
+    }
+    return {
+        count: samples.length,
+        zMin: round3(lo.z),
+        zMax: round3(hi.z),
+        zRange: round3(hi.z - lo.z),
+        zMean: round3(sum / samples.length),
+        highest: hi.label,
+        lowest: lo.label,
+    };
+}
+
+export interface LineFit {
+    /** z = intercept + slope * s */
+    intercept: number;
+    slope: number;
+    slopeMmPer100Mm: number;
+    slopeDeg: number;
+    /** end-to-end rise predicted by the fit over the sampled length. */
+    riseOverLengthMm: number;
+    residuals: { label: string; mm: number }[];
+    rmsResidualMm: number;
+    maxResidualMm: number;
+    /** Peak-to-valley of the residuals = flatness relative to the best-fit line. */
+    flatnessMm: number;
+}
+
+/** Least-squares line z(s) over path samples (needs >= 2 distinct s). */
+export function fitLine(samples: ContactSample[]): LineFit | null {
+    const pts = samples.filter((p) => p.s !== undefined);
+    if (pts.length < 2) {
+        return null;
+    }
+    const n = pts.length;
+    const meanS = pts.reduce((a, p) => a + (p.s as number), 0) / n;
+    const meanZ = pts.reduce((a, p) => a + p.z, 0) / n;
+    let sxx = 0;
+    let sxz = 0;
+    for (const p of pts) {
+        const ds = (p.s as number) - meanS;
+        sxx += ds * ds;
+        sxz += ds * (p.z - meanZ);
+    }
+    if (sxx < 1e-12) {
+        return null;
+    }
+    const slope = sxz / sxx;
+    const intercept = meanZ - slope * meanS;
+    const residuals = pts.map((p) => ({ label: p.label, mm: round3(p.z - (intercept + slope * (p.s as number))) }));
+    const rms = Math.sqrt(residuals.reduce((a, r) => a + r.mm * r.mm, 0) / n);
+    const resValues = residuals.map((r) => r.mm);
+    const sMin = Math.min(...pts.map((p) => p.s as number));
+    const sMax = Math.max(...pts.map((p) => p.s as number));
+    return {
+        intercept: Number(intercept.toFixed(4)),
+        slope: Number(slope.toFixed(6)),
+        slopeMmPer100Mm: round3(slope * 100),
+        slopeDeg: Number((Math.atan(slope) * 180 / Math.PI).toFixed(3)),
+        riseOverLengthMm: round3(slope * (sMax - sMin)),
+        residuals,
+        rmsResidualMm: Number(rms.toFixed(4)),
+        maxResidualMm: round3(Math.max(...resValues.map((r) => Math.abs(r)))),
+        flatnessMm: round3(Math.max(...resValues) - Math.min(...resValues)),
+    };
+}
+
+export interface PlaneFit {
+    /** z = a + b*x + c*y */
+    a: number;
+    b: number;
+    c: number;
+    tiltXMmPer100Mm: number;
+    tiltYMmPer100Mm: number;
+    tiltXDeg: number;
+    tiltYDeg: number;
+    residuals: { label: string; mm: number }[];
+    rmsResidualMm: number;
+    maxResidualMm: number;
+    /** Peak-to-valley of the residuals = flatness relative to the best-fit plane. */
+    flatnessMm: number;
+}
+
+/** Least-squares plane over >= 3 non-collinear samples (normal equations, 3x3). */
+export function fitPlane(samples: ContactSample[]): PlaneFit | null {
+    const n = samples.length;
+    if (n < 3) {
+        return null;
+    }
+    // Centre the data for conditioning.
+    const mx = samples.reduce((a, p) => a + p.x, 0) / n;
+    const my = samples.reduce((a, p) => a + p.y, 0) / n;
+    const mz = samples.reduce((a, p) => a + p.z, 0) / n;
+    let sxx = 0;
+    let sxy = 0;
+    let syy = 0;
+    let sxz = 0;
+    let syz = 0;
+    for (const p of samples) {
+        const dx = p.x - mx;
+        const dy = p.y - my;
+        const dz = p.z - mz;
+        sxx += dx * dx;
+        sxy += dx * dy;
+        syy += dy * dy;
+        sxz += dx * dz;
+        syz += dy * dz;
+    }
+    const det = sxx * syy - sxy * sxy;
+    if (Math.abs(det) < 1e-9) {
+        return null; // collinear in XY - no plane
+    }
+    const b = (sxz * syy - syz * sxy) / det;
+    const c = (syz * sxx - sxz * sxy) / det;
+    const a = mz - b * mx - c * my;
+    const residuals = samples.map((p) => ({ label: p.label, mm: round3(p.z - (a + b * p.x + c * p.y)) }));
+    const resValues = residuals.map((r) => r.mm);
+    const rms = Math.sqrt(resValues.reduce((acc, r) => acc + r * r, 0) / n);
+    return {
+        a: Number(a.toFixed(4)),
+        b: Number(b.toFixed(6)),
+        c: Number(c.toFixed(6)),
+        tiltXMmPer100Mm: round3(b * 100),
+        tiltYMmPer100Mm: round3(c * 100),
+        tiltXDeg: Number((Math.atan(b) * 180 / Math.PI).toFixed(3)),
+        tiltYDeg: Number((Math.atan(c) * 180 / Math.PI).toFixed(3)),
+        residuals,
+        rmsResidualMm: Number(rms.toFixed(4)),
+        maxResidualMm: round3(Math.max(...resValues.map((r) => Math.abs(r)))),
+        flatnessMm: round3(Math.max(...resValues) - Math.min(...resValues)),
+    };
+}
+
+/** rows = ys (ascending), cols = xs (ascending); null where no contact. */
+export function buildZMatrix(
+    xs: number[],
+    ys: number[],
+    cells: { row: number; col: number; z: number | null }[]
+): (number | null)[][] {
+    const matrix: (number | null)[][] = ys.map(() => xs.map(() => null as number | null));
+    for (const c of cells) {
+        if (c.row >= 0 && c.row < ys.length && c.col >= 0 && c.col < xs.length) {
+            matrix[c.row][c.col] = c.z === null ? null : round3(c.z);
+        }
+    }
+    return matrix;
+}
+
+/**
+ * Compact text height map: a numeric table of Z relative to the highest
+ * contact (0.000 = highest, negatives lower; "  --  " = no contact), rows
+ * printed with the LARGEST Y first so the picture is oriented like the bed
+ * seen from above (+Y away), plus a one-character shade per cell.
+ */
+export function renderHeightMap(xs: number[], ys: number[], matrix: (number | null)[][]): string {
+    const values: number[] = [];
+    matrix.forEach((row) => row.forEach((z) => {
+        if (z !== null) {
+            values.push(z);
+        }
+    }));
+    if (values.length === 0) {
+        return 'no contacts';
+    }
+    const zMax = Math.max(...values);
+    const zMin = Math.min(...values);
+    const range = zMax - zMin;
+    const shades = '.:-=+*#%@';
+    const cellW = 8;
+    const pad = (text: string, w: number) => (text.length >= w ? text : ' '.repeat(w - text.length) + text);
+    const lines: string[] = [];
+    lines.push(`Z relative to the highest contact (${zMax.toFixed(3)}); range ${range.toFixed(3)} mm; rows = machine Y (top = +Y), cols = machine X`);
+    lines.push(`${pad('Y \\ X', 9)}${xs.map((x) => pad(x.toFixed(1), cellW)).join('')}   shade`);
+    for (let r = ys.length - 1; r >= 0; r--) {
+        const cells = matrix[r].map((z) => (z === null ? pad('--', cellW) : pad((z - zMax).toFixed(3), cellW)));
+        const shade = matrix[r].map((z) => {
+            if (z === null) {
+                return '?';
+            }
+            const level = range < 1e-9 ? shades.length - 1 : Math.round(((z - zMin) / range) * (shades.length - 1));
+            return shades[Math.min(shades.length - 1, Math.max(0, level))];
+        }).join('');
+        lines.push(`${pad(ys[r].toFixed(1), 9)}${cells.join('')}   ${shade}`);
+    }
+    lines.push(`shade: '.' = lowest (${zMin.toFixed(3)}) ... '@' = highest (${zMax.toFixed(3)}); '?' = no contact`);
+    return lines.join('\n');
+}
+
+/** Path rendering: one line per station with a bar proportional to height above the lowest. */
+export function renderPathProfile(samples: { label: string; s: number; z: number | null }[]): string {
+    const zs = samples.map((p) => p.z).filter((z): z is number => z !== null);
+    if (zs.length === 0) {
+        return 'no contacts';
+    }
+    const zMax = Math.max(...zs);
+    const zMin = Math.min(...zs);
+    const range = zMax - zMin;
+    const width = 30;
+    return samples.map((p) => {
+        const label = `${p.label.padEnd(4)} s=${p.s.toFixed(1).padStart(7)}`;
+        if (p.z === null) {
+            return `${label}  no contact`;
+        }
+        const bars = range < 1e-9 ? width : Math.round(((p.z - zMin) / range) * width);
+        return `${label}  z=${p.z.toFixed(3)}  ${(p.z - zMax).toFixed(3).padStart(7)}  |${'#'.repeat(bars)}`;
+    }).join('\n');
+}

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -11,6 +11,13 @@ import { jobManager } from '../jobs';
 import { describeProbeCirclePlanAsGcode, planProbeCircle, runProbeCircleProcedure } from '../probeCircle';
 import { describeProbePlanAsGcode, planProbePoint, runProbePointProcedure } from '../probeTool';
 import { describeProbeSequencePlanAsGcode, planProbeSequence, runProbeSequenceProcedure } from '../probeSequence';
+import {
+    ProbeSurfacePlan,
+    describeProbeSurfacePlanAsGcode,
+    planProbeSurfaceGrid,
+    planProbeSurfacePath,
+    runProbeSurfaceProcedure,
+} from '../probeSurface';
 import { describeProbeVectorPlanAsGcode, planProbeVector, runProbeVectorProcedure } from '../probeVector';
 import { probeFeedService } from '../probeFeed';
 import { TRAVEL_FEED, assertMachineReadyForProcedure, moveMachineSettled } from '../probing';
@@ -301,6 +308,166 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
                     + 'hops and depths), and approve. Their one-time code passed to start_gcode_job runs '
                     + 'the whole star and returns the circle fit.',
             };
+        },
+    });
+
+    // Shared staging for the two top-surface scans. The envelope description
+    // is repeated in both tool descriptions on purpose: the MCP client caches
+    // schemas, and the operator-authorised law-2 exception must be visible
+    // wherever the tool is read.
+    const SURFACE_ENVELOPE_TEXT = 'ENVELOPE (operator-authorised 2026-09-05, the ONLY exception to motion law 2 - '
+        + 'valid only inside this procedure, only between consecutive stations): after each station the probe '
+        + 'retracts to LAST CONTACT + z_safe_delta_mm (default 20, HARD CAP 20) and hops horizontally AT THAT '
+        + 'HEIGHT to the next station, which must be within max_hop_mm (default 60, HARD CAP 60) - a wider '
+        + 'spacing/pitch is REFUSED at staging, never split silently. Hops run in <= 10 mm sensor-checked segments '
+        + 'expecting NO contact: a touch during a hop is a collision and latches the CRASH alarm. Each -Z march '
+        + 'searches from the hop height down to max(last contact - max_drop_mm (default 40, cap 80), '
+        + 'floor_z_machine (default start_z_machine - max_drop_mm)); reaching the floor without contact records '
+        + 'the station as no_contact and continues with the reference height unchanged (the first station finding '
+        + 'nothing aborts). The approach to the FIRST station is a full law-2 move: raise to the safe traverse '
+        + 'height, traverse, guarded 1 mm descent to start_z_machine (REQUIRED - a measured or operator-stated '
+        + 'toolhead machine Z with the tip just above the surface, never a guess). Ends raised at the traverse '
+        + 'height. All numbers MACHINE coordinates; Z values are toolhead Z at contact (surface = Z - probe length).';
+    const surfaceCommonProperties = {
+        start_z_machine: {
+            type: 'number',
+            description: 'REQUIRED. Toolhead machine Z where the first -Z march starts (probe tip just above the '
+                + 'surface) - measured (probe_point -Z, an earlier scan) or operator-stated. Reached by a guarded descent.',
+        },
+        floor_z_machine: {
+            type: 'number',
+            description: 'Absolute deepest toolhead machine Z any march may command. Default start_z_machine - '
+                + 'max_drop_mm. State it explicitly (lower) to scan into a deep pocket; must stay within 150 mm of start_z_machine.',
+        },
+        z_safe_delta_mm: {
+            type: 'number',
+            description: 'Retract above the last contact for the hop to the next station. Default 20, HARD CAP 20 '
+                + '(operator law), min 3. Above the cap = refused.',
+        },
+        max_hop_mm: {
+            type: 'number',
+            description: 'Largest allowed horizontal distance between consecutive stations. Default 60, HARD CAP 60 '
+                + '(operator law). A plan whose spacing/pitch exceeds it is refused at staging.',
+        },
+        max_drop_mm: {
+            type: 'number',
+            description: 'How far below the previous contact one station may search before recording no_contact. '
+                + 'Default 40, cap 80 (also bounded by floor_z_machine).',
+        },
+        coarse_step_mm: { type: 'number', description: 'Coarse -Z step for every march, default 1 (0.2-2). 2 is faster on a known-flat surface.' },
+        fine_step_mm: { type: 'number', description: 'Fine step, default 0.1 (0.02-0.5).' },
+        backoff_mm: { type: 'number', description: 'Confirm-cycle lift, default 1 (also the confirm re-contact window).' },
+        sensor_delay_ms: { type: 'number', description: 'Contact-check window per step, default 300 (GPIO transport: ~50 is enough).' },
+        confirm_passes: { type: 'number', description: 'Lift-and-retest cycles per station, default 3 (1-10).' },
+        reason: { type: 'string', description: 'Shown to the operator: what surface is being scanned and why.' },
+    };
+    const stageSurfaceScan = (plan: ProbeSurfacePlan, reason: string, label: string) => {
+        const envelope = `; reason: ${reason}
+${describeProbeSurfacePlanAsGcode(plan)}`;
+        const validation = validateGcode(envelope);
+        const job = jobManager.submit(
+            envelope,
+            `surface-${plan.kind} ${plan.stations.length}st ${label} - ${reason.slice(0, 40)}`,
+            'cnc',
+            validation,
+            'procedure'
+        );
+        job.runner = async () => runProbeSurfaceProcedure(plan);
+        return {
+            job: jobManager.describe(job),
+            plan,
+            confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+            next_step: 'Ask the operator to open confirm_url and review the WHOLE scan: the law-2 exception '
+                + `(hops at last contact + ${plan.zSafeDeltaMm} mm, largest hop ${plan.worstHopMm} mm), every station, `
+                + `the guarded descent to Z${plan.startZMachine} and the absolute floor Z${plan.absoluteFloorZ}. One approval `
+                + 'covers the circuit; their one-time code passed to start_gcode_job runs it (detached - long-poll '
+                + 'get_gcode_job_status for the result: per-station machine XYZ plus flatness statistics).',
+        };
+    };
+
+    registry.register({
+        name: 'probe_surface_path',
+        description: 'Stage a TOP-SURFACE FLATNESS scan along a straight line for human confirmation: N stations '
+            + 'from a start point to an end point (or direction + length), spaced by count or maximum spacing, '
+            + 'each measured with a -Z sensor-gated march of the spindle touch probe (coarse to contact, release, '
+            + 'fine, lift-and-retest confirm, median). Result per station: machine XYZ of contact or no_contact; '
+            + 'plus Z min/max/range, the best-fit line (slope in mm per 100 mm and degrees, rise over the length) '
+            + 'and flatness as residual peak-to-valley, and a text profile. Purpose: level/flatness of stock along a '
+            + `line, e.g. along a rotary-mounted board. ${SURFACE_ENVELOPE_TEXT}`,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                start_x: { type: 'number', description: 'First station machine X.' },
+                start_y: { type: 'number', description: 'First station machine Y.' },
+                end_x: { type: 'number', description: 'Last station machine X (with end_y). Alternative: dx/dy + length_mm.' },
+                end_y: { type: 'number', description: 'Last station machine Y.' },
+                dx: { type: 'number', description: 'Path direction X component (with dy and length_mm) when end_x/end_y are not given. Magnitude ignored.' },
+                dy: { type: 'number', description: 'Path direction Y component.' },
+                length_mm: { type: 'number', description: 'Path length along dx/dy (1-400).' },
+                stations: { type: 'number', description: 'Station count including both ends (2-60). Alternative: spacing_mm.' },
+                spacing_mm: {
+                    type: 'number',
+                    description: 'MAXIMUM spacing: the length is divided evenly into steps no larger than this, both ends '
+                        + 'covered. Must give consecutive stations within max_hop_mm or staging refuses.',
+                },
+                ...surfaceCommonProperties,
+            },
+            required: ['start_x', 'start_y', 'start_z_machine', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            const reason = String(args.reason || '').trim();
+            if (!reason) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            probeFeedService.assertNoOvertravel();
+            const plan = planProbeSurfacePath(args as Parameters<typeof planProbeSurfacePath>[0]);
+            return stageSurfaceScan(plan, reason, `${plan.path ? plan.path.lengthMm : 0}mm`);
+        },
+    });
+
+    registry.register({
+        name: 'probe_surface_grid',
+        description: 'Stage a TOP-SURFACE HEIGHT MAP for human confirmation: a serpentine grid of -Z touches of the '
+            + 'spindle touch probe over a region (x/y extents, or centre + size; sampled by maximum pitch or by '
+            + 'x_count/y_count), every station a sensor-gated march (coarse to contact, release, fine, '
+            + 'lift-and-retest confirm, median). Result: per-station machine XYZ or no_contact, a zMatrix '
+            + '(rows = ys ascending, cols = xs ascending, null = no contact) with its coordinates, Z min/max/range, '
+            + 'the best-fit plane (tilt X/Y in mm per 100 mm and degrees) with per-point residuals and flatness '
+            + '(residual peak-to-valley), and a compact text height map (+Y at the top). Purpose: scan a pocketed '
+            + `box, a log, a wasteboard - anything with a top. ${SURFACE_ENVELOPE_TEXT}`,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                x_min: { type: 'number', description: 'Region machine X minimum (with x_max/y_min/y_max). Alternative: center_x/center_y + size.' },
+                x_max: { type: 'number', description: 'Region machine X maximum.' },
+                y_min: { type: 'number', description: 'Region machine Y minimum.' },
+                y_max: { type: 'number', description: 'Region machine Y maximum.' },
+                center_x: { type: 'number', description: 'Region centre machine X (with center_y, size_x_mm[, size_y_mm]).' },
+                center_y: { type: 'number', description: 'Region centre machine Y.' },
+                size_x_mm: { type: 'number', description: 'Region width along X.' },
+                size_y_mm: { type: 'number', description: 'Region depth along Y (default = size_x_mm).' },
+                pitch_mm: {
+                    type: 'number',
+                    description: 'MAXIMUM grid pitch on both axes: each extent is divided evenly into steps no larger than '
+                        + 'this, both edges covered. Must be within max_hop_mm (cap 60) or staging refuses - the operator '
+                        + 'picks a finer pitch, the plan is never split.',
+                },
+                x_count: { type: 'number', description: 'Number of X lines (2-40) instead of pitch_mm for X.' },
+                y_count: { type: 'number', description: 'Number of Y lines (2-40) instead of pitch_mm for Y. Max 400 stations total.' },
+                ...surfaceCommonProperties,
+            },
+            required: ['start_z_machine', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            const reason = String(args.reason || '').trim();
+            if (!reason) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            probeFeedService.assertNoOvertravel();
+            const plan = planProbeSurfaceGrid(args as Parameters<typeof planProbeSurfaceGrid>[0]);
+            return stageSurfaceScan(plan, reason, plan.grid ? `${plan.grid.xs.length}x${plan.grid.ys.length}` : '');
         },
     });
 


### PR DESCRIPTION
## Summary

Two staged touch-probe procedures for measuring a TOP surface, one operator approval per circuit, every commanded move enumerated with numbers on the confirm page, machine coordinates only:

- **`probe_surface_path`** — N −Z stations along a straight line (start + end, or direction + length; by count or maximum spacing). Result: per-station machine XYZ contact (or `no_contact`), confirm-pass spread, Z min/max/range, best-fit line (slope in mm/100 mm and degrees, rise over the length), flatness as residual peak-to-valley, text profile.
- **`probe_surface_grid`** — serpentine −Z grid over a region (extents or centre + size; by maximum pitch or counts, ≤ 400 stations). Result: `zMatrix` with coordinates, per-point contacts, best-fit plane + residuals, min/max/range, ASCII height map (+Y at the top).

## The safety envelope (operator, 2026-09-05)

> "with the grid we need the point to point variation to not risk the probe toolhead so no more than 20mm z safe delta from the top (within a horizontal change of 60mm)"

This is the **only** exception to motion law 2, valid inside these two procedures only, between consecutive stations only:

| Parameter | Default | Hard limit | Enforcement |
|---|---|---|---|
| `z_safe_delta_mm` | 20 | cap 20, min 3 | `resolveEnvelope` refuses at staging; runtime retracts to `lastContact + delta` (`hopHeightFor`) |
| `max_hop_mm` | 60 | cap 60 | `resolveEnvelope` + `assertHopsWithin` refuse at staging, naming the offending pair — never split silently |
| `max_drop_mm` | 40 | cap 80 | `stationEnvelope` floor = `max(lastContact − drop, floor_z_machine)`; floor without contact → `no_contact`, reference unchanged |
| `start_z_machine` | — | REQUIRED | law-2 approach: raise to traverse Z, hop at gantry height, guarded 1 mm descent (contact = CRASH) |

Runtime: hops go through `moveMachineSettled` with `clearExpectedContact()` in ≤ 10 mm sensor-checked segments (a touch during a hop latches CRASH); only marches run with `setExpectedContact(['probe'])`. Staged-position re-check with one re-read after ~1.2 s (the origin-offset transient), abort-raise to the traverse height, phases via `mcpBroadcast`, structured result on `job.result`.

Interpretation to review: the FIRST station finding nothing between `start_z_machine` and the floor **aborts** (no measured reference to hang the envelope on) — later stations record `no_contact` and continue.

## Files

- `surfaceScan.ts` — pure planning + statistics, no imports; unit-tested alone (23 tests: station generation, serpentine turns, 60 mm hop refusal, floors, line/plane fits + residuals, matrix, ASCII map).
- `probeSurface.ts` — plan builders, confirm-page gcode, runner.
- `tools/probing.ts` — the two registrations (`additionalProperties: false`, ranges in descriptions).
- README (tool surface, "Surface scans" subsection, file layout) and `.claude/skills/cnc-probing/SKILL.md` ("Surface flatness and height maps").

## Verification

- `tsc -p tsconfig-server.json --noEmit | grep services/mcp` → empty
- `eslint surfaceScan.ts probeSurface.ts tools/probing.ts` → 0 errors
- Unit tests on the compiled pure module → 23 passed
- Not run on hardware from this session (no machine reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
