### PR TITLE
Fix: Console input box mirrored history (ANSI codes) once the circular buffer filled

### DIFF
--- a/src/app/ui/widgets/Console/Console.jsx
+++ b/src/app/ui/widgets/Console/Console.jsx
@@ -21,6 +21,10 @@ import Terminal from './Terminal';
 
 let pubsubTokens = [];
 let unlisten = null;
+// Print the help/greeting only on the first ever mount - not again after the
+// operator clears the console and switches pages (history is legitimately
+// empty then).
+let hasGreeted = false;
 function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderStamp }) {
     const {
         connectionType,
@@ -384,13 +388,15 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
         });
 
         if (terminalHistory.getLength() === 0) {
-            terminalHistory.push('');
-            actions.getHelp();
-            actions.greetings();
+            if (!hasGreeted) {
+                hasGreeted = true;
+                actions.getHelp();
+                actions.greetings();
+            }
         } else {
             const terminal = terminalRef.current;
             const data = [];
-            for (let i = 1; i < terminalHistory.getLength(); i++) {
+            for (let i = 0; i < terminalHistory.getLength(); i++) {
                 data.push(`\r${terminalHistory.get(i)}\r\n`);
             }
             terminal.write(data.join(''));
@@ -467,15 +473,13 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
             if (terminal) {
                 terminal.clear(false);
                 const data = [];
-                for (let i = 1; i < terminalHistory.getLength(); i++) {
+                for (let i = 0; i < terminalHistory.getLength(); i++) {
                     data.push(`\r${terminalHistory.get(i)}\r\n`);
                 }
                 terminal.write(data.join(''));
             }
         }
     }, [isDefault]);
-
-    const inputValue = terminalHistory.getLength() > 0 ? terminalHistory.get(0) : '';
 
     return (
         <div>
@@ -486,7 +490,6 @@ function Console({ widgetId, widgetActions, minimized, isDefault, clearRenderSta
                 shouldRenderFitaddon={shouldRenderFitaddon}
                 terminalHistory={terminalHistory}
                 consoleHistory={consoleHistory}
-                inputValue={inputValue}
             />
         </div>
 

--- a/src/app/ui/widgets/Console/Terminal.jsx
+++ b/src/app/ui/widgets/Console/Terminal.jsx
@@ -14,16 +14,22 @@ const prompt = '> ';
 let verticalScrollbar = null;
 let term = null;
 let fitAddon = null;
+// The unsent command draft. Module-level (like `term` above) so it survives
+// the widget remounting on page switches. It must NOT live in terminalHistory:
+// that is a circular buffer of console lines, and once full, each push rotates
+// the reserved slot away and the input box starts mirroring console history -
+// ANSI colour codes and all.
+let inputDraft = '';
 
-const TerminalWrapper = forwardRef(({ inputValue: inputValueProp, terminalHistory, onData, consoleHistory, isDefault }, ref) => {
-    const [inputValue, setInputValue] = useState(inputValueProp);
+const TerminalWrapper = forwardRef(({ terminalHistory, onData, consoleHistory, isDefault }, ref) => {
+    const [inputValue, setInputValue] = useState(inputDraft);
     const [inputHeight, setInputHeight] = useState(20);
     const terminalContainer = useRef();
     const input = useRef();
     const actions = {
         changeInputValue: (event) => {
             setInputValue(event.target.value);
-            terminalHistory.set(0, event.target.value);
+            inputDraft = event.target.value;
         }
     };
 
@@ -131,21 +137,22 @@ const TerminalWrapper = forwardRef(({ inputValue: inputValueProp, terminalHistor
             onData(event.target.value);
             // Reset the index to the last position of the location array
             consoleHistory.push(event.target.value);
-            event.target.value = '';
-            setInputValue(event.target.value);
-            terminalHistory.set(0, event.target.value);
+            setInputValue('');
+            inputDraft = '';
         }
 
         // Arrow Up
         if (event.keyCode === 38) {
-            event.target.value = consoleHistory.back() || '';
-            terminalHistory.set(0, event.target.value);
+            const value = consoleHistory.back() || '';
+            setInputValue(value);
+            inputDraft = value;
         }
 
         // Arrow Down
         if (event.keyCode === 40) {
-            event.target.value = consoleHistory.forward() || '';
-            terminalHistory.set(0, event.target.value);
+            const value = consoleHistory.forward() || '';
+            setInputValue(value);
+            inputDraft = value;
         }
     }
 
@@ -183,7 +190,6 @@ const TerminalWrapper = forwardRef(({ inputValue: inputValueProp, terminalHistor
             term.clear();
             if (isHistory) {
                 terminalHistory.clear();
-                terminalHistory.push('');
             }
         }
     }
@@ -216,8 +222,6 @@ const TerminalWrapper = forwardRef(({ inputValue: inputValueProp, terminalHistor
         write
     }));
 
-    const command = terminalHistory.getLength() > 0 ? terminalHistory.get(0) : inputValue;
-
     return (
         <div
             className={isDefault ? styles['terminal-content-absolute'] : styles['terminal-content']}
@@ -239,7 +243,7 @@ const TerminalWrapper = forwardRef(({ inputValue: inputValueProp, terminalHistor
                 }}
                 type="text"
                 placeholder="Send Command"
-                value={command}
+                value={inputValue}
                 onChange={actions.changeInputValue}
                 onKeyDown={(event) => {
                     setTerminalInput(event);
@@ -253,7 +257,6 @@ TerminalWrapper.propTypes = {
     onData: PropTypes.func,
     isDefault: PropTypes.bool,
     terminalHistory: PropTypes.object.isRequired,
-    consoleHistory: PropTypes.object.isRequired,
-    inputValue: PropTypes.string.isRequired
+    consoleHistory: PropTypes.object.isRequired
 };
 export default TerminalWrapper;


### PR DESCRIPTION
Stacked on #78 (`mcp/44-surface-scans`).

## Symptom

During verbose MCP procedures (e.g. a `probe_circle` run, observed 2026-09-02) the Workspace console **input box** filled with console-history lines carrying raw ANSI colour codes, e.g. `[35m14:52:00.108 [mcp:circle:confirm:az135] > G53[39m`, and kept changing as new lines arrived. The Clear button emptied it.

## Root cause (single, for both symptoms)

`terminalHistory` is a `CircularArray(1000)` (`src/app/flux/workspace/state.ts`) doing double duty: **logical slot 0 held the input-box draft** (`<input value={terminalHistory.get(0)}>`) while every console line was `push()`ed into the same buffer. Once 1000 entries accumulate, each push rotates the start index — slot 0 stops being the draft and becomes the *oldest console line*, so the input element mirrors console history from then on. The ESC byte is unprintable in an `<input>`, leaving the visible `[35m…[39m`. Verbose MCP output fills the buffer quickly, which is why it surfaced mid-procedure.

Reproduced against the real `CircularArray`: the draft survives to entry 1000; entry 1001 replaces it with the first console line, and each further line marches the input through history.

**The `mcp:gcode` broadcast was never coloured.** The server sends raw gcode (`mcpBroadcast('mcp:gcode', { tool, gcode })` in `tools/camera.ts`); `cli-color` magenta is applied inside the Console widget for xterm rendering, where it belongs. Server-side log colouring is untouched.

## Fix

- **Terminal.jsx** — the draft now lives in a module-level `inputDraft` (same singleton pattern as the file's existing `term`/`fitAddon`, so it still survives page-switch remounts) and the `<input>` is fully controlled. All `terminalHistory.set(0, …)` calls removed; `clear()` no longer seeds a `''` sentinel; arrow-key recall goes through React state instead of writing `event.target.value` directly.
- **Console.jsx** — history-replay loops start at index 0 (they previously skipped the sentinel slot and, after rotation, silently dropped a real line); `inputValue` prop plumbing removed; a `hasGreeted` module flag preserves the existing behaviour of not re-printing the help text after clear + page switch.

MCP activity now flows only into the console history display; the input box can never receive it regardless of buffer volume.

Zero new dependencies. ESLint clean on both files (only pre-existing `exhaustive-deps` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)