### PR TITLE
Feature: probe_program composite survey, job timing breakdown, first-station floor

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -236,6 +236,33 @@ result says `approach: slow-zone | coarse-contact` and `worstPressMm`. `coarse_s
 is capped at 1 mm in surface scans (operator law: never 2; 0.5–1). On the GPIO
 transport `sensor_delay_ms: 50` is ample.
 
+## Whole-stock programs (one approval)
+
+`probe_program` strings operations into ONE approved job: `rotate_b` (absolute B;
+the runner refuses it unless the toolhead is at/above the traverse height),
+`surface_path`, `surface_grid` and `sequence` with their usual arguments. Where a
+later op needs a number only an earlier op can measure, pass a REFERENCE with
+operator-approved bounds - `expected_z_machine: {"from": "c90.top.z", "between":
+[200, 240]}` (sequence op `c90`, probe named `top`), `start_z_machine: {"from":
+"c90.top.z", "plus": 7, "between": [205, 250]}`, a sequence `descend` `z: {"from":
+"ns90.summary.zMean", "minus": 7, "between": [...]}`. Bounds are required (law 3):
+the confirm page shows them, and the runner refuses the op outside them, stops the
+program raised and keeps earlier results under `result.ops`. Order ops so every
+reference points backwards; `on_fail: "skip"` lets an overtravel-type op fail
+without ending the program. A four-face survey is `rotate_b 90 → centre sequence →
+N-S path → W-E path → sides sequence → rotate_b 180 → …`; budget the event log
+(≈ 100 + stations × 120 per scan op) before staging and use
+`wait_for_approval_ms` to start.
+
+**Speed.** Read `result.timing` (or `get_job_timing`) after a scan instead of mining
+events: per command kind it gives count, feeds, distance, controller time vs motion
+time vs overhead, idle and sensor windows, plus per-station wall time. The coarse walk
+down from the hop height is the biggest cost (~19 of 30 commands per station at
+`z_safe_delta_mm` 20), so on stock known to vary < 5 mm between stations use
+`z_safe_delta_mm: 5`, `confirm_passes: 2` and `sensor_delay_ms: 30` on GPIO (an
+11-station path ~400 s → ~170 s). Never raise the coarse feed yourself: impact speed is
+the operator's call.
+
 **Event-log budget — check it BEFORE staging a large scan.** The job keeps at most
 `mcpJobEventLimit` events (default 2000; `get_mcp_diagnostics` → `buffers` and the
 Settings pane show the live value). Beyond that the log keeps its first 20 events

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -271,6 +271,52 @@ surface scans** (operator, job cdbc29371b97: "we never wanted 2mm"; range 0.5–
 Verified on the rerun (cdbc29371b97, 8/8, same numbers as d8f6): every station
 `slow-zone`, `worstPressMm 0.1`, 408 s vs 492 s.
 
+**Where the time goes (measured 2026-09-05, on-box analysis of the four-face survey).** Every
+command batch costs ~270 ms over its motion time on the WiFi channel (four HTTP lines per
+batch); motion time is distance / feed, so short steps are dominated by that overhead.
+
+| Step | Feed | Motion | Measured per command |
+|---|---|---|---|
+| Coarse 1 mm | F100 | 600 ms | ~874 ms |
+| Fine 0.1 mm | F60 | 100 ms | ~365 ms |
+| Backoff 0.3 mm | F60 | 300 ms | ~574 ms |
+| Retract 20 mm | F600 | 2000 ms | ~2280 ms |
+| Descent segment 5 mm | F600 | 500 ms | ~834 ms |
+| Raise 120 mm | F600 | 12 s | ~12.4 s |
+
+An 11-station path at 402 s split as: 179 s coarse steps, 51 s fine, 35 s confirm, 26 s
+retracts, 20 s hops, 18 s station-1 guard band, 17 s backoffs, 14 s initial descent, 16 s
+traverse + final raise, 25 s of sensor windows; ~31.5 s per station of which 19 of the 30
+commands are the coarse walk back down from the 20 mm hop height. Levers, no code needed:
+`z_safe_delta_mm` 20 → 5 (~145 s per scan; the hop guard still catches a surface rising > 5 mm),
+`confirm_passes` 2 (~19 s), `sensor_delay_ms` 30 (~8 s); coarse feed F100 → F300 (~80 s) is an
+operator call on impact speed. Code levers: `get_job_timing` / `result.timing` now compute this
+breakdown from any job's events (per kind: count, feeds, distance, controller vs motion vs
+overhead, idle, sensor windows; per station; waits). One-line `G53 G1 …` (three lines per
+batch, no workspace switch, ~100 s per scan) is NOT used: it is unverified on this firmware and
+an unsupported inline G53 would execute in WORK coordinates. Station 1 of a surface scan now searches down to an explicit `floor_z_machine` (job
+d7ac9247838e aborted because only start − max_drop was honoured).
+
+**`probe_program` — one approval for a whole survey (2026-09-06).** An ordered list of
+operations, staged once and approved on ONE confirm page that enumerates every op's envelope
+and the B rotation schedule, run by one runner that hands the machine from op to op (each ends
+raised at the traverse height): `rotate_b` (absolute B on the direct path, refused unless the
+toolhead is at/above the safe traverse height, verified by the M114 in the same batch or the
+heartbeat's `b`), `surface_path`, `surface_grid` and `sequence` with their standalone
+arguments. Numbers an op cannot know at staging are **references** to earlier results —
+`{from: "c90.top.z", plus: 7, between: [200, 240]}` (a sequence probe by name, `.z` shorthand
+for `contactMachine.z`) or `{from: "ns90.summary.zMean", minus: 7, between: [...]}` — with
+operator-approved **bounds required** (law 3): the page shows the bounds and a preview plan at
+the mid-point, and the runner refuses the op if the resolved value falls outside them,
+stopping the program raised and keeping every earlier result under `result.ops`. `on_fail:
+"skip"` records a failure and continues (rotations always stop). Each op result is the
+standalone tool's result object. The four-face survey that took 18 approvals is one program:
+`rotate_b 90 → sequence (centre) → surface_path N–S (expected from the centre) → surface_path
+W–E → sequence (sides) → rotate_b 180 → …`. Still to do from the brief
+([docs/COMPOSITE_PROBE_PROGRAM.md](docs/COMPOSITE_PROBE_PROGRAM.md)): multi-segment paths in
+one op (stage two path ops for now), tip diameter as configuration, the stock-geometry
+reduction (section size, centring, yaw), live progress on the confirm page.
+
 ## Safety model (operator-defined, non-negotiable)
 
 - **Compound motion and all cutting goes out as gcode FILES** through the same
@@ -481,7 +527,7 @@ Full agent guidance in `.claude/skills/tool-change/SKILL.md`.
   operator to close their copy. The build dirties `src/package.json` and
   `MaterialTestGcodeParams.jsx` — revert before staging.
 - **Stack**: stacked single-commit PRs `mcp/N-*`, each targeting the previous branch
-  (#15 → #79 as of 2026-09-05, then `mcp/46-position-of-record`; next `mcp/47`. #70 stale-
+  (#15 → #79 as of 2026-09-05, then `mcp/46-position-of-record` (#80) and `mcp/47-timing-inline-g53`; next `mcp/48`. #70 stale-
   heartbeat, #71 probe_sequence, #72 GPIO probe feed, #73 Linux/mac packaging, #74 machine
   settings + docs, #75 sensor toggles + LAN, #76 job events + even survey, #77 offset
   transient + detached procedures, #78 surface scans, #79 console input leak, mcp/46 position

--- a/src/server/services/mcp/docs/COMPOSITE_PROBE_PROGRAM.md
+++ b/src/server/services/mcp/docs/COMPOSITE_PROBE_PROGRAM.md
@@ -1,0 +1,76 @@
+<!-- Written by the on-box GPT-5.6 agent on 2026-09-05 after the four-face rotary-stock survey
+(see the "Timing" section of the MCP README for the measured cost table it is based on). Kept
+verbatim as the design brief. Implemented 2026-09-06 as the `probe_program` tool (probeProgram.ts):
+items 1, 2, 3 (bounded references), 9 (abort semantics) and 11 (per-op parameters); item 4 via the
+explicit-floor fix; items 5, 6, 7, 8 (beyond the configurable event limit) and 10 remain open. -->
+
+# Proposal: one approved operation for a multi-rotation stock survey
+
+Goal: stage ONCE, operator approves ONCE, runner performs: for B in [0, 90, 180, 270]:
+rotate -> centre probe -> N-S top scan (overtravel past the end) -> W-E top scan (both edges);
+plus horizontal side + end marches at two rotations. Today this is 18 approvals (~75 min wall).
+
+## What the tooling lacks today (each item is a concrete gap hit on 2026-09-05)
+1. **A composite procedure job (`probe_program`)**: ordered `ops[]`, each op one of
+   `rotate_b | surface_path | surface_grid | sequence` with its own envelope; ONE confirm page
+   enumerating every op's envelope (extents, floors, hop heights, B targets); ONE runner;
+   partial results kept per op on abort. Existing runners (probeSurface, probeSequence) become
+   callable op executors sharing the position-of-record and the crash guard.
+2. **B rotation inside a procedure** (`rotate_b` op): today only a file job can move B (Z returns
+   to top, door interlock, separate approval). Needs: direct guarded `G0 B<abs>` via the same
+   path as moveMachineSettled, verified-settle on B (M114 B within 0.01 of target - heartbeat
+   `b` lags ~1 beat), precondition toolhead Z >= traverse Z (320) or XY outside a declared
+   sweep radius, and the confirm page saying "stock WILL rotate to B90/180/270".
+3. **Run-time references between ops**: `expected_z_machine: {from: "centre_b90"}`,
+   `start_z_machine: {from: "centre_b90", plus: 7}`, side-march Z `{from: "ns_b180.zMean",
+   minus: 7}`. Staging cannot know the value, so each reference carries operator-approved
+   BOUNDS (`between: [195, 235]`); the runner refuses the op if the resolved value falls
+   outside, raises, and stops. The confirm page shows the bounds, not a number.
+4. **First-station search window**: station 1 aborts unless a surface lies within max_drop_mm
+   of start_z even when floor_z_machine is explicitly lower (d7ac9247838e). Add
+   `first_station_search_mm` (bounded by the floor) or honour the explicit floor for station 1
+   only when no expected_z is given. With (3) this is mostly moot but still a footgun.
+5. **Multi-segment paths in one op**: `segments: [{start, end}, ...]` sharing a reference, so
+   W-E from the measured centre outward to both edges is one op (today two jobs, or an
+   off-stock first station aborts - 1dc39a8210a4).
+6. **Tip radius as configuration** (`probeTipDiameterMm` in the tool-setter config): side and
+   end marches report contact centre AND corrected face; width/thickness/end position come out
+   corrected. Unpinned today (~2.5 mm per README, inconsistent).
+7. **Stock-geometry reduction in the result**: faces keyed by B; per face: mean/slope/flatness;
+   across faces: section dimensions (opposite-face pair means), axis height, centring offsets,
+   yaw and pitch of the stock centreline (from side pairs and pair-mean slopes), end squareness.
+   All the arithmetic done by hand in REPORT-four-face-scan-2026-09-05.md.
+8. **Event budget**: a full program is ~6,000-8,000 events at today's verbosity (537 batches x
+   2 events per 11-station scan + readings). Either per-op event logs, or `mcpJobEventLimit`
+   default 10,000, or drop the per-batch `response` payload behind a verbosity flag. Summaries
+   and per-op results must never be trimmed.
+9. **Abort semantics**: any op failure (no contact at station 1, hop-guard contact, crash
+   alarm, B settle failure) -> raise to traverse Z, mark the op failed, stop the program, keep
+   all earlier op results. Optional `on_fail: skip|stop` per op for overtravel-type ops.
+10. **Confirm page for long programs**: live progress (op k of n, station, ETA from the timing
+    table), the B schedule, total extents, and the token TTL is irrelevant once
+    wait_for_approval_ms hands off - but the page should keep working as a monitor for the
+    ~40-70 min run.
+11. **Speed knobs exposed per op** (from the timing analysis): z_safe_delta_mm (use 5), coarse
+    feed (F100 -> F300, operator-gated default), single G53 window per march, confirm_passes 2,
+    sensor_delay 30. With these the full program is ~35-40 min instead of ~75.
+
+## Sketch of the request
+```json
+{"name":"four-face survey","ops":[
+ {"id":"rot90","kind":"rotate_b","b":90,"require_z_at_least":320},
+ {"id":"c90","kind":"sequence","steps":[{"kind":"hop","x":170,"y":199},{"kind":"descend","z":235},
+   {"kind":"probe","name":"top","dz":-1,"max_travel_mm":40}]},
+ {"id":"ns90","kind":"surface_path","start_x":170,"start_y":262,"end_x":170,"end_y":120,"spacing_mm":15,
+   "expected_z_machine":{"from":"c90.top.z","between":[195,235]},"start_z_machine":{"from":"c90.top.z","plus":7},
+   "max_drop_mm":10,"z_safe_delta_mm":5},
+ {"id":"we90","kind":"surface_path","segments":[{"start":[170,199],"end":[115,199]},{"start":[170,199],"end":[225,199]}],
+   "spacing_mm":14,"expected_z_machine":{"from":"c90.top.z"},"start_z_machine":{"from":"c90.top.z","plus":7}},
+ {"id":"sides90","kind":"sequence","steps":[{"kind":"hop","x":118,"y":150},{"kind":"descend","z":{"from":"c90.top.z","minus":7,"between":[195,230]}},
+   {"kind":"probe","name":"west_y150","dx":1,"max_travel_mm":25}, "..."]},
+ {"id":"rot180","kind":"rotate_b","b":180}, "..."]}
+```
+Laws preserved: the confirm page is still the single motion gate (law 6); every XY move is at
+traverse height or inside the approved station envelope (law 2); every number is measured,
+operator-stated, or a bounded reference to a measurement made earlier in the same approved
+program (law 3); rotations are enumerated on the page (law 1's "no inferred approvals").

--- a/src/server/services/mcp/jobTiming.ts
+++ b/src/server/services/mcp/jobTiming.ts
@@ -1,0 +1,332 @@
+import { JobEvent } from './jobs';
+
+// Where a procedure's time went, computed from its own event log (pure, so an
+// agent gets the breakdown from get_gcode_job_status / get_job_timing instead
+// of mining events by hand - operator request 2026-09-05 after the four-face
+// scan analysis). Every direct command is one `gcode` send event (tool,
+// gcode, idleMs, senseMs...) followed by its reply event (execMs, response);
+// the runner's phase events (hop-<label>, measured-<label>, ...) delimit the
+// stations. Motion time is distance / feed from the commanded coordinates;
+// the rest of execMs is controller + HTTP overhead (four lines per batch on
+// the WiFi channel, ~270 ms measured).
+
+export type CommandKind =
+    | 'coarse' | 'fine' | 'confirm' | 'backoff' | 'release' | 'retract'
+    | 'hop' | 'descend-guard' | 'descend' | 'raise' | 'traverse' | 'travel' | 'retreat' | 'other';
+
+const KIND_PATTERNS: [RegExp, CommandKind][] = [
+    [/:descend-guard/, 'descend-guard'],
+    [/:descend/, 'descend'],
+    [/:coarse/, 'coarse'],
+    [/:fine/, 'fine'],
+    [/:confirm/, 'confirm'],
+    [/:backoff/, 'backoff'],
+    [/:release/, 'release'],
+    [/:retract/, 'retract'],
+    [/:hop/, 'hop'],
+    [/(final-|abort-)?raise/, 'raise'],
+    [/:traverse/, 'traverse'],
+    [/:travel/, 'travel'],
+    [/retreat/, 'retreat'],
+];
+
+export function classifyCommand(tool: string): CommandKind {
+    for (const [pattern, kind] of KIND_PATTERNS) {
+        if (pattern.test(tool)) {
+            return kind;
+        }
+    }
+    return 'other';
+}
+
+export interface CommandRecord {
+    seq: number;
+    at: number;
+    tool: string;
+    kind: CommandKind;
+    /** Commanded machine-frame words present in the batch. */
+    target: { x?: number; y?: number; z?: number };
+    feed: number | null;
+    /** Straight-line distance from the previous command's target (null when unknown). */
+    distanceMm: number | null;
+    /** distance / feed, ms (null when unknown). */
+    motionMs: number | null;
+    /** Send -> controller reply. */
+    execMs: number | null;
+    /** execMs - motionMs (controller + transport overhead per batch). */
+    overheadMs: number | null;
+    /** Previous reply -> this send (sensor window + runner logic + engine). */
+    idleMs: number | null;
+    /** Sensor window that preceded this send. */
+    senseMs: number | null;
+}
+
+export interface KindSummary {
+    kind: CommandKind;
+    count: number;
+    feeds: number[];
+    distanceMm: number;
+    execMs: number;
+    motionMs: number;
+    overheadMs: number;
+    idleMs: number;
+    senseMs: number;
+    meanExecMs: number | null;
+    meanOverheadMs: number | null;
+}
+
+export interface StationTiming {
+    label: string;
+    /** Wall time from the previous station's end (or the run start) to this station's measured/no-contact event. */
+    ms: number;
+    commands: number;
+    byKind: { [kind: string]: { count: number; execMs: number; idleMs: number } };
+    outcome: 'contact' | 'no_contact';
+    approach: 'slow-zone' | 'coarse-contact' | 'unknown';
+}
+
+export interface JobTiming {
+    events: number;
+    commands: number;
+    /** submitted -> approved */
+    approvalWaitMs: number | null;
+    /** started -> completed/failed (or the last event while running) */
+    runMs: number | null;
+    /** Sum over commands. */
+    totals: { execMs: number; motionMs: number; overheadMs: number; idleMs: number; senseMs: number };
+    byKind: KindSummary[];
+    stations: StationTiming[];
+    medianStationMs: number | null;
+    waits: {
+        settleWaits: number;
+        settleWaitMs: number;
+        slowSteps: number;
+        slowStepMs: number;
+        positionEstimated: number;
+        eventLoopStalls: number;
+        heartbeatFrameFlips: number;
+    };
+    note: string;
+}
+
+function round(value: number): number {
+    return Math.round(value);
+}
+
+function parseWords(gcode: string): { target: { x?: number; y?: number; z?: number }; feed: number | null } {
+    const line = (gcode.match(/G0?1\b[^\n]*/) || [''])[0];
+    const target: { x?: number; y?: number; z?: number } = {};
+    const x = line.match(/\bX(-?\d+(?:\.\d+)?)/);
+    const y = line.match(/\bY(-?\d+(?:\.\d+)?)/);
+    const z = line.match(/\bZ(-?\d+(?:\.\d+)?)/);
+    if (x) {
+        target.x = Number(x[1]);
+    }
+    if (y) {
+        target.y = Number(y[1]);
+    }
+    if (z) {
+        target.z = Number(z[1]);
+    }
+    const f = line.match(/\bF(\d+(?:\.\d+)?)/);
+    return { target, feed: f ? Number(f[1]) : null };
+}
+
+/** Pair every gcode send with its reply and derive motion/overhead per command. */
+export function extractCommands(events: JobEvent[]): CommandRecord[] {
+    const commands: CommandRecord[] = [];
+    const last: { x?: number; y?: number; z?: number } = {};
+    let pendingIndex = -1;
+    for (const event of events) {
+        if (event.phase !== 'gcode') {
+            continue;
+        }
+        const e = event as JobEvent & { gcode?: string; response?: string; execMs?: number; idleMs?: number; senseMs?: number; tool?: string };
+        if (typeof e.gcode === 'string') {
+            const { target, feed } = parseWords(e.gcode);
+            const axes = (['x', 'y', 'z'] as const).filter((axis) => target[axis] !== undefined);
+            let distance: number | null = null;
+            if (axes.length && axes.every((axis) => last[axis] !== undefined)) {
+                distance = Math.hypot(...axes.map((axis) => (target[axis] as number) - (last[axis] as number)));
+            }
+            axes.forEach((axis) => {
+                last[axis] = target[axis];
+            });
+            const motionMs = distance !== null && feed ? (distance / feed) * 60000 : null;
+            commands.push({
+                seq: e.seq,
+                at: e.at,
+                tool: String(e.tool || ''),
+                kind: classifyCommand(String(e.tool || '')),
+                target,
+                feed,
+                distanceMm: distance === null ? null : Number(distance.toFixed(3)),
+                motionMs: motionMs === null ? null : round(motionMs),
+                execMs: null,
+                overheadMs: null,
+                idleMs: typeof e.idleMs === 'number' ? e.idleMs : null,
+                senseMs: typeof e.senseMs === 'number' ? e.senseMs : null,
+            });
+            pendingIndex = commands.length - 1;
+        } else if (typeof e.response === 'string' && pendingIndex >= 0) {
+            const command = commands[pendingIndex];
+            if (command.execMs === null) {
+                const exec = typeof e.execMs === 'number' ? e.execMs : e.at - command.at;
+                command.execMs = exec;
+                command.overheadMs = command.motionMs === null ? null : exec - command.motionMs;
+            }
+        }
+    }
+    return commands;
+}
+
+function summarizeKinds(commands: CommandRecord[]): KindSummary[] {
+    const map = new Map<CommandKind, KindSummary>();
+    for (const c of commands) {
+        let s = map.get(c.kind);
+        if (!s) {
+            s = {
+                kind: c.kind,
+                count: 0,
+                feeds: [],
+                distanceMm: 0,
+                execMs: 0,
+                motionMs: 0,
+                overheadMs: 0,
+                idleMs: 0,
+                senseMs: 0,
+                meanExecMs: null,
+                meanOverheadMs: null,
+            };
+            map.set(c.kind, s);
+        }
+        s.count += 1;
+        if (c.feed !== null && !s.feeds.includes(c.feed)) {
+            s.feeds.push(c.feed);
+        }
+        s.distanceMm += c.distanceMm || 0;
+        s.execMs += c.execMs || 0;
+        s.motionMs += c.motionMs || 0;
+        s.overheadMs += c.overheadMs || 0;
+        s.idleMs += c.idleMs || 0;
+        s.senseMs += c.senseMs || 0;
+    }
+    const list = [...map.values()].map((s) => ({
+        ...s,
+        distanceMm: Number(s.distanceMm.toFixed(3)),
+        meanExecMs: s.count ? round(s.execMs / s.count) : null,
+        meanOverheadMs: s.count ? round(s.overheadMs / s.count) : null,
+    }));
+    return list.sort((a, b) => b.execMs + b.idleMs - (a.execMs + a.idleMs));
+}
+
+const STATION_END = /^(measured|no-contact)-(.+)$/;
+
+function summarizeStations(events: JobEvent[], commands: CommandRecord[]): StationTiming[] {
+    const stations: StationTiming[] = [];
+    const started = events.find((e) => e.phase === 'started');
+    // Exclusive lower bound: a command sent in the same millisecond as
+    // 'started' still belongs to the first station.
+    const firstAt = events.length ? events[0].at : 0;
+    let windowStart = (started ? started.at : firstAt) - 1;
+    let approach: StationTiming['approach'] = 'unknown';
+    for (const event of events) {
+        if (/^fine-contact-/.test(event.phase)) {
+            approach = 'slow-zone';
+        } else if (/^coarse-contact-/.test(event.phase)) {
+            approach = 'coarse-contact';
+        }
+        const m = event.phase.match(STATION_END);
+        if (!m) {
+            continue;
+        }
+        const inWindow = commands.filter((c) => c.at > windowStart && c.at <= event.at);
+        const byKind: StationTiming['byKind'] = {};
+        for (const c of inWindow) {
+            const k = byKind[c.kind] || { count: 0, execMs: 0, idleMs: 0 };
+            k.count += 1;
+            k.execMs += c.execMs || 0;
+            k.idleMs += c.idleMs || 0;
+            byKind[c.kind] = k;
+        }
+        stations.push({
+            label: m[2],
+            ms: event.at - windowStart,
+            commands: inWindow.length,
+            byKind,
+            outcome: m[1] === 'measured' ? 'contact' : 'no_contact',
+            approach,
+        });
+        windowStart = event.at;
+        approach = 'unknown';
+    }
+    return stations;
+}
+
+function sumNotesMs(events: JobEvent[], phase: string): { count: number; ms: number } {
+    let count = 0;
+    let ms = 0;
+    for (const e of events) {
+        if (e.phase !== phase) {
+            continue;
+        }
+        count += 1;
+        const numeric = (e as JobEvent & { ms?: number }).ms;
+        if (typeof numeric === 'number') {
+            ms += numeric;
+        } else {
+            const m = String(e.note || '').match(/after (\d+) ms/);
+            if (m) {
+                ms += Number(m[1]);
+            }
+        }
+    }
+    return { count, ms };
+}
+
+export function summarizeJobTiming(events: JobEvent[]): JobTiming {
+    const commands = extractCommands(events);
+    const byKind = summarizeKinds(commands);
+    const stations = summarizeStations(events, commands);
+    const totals = commands.reduce((acc, c) => ({
+        execMs: acc.execMs + (c.execMs || 0),
+        motionMs: acc.motionMs + (c.motionMs || 0),
+        overheadMs: acc.overheadMs + (c.overheadMs || 0),
+        idleMs: acc.idleMs + (c.idleMs || 0),
+        senseMs: acc.senseMs + (c.senseMs || 0),
+    }), { execMs: 0, motionMs: 0, overheadMs: 0, idleMs: 0, senseMs: 0 });
+    const find = (phase: string) => events.find((e) => e.phase === phase);
+    const submitted = find('submitted');
+    const approved = find('approved');
+    const started = find('started');
+    const ended = events.find((e) => e.phase === 'completed' || e.phase === 'failed' || e.phase === 'stopped');
+    const lastAt = events.length ? events[events.length - 1].at : null;
+    const sortedStations = stations.filter((s) => s.outcome === 'contact').map((s) => s.ms).sort((a, b) => a - b);
+    const endAt = ended ? ended.at : lastAt;
+    const runMs = started && endAt !== null ? endAt - started.at : null;
+    const settle = sumNotesMs(events, 'settle-done');
+    const slow = sumNotesMs(events, 'slow_step');
+    return {
+        events: events.length,
+        commands: commands.length,
+        approvalWaitMs: submitted && approved ? approved.at - submitted.at : null,
+        runMs,
+        totals,
+        byKind,
+        stations,
+        medianStationMs: sortedStations.length ? sortedStations[Math.floor((sortedStations.length - 1) / 2)] : null,
+        waits: {
+            settleWaits: settle.count,
+            settleWaitMs: settle.ms,
+            slowSteps: slow.count,
+            slowStepMs: slow.ms,
+            positionEstimated: events.filter((e) => e.phase === 'position-estimated').length,
+            eventLoopStalls: events.filter((e) => e.phase === 'event_loop_stall').length,
+            heartbeatFrameFlips: events.filter((e) => e.phase === 'heartbeat_frame_flip').length,
+        },
+        note: 'execMs = send -> controller reply per command batch; motionMs = commanded distance / feed; overheadMs = the '
+            + 'difference (controller + transport per batch); idleMs = previous reply -> this send (sensor window + runner); '
+            + 'senseMs = the sensor window inside that idle. Stations are delimited by the runner\'s measured-/no-contact- '
+            + 'events. Levers: fewer coarse steps (smaller z_safe_delta_mm), coarse feed, confirm_passes, sensor_delay_ms.',
+    };
+}

--- a/src/server/services/mcp/probeProgram.ts
+++ b/src/server/services/mcp/probeProgram.ts
@@ -1,0 +1,345 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention (planProbeProgram takes the
+// probe_program arguments verbatim).
+import { mcpBroadcast } from './index';
+import { probeFeedService } from './probeFeed';
+import {
+    ProbeSequencePlan,
+    describeProbeSequencePlanAsGcode,
+    planProbeSequence,
+    runProbeSequenceProcedure,
+} from './probeSequence';
+import {
+    ProbeSurfacePlan,
+    describeProbeSurfacePlanAsGcode,
+    planProbeSurfaceGrid,
+    planProbeSurfacePath,
+    runProbeSurfaceProcedure,
+} from './probeSurface';
+import {
+    ProcedureAbort,
+    ROTATE_FEED,
+    TRAVEL_FEED,
+    assertMachineReadyForProcedure,
+    knownMachinePosition,
+    moveMachineSettled,
+    rotateB,
+} from './probing';
+import {
+    RefResolveError,
+    RefSpec,
+    refMidpoint,
+    resolveRef,
+    substituteRefs,
+    validateRef,
+} from './programRefs';
+import { McpToolError } from './registry';
+import { getPositionSnapshot, safeTraverseZ } from './tools/machine';
+
+// A composite probing PROGRAM: an ordered list of operations - rotate the
+// rotary axis, top-surface scans (path / grid), probe sequences (side and
+// end marches) - staged ONCE, approved ONCE on a single confirm page that
+// enumerates every operation's envelope and every rotation, and run by ONE
+// runner that hands the machine from operation to operation. Operator
+// request 2026-09-05 after a four-face survey that took 18 approvals.
+//
+// Numbers an operation needs but cannot know at staging (the top of the
+// face that a centre probe earlier in the SAME program will measure) are
+// REFERENCES to earlier results: { from: "c90.top.z", plus: 7, between:
+// [195, 240] }. Law 3 is kept by the bounds: the operator approves the
+// range, the runner refuses the operation (and stops the program, raised)
+// if the resolved value falls outside it, and the confirm page shows the
+// bounds with a preview plan computed at the mid-point. Every other law is
+// unchanged: each operation runs through the existing runners (position of
+// record, crash guard, hop envelope, slow zone, segmented descents), a
+// rotation requires the toolhead at or above the safe traverse height, and
+// every operation ends raised at that height.
+
+export { isRef, lookupPath, resolveRef, substituteRefs } from './programRefs';
+export type { RefSpec } from './programRefs';
+
+export type ProgramOpKind = 'rotate_b' | 'surface_path' | 'surface_grid' | 'sequence';
+
+export interface ProgramOp {
+    id: string;
+    kind: ProgramOpKind;
+    /** Raw arguments for the underlying tool (numbers or references). */
+    args: { [key: string]: unknown };
+    /** What to do when this op fails: stop the program (default) or record and continue. Rotations always stop. */
+    on_fail: 'stop' | 'skip';
+    /** Dotted arg paths that hold references, with their bounds (for the page). */
+    refs: { path: string; ref: RefSpec }[];
+}
+
+export interface ProbeProgramPlan {
+    name: string;
+    ops: ProgramOp[];
+    hopZ: number;
+    staged: { x: number; y: number; z: number; b: number | null };
+    /** Preview descriptions (refs at their mid-point) for the confirm page. */
+    previews: { id: string; text: string }[];
+    rotations: number[];
+}
+
+const MAX_OPS = 40;
+const ID_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,31}$/;
+
+type SubPlan =
+    | { kind: 'surface_path'; plan: ProbeSurfacePlan }
+    | { kind: 'surface_grid'; plan: ProbeSurfacePlan }
+    | { kind: 'sequence'; plan: ProbeSequencePlan };
+
+function buildSubPlan(kind: ProgramOpKind, args: { [key: string]: unknown }): SubPlan {
+    if (kind === 'surface_path') {
+        return { kind, plan: planProbeSurfacePath(args as Parameters<typeof planProbeSurfacePath>[0]) };
+    }
+    if (kind === 'surface_grid') {
+        return { kind, plan: planProbeSurfaceGrid(args as Parameters<typeof planProbeSurfaceGrid>[0]) };
+    }
+    if (kind === 'sequence') {
+        return { kind, plan: planProbeSequence(args as Parameters<typeof planProbeSequence>[0]) };
+    }
+    throw new McpToolError(`Unsupported op kind ${kind}.`);
+}
+
+function describeSubPlan(sub: SubPlan): string {
+    return sub.kind === 'sequence' ? describeProbeSequencePlanAsGcode(sub.plan) : describeProbeSurfacePlanAsGcode(sub.plan);
+}
+
+export function planProbeProgram(args: { name?: unknown; ops?: unknown }): ProbeProgramPlan {
+    const name = String(args.name || '').trim();
+    if (!name) {
+        throw new McpToolError('name is required (shown to the operator).');
+    }
+    if (!Array.isArray(args.ops) || args.ops.length < 1 || args.ops.length > MAX_OPS) {
+        throw new McpToolError(`ops is required: 1-${MAX_OPS} operations of kind rotate_b | surface_path | surface_grid | sequence.`);
+    }
+    const snapshot = getPositionSnapshot();
+    const { x, y, z } = snapshot.machine;
+    if (x === null || y === null || z === null) {
+        throw new McpToolError('Current machine position unknown; cannot anchor the program.');
+    }
+    const hopZ = safeTraverseZ();
+    const ids = new Set<string>();
+    const ops: ProgramOp[] = [];
+    const previews: { id: string; text: string }[] = [];
+    const rotations: number[] = [];
+    let anyRotate = false;
+
+    (args.ops as unknown[]).forEach((raw, index) => {
+        const where = `ops[${index}]`;
+        if (!raw || typeof raw !== 'object') {
+            throw new McpToolError(`${where}: must be an object.`);
+        }
+        const op = raw as { [key: string]: unknown };
+        const id = String(op.id || '');
+        if (!ID_PATTERN.test(id)) {
+            throw new McpToolError(`${where}: id is required (letters, digits, _ or -, max 32 chars) - other ops reference results by it.`);
+        }
+        if (ids.has(id)) {
+            throw new McpToolError(`${where}: duplicate id "${id}".`);
+        }
+        ids.add(id);
+        const kind = String(op.kind || '') as ProgramOpKind;
+        if (!['rotate_b', 'surface_path', 'surface_grid', 'sequence'].includes(kind)) {
+            throw new McpToolError(`${where}: kind must be rotate_b, surface_path, surface_grid or sequence.`);
+        }
+        const onFail = op.on_fail === 'skip' ? 'skip' : 'stop';
+        const opArgs: { [key: string]: unknown } = {};
+        for (const [key, value] of Object.entries(op)) {
+            if (!['id', 'kind', 'on_fail'].includes(key)) {
+                opArgs[key] = value;
+            }
+        }
+
+        if (kind === 'rotate_b') {
+            const b = Number(opArgs.b);
+            if (!Number.isFinite(b) || b < -360 || b > 360) {
+                throw new McpToolError(`${where} (rotate_b): b is required, absolute degrees in -360..360.`);
+            }
+            const requireZ = opArgs.require_z_at_least === undefined ? hopZ : Number(opArgs.require_z_at_least);
+            if (!Number.isFinite(requireZ) || requireZ < hopZ) {
+                throw new McpToolError(`${where} (rotate_b): require_z_at_least must be >= the safe traverse height ${hopZ} (law 2: the stock turns under a raised head).`);
+            }
+            if (!snapshot.isFourAxis) {
+                throw new McpToolError(`${where} (rotate_b): the heartbeat reports no B axis - is the rotary module installed and selected in Machine Settings?`);
+            }
+            anyRotate = true;
+            rotations.push(b);
+            ops.push({ id, kind, args: { b, require_z_at_least: requireZ }, on_fail: 'stop', refs: [] });
+            previews.push({ id, text: `; ROTATE STOCK: B -> ${b} deg (absolute), requires toolhead machine Z >= ${requireZ}\nG90\nG0 B${b.toFixed(3)} F${ROTATE_FEED}; verified by M114 (B within 0.05 deg)` });
+            return;
+        }
+
+        // Validate references (bounds), then build a PREVIEW plan at the
+        // mid-point of each bounded reference so the page can enumerate the
+        // envelope and every cap is checked now, not at run time.
+        let previewArgs: { [key: string]: unknown };
+        let refs: { path: string; ref: RefSpec }[];
+        try {
+            ({ args: previewArgs, refs } = substituteRefs(opArgs, (ref, path) => {
+                validateRef(ref, `${where}.${path}`);
+                return refMidpoint(ref);
+            }));
+        } catch (err) {
+            if (err instanceof RefResolveError) {
+                throw new McpToolError(err.message);
+            }
+            throw err;
+        }
+        if (refs.some((r) => !ids.has(r.ref.from.split('.')[0]) || r.ref.from.split('.')[0] === id)) {
+            const bad = refs.find((r) => !ids.has(r.ref.from.split('.')[0]) || r.ref.from.split('.')[0] === id) as { ref: RefSpec };
+            throw new McpToolError(`${where}: reference "${bad.ref.from}" points at an op that does not run BEFORE this one.`);
+        }
+        let preview: SubPlan;
+        try {
+            preview = buildSubPlan(kind, previewArgs);
+        } catch (err) {
+            throw new McpToolError(`${where} ("${id}", ${kind}): ${(err as Error).message}`);
+        }
+        ops.push({ id, kind, args: opArgs, on_fail: onFail, refs });
+        const refLines = refs.map((r) => `; REFERENCE ${r.path} = ${r.ref.from}${r.ref.plus ? ` + ${r.ref.plus}` : ''}${r.ref.minus ? ` - ${r.ref.minus}` : ''}, `
+            + `approved bounds [${r.ref.between[0]}, ${r.ref.between[1]}] - preview below uses ${refMidpoint(r.ref)}; the runner REFUSES the op outside the bounds`);
+        previews.push({ id, text: [...refLines, describeSubPlan(preview)].join('\n') });
+    });
+
+    return {
+        name,
+        ops,
+        hopZ,
+        staged: { x, y, z, b: snapshot.b },
+        previews,
+        rotations: anyRotate ? rotations : [],
+    };
+}
+
+export function describeProbeProgramAsGcode(plan: ProbeProgramPlan): string {
+    const lines = [
+        `; PROBE PROGRAM "${plan.name}": ${plan.ops.length} operations, ONE approval`,
+        `; anchored at machine (${plan.staged.x}, ${plan.staged.y}, ${plan.staged.z})${plan.staged.b === null ? '' : ` B${plan.staged.b}`}`,
+        '; every operation runs through its own runner (position of record, crash guard, hop envelope, slow zone,',
+        `; <= 5 mm descent segments) and ends raised at the safe traverse height Z${plan.hopZ}; the next op starts there.`,
+        plan.rotations.length
+            ? `; THE STOCK WILL ROTATE: B schedule ${plan.rotations.map((b) => `${b} deg`).join(' -> ')} (absolute), only with the toolhead at Z >= ${plan.hopZ}.`
+            : '; no rotations in this program.',
+        '; A failed operation (no contact where required, hop-guard contact, alarm, rotation not settled) stops the program',
+        '; raised at the traverse height and keeps every earlier result; on_fail: skip records the failure and continues.',
+        '; References ({from: "<op>.<path>"}) resolve at run time from earlier results and are REFUSED outside their approved bounds.',
+    ];
+    plan.ops.forEach((op, index) => {
+        lines.push('');
+        lines.push(`; ===== OP ${index + 1}/${plan.ops.length} "${op.id}" (${op.kind}${op.on_fail === 'skip' ? ', on_fail: skip' : ''}) =====`);
+        const preview = plan.previews.find((p) => p.id === op.id);
+        lines.push(preview ? preview.text : '; (no preview)');
+    });
+    lines.push('');
+    lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; program ends raised at the safe traverse height (also on abort)`);
+    return lines.join('\n');
+}
+
+export interface ProgramOpResult {
+    id: string;
+    kind: ProgramOpKind;
+    status: 'completed' | 'failed' | 'skipped';
+    resolvedRefs: { path: string; from: string; value: number }[];
+    startedAt: number;
+    endedAt: number;
+    result?: object;
+    error?: string;
+}
+
+export async function runProbeProgramProcedure(plan: ProbeProgramPlan): Promise<object> {
+    assertMachineReadyForProcedure();
+    const results: { [opId: string]: unknown } = {};
+    const report: ProgramOpResult[] = [];
+    const phases: { phase: string; note?: string }[] = [];
+    const announce = (phase: string, note?: string) => {
+        phases.push({ phase, note });
+        mcpBroadcast('mcp:activity', { tool: 'probe_program', phase, note });
+    };
+    const startedAt = Date.now();
+    let stoppedAt: string | null = null;
+
+    for (let index = 0; index < plan.ops.length; index++) {
+        const op = plan.ops[index];
+        const opStarted = Date.now();
+        const resolved: ProgramOpResult['resolvedRefs'] = [];
+        announce(`op-${op.id}-start`, `${index + 1}/${plan.ops.length} ${op.kind}`);
+        try {
+            probeFeedService.assertNoOvertravel();
+            if (op.kind === 'rotate_b') {
+                const b = Number(op.args.b);
+                const requireZ = Number(op.args.require_z_at_least);
+                const outcome = await rotateB(`probe_program:${op.id}`, b, requireZ);
+                results[op.id] = outcome;
+                report.push({ id: op.id, kind: op.kind, status: 'completed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), result: outcome });
+                announce(`op-${op.id}-done`, `B ${outcome.from === null ? '?' : outcome.from} -> ${outcome.to} deg`);
+                continue;
+            }
+            // Resolve references NOW against earlier results, re-plan at the
+            // machine's current (raised) position, run the existing runner.
+            const { args: liveArgs } = substituteRefs(op.args, (ref, path) => {
+                const r = resolveRef(ref, results);
+                resolved.push({ path, from: ref.from, value: r.value });
+                announce(`op-${op.id}-ref`, `${path} = ${r.source}`);
+                return r.value;
+            });
+            const sub = buildSubPlan(op.kind, liveArgs);
+            const outcome = sub.kind === 'sequence'
+                ? await runProbeSequenceProcedure(sub.plan)
+                : await runProbeSurfaceProcedure(sub.plan);
+            results[op.id] = outcome;
+            report.push({ id: op.id, kind: op.kind, status: 'completed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), result: outcome });
+            announce(`op-${op.id}-done`);
+        } catch (err) {
+            const message = (err as Error).message;
+            report.push({ id: op.id, kind: op.kind, status: 'failed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), error: message });
+            announce(`op-${op.id}-failed`, message);
+            const trip = probeFeedService.getTrip();
+            if (trip || op.on_fail === 'stop' || op.kind === 'rotate_b') {
+                stoppedAt = op.id;
+                // Every sub-runner raises to the traverse height on its own
+                // abort; make sure of it here for the program as a whole
+                // (unless an alarm is latched - then nothing moves).
+                if (!trip) {
+                    try {
+                        const known = knownMachinePosition();
+                        if (known.position.z !== null && known.position.z < plan.hopZ - 0.5) {
+                            await moveMachineSettled('probe_program:abort-raise', { z: plan.hopZ }, TRAVEL_FEED);
+                        }
+                    } catch (raiseErr) {
+                        announce('abort-raise-failed', (raiseErr as Error).message);
+                    }
+                }
+                for (const later of plan.ops.slice(index + 1)) {
+                    report.push({
+                        id: later.id,
+                        kind: later.kind,
+                        status: 'skipped',
+                        resolvedRefs: [],
+                        startedAt: Date.now(),
+                        endedAt: Date.now(),
+                        error: `not run: program stopped at "${op.id}"`,
+                    });
+                }
+                const completed = report.filter((r) => r.status === 'completed').length;
+                const tail = trip ? 'A safety alarm is latched - the operator must clear it.' : 'Machine raised to the traverse height.';
+                throw new ProcedureAbort(`Program "${plan.name}" stopped at op "${op.id}" (${index + 1}/${plan.ops.length}): ${message} `
+                    + `${completed} earlier op(s) completed; their results are on the job record under result.ops. ${tail}`);
+            }
+            announce(`op-${op.id}-skipped`, 'on_fail: skip - continuing');
+        }
+    }
+
+    return {
+        name: plan.name,
+        ops: report,
+        completedOps: report.filter((r) => r.status === 'completed').length,
+        stoppedAt,
+        rotations: plan.rotations,
+        durationMs: Date.now() - startedAt,
+        phases,
+        note: `Program complete: ${report.filter((r) => r.status === 'completed').length}/${plan.ops.length} operations. `
+            + 'Each op result is the same object its standalone tool returns (stations / results, fits, timing).',
+    };
+}

--- a/src/server/services/mcp/probeSurface.ts
+++ b/src/server/services/mcp/probeSurface.ts
@@ -102,6 +102,8 @@ export interface ProbeSurfacePlan {
     slowZoneMm: number;
     /** Expected contact Z for station 1 (a measured neighbour); null = coarse capped at 1 mm there. */
     expectedZMachine: number | null;
+    /** floor_z_machine was given explicitly: station 1 may search down to it (not just start_z - max_drop). */
+    floorExplicit: boolean;
     path?: {
         start: { x: number; y: number };
         end: { x: number; y: number };
@@ -224,6 +226,7 @@ function finishPlan(
         confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 3), 1), 10),
         slowZoneMm: Math.min(Math.max(Number(args.slow_zone_mm) || 1, 0.3), env.zSafeDeltaMm),
         expectedZMachine: expectedZ,
+        floorExplicit: args.floor_z_machine !== undefined && args.floor_z_machine !== null && args.floor_z_machine !== '',
     };
 }
 
@@ -290,6 +293,11 @@ export function describeProbeSurfacePlanAsGcode(plan: ProbeSurfacePlan): string 
     const firstEnv = stationEnvelope(plan.startZMachine, true, plan.startZMachine, {
         zSafeDeltaMm: plan.zSafeDeltaMm, maxDropMm: plan.maxDropMm, absoluteFloorZ: plan.absoluteFloorZ,
     });
+    if (plan.floorExplicit) {
+        // Station 1 searches to the explicit floor (runner: stationFloorZ).
+        firstEnv.floorZ = plan.absoluteFloorZ;
+        firstEnv.travelMm = Number((firstEnv.marchStartZ - plan.absoluteFloorZ).toFixed(3));
+    }
     // The guarded descent starts at min(start_z + guard, traverse height): the
     // runner never commands a Z above the height it is already at.
     const guardTop = Math.min(plan.startZMachine + DESCENT_GUARD_MM, plan.hopZ);
@@ -688,6 +696,11 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
             const env = stationEnvelope(reference === null ? plan.startZMachine : reference, isFirst, plan.startZMachine, {
                 zSafeDeltaMm: plan.zSafeDeltaMm, maxDropMm: plan.maxDropMm, absoluteFloorZ: plan.absoluteFloorZ,
             });
+            // Station 1 may search all the way to an EXPLICIT floor_z_machine
+            // (job d7ac9247838e aborted because start_z - max_drop was the
+            // only window honoured); later stations keep max_drop below the
+            // last contact.
+            const stationFloorZ = isFirst && plan.floorExplicit ? plan.absoluteFloorZ : env.floorZ;
             // The march starts where the walk left us (start_z for station 1,
             // the hop height otherwise). Re-verify before trusting the sensor.
             const marchStartZ = isFirst ? plan.startZMachine : currentZ;
@@ -698,12 +711,12 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
             // Expected contact for the slow zone: the previous real contact,
             // or the caller's expected_z_machine for station 1.
             const expectedContact = isFirst ? plan.expectedZMachine : reference;
-            const outcome = await marchDownZ(plan, station, marchStartZ, env.floorZ, expectedContact, announce);
+            const outcome = await marchDownZ(plan, station, marchStartZ, stationFloorZ, expectedContact, announce);
             let retractTo: number;
             if (outcome === null) {
                 if (reference === null) {
                     throw new ProcedureAbort(`Station "${station.label}" (the first) found no surface between Z${marchStartZ} and the floor `
-                        + `Z${env.floorZ} - no measured reference to base the envelope on. Check start_z_machine / floor_z_machine.`);
+                        + `Z${stationFloorZ} - no measured reference to base the envelope on. Check start_z_machine / floor_z_machine.`);
                 }
                 results.push({
                     index: station.index,
@@ -716,10 +729,10 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
                     status: 'no_contact',
                     z: null,
                     marchStartZ,
-                    floorZ: env.floorZ,
+                    floorZ: stationFloorZ,
                 });
                 retractTo = hopHeightFor(reference);
-                announce(`no-contact-${station.label}`, `nothing between Z${marchStartZ} and the floor Z${env.floorZ}; reference stays Z${reference}`);
+                announce(`no-contact-${station.label}`, `nothing between Z${marchStartZ} and the floor Z${stationFloorZ}; reference stays Z${reference}`);
             } else {
                 reference = outcome.contactZ;
                 results.push({
@@ -733,7 +746,7 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
                     status: 'contact',
                     z: outcome.contactZ,
                     marchStartZ,
-                    floorZ: env.floorZ,
+                    floorZ: stationFloorZ,
                     confirmPassContacts: outcome.passContacts,
                     spreadMm: outcome.spreadMm,
                     approach: outcome.approach,

--- a/src/server/services/mcp/probing.ts
+++ b/src/server/services/mcp/probing.ts
@@ -158,7 +158,10 @@ async function moveMachineSettledUnguarded(
         target.y !== undefined ? `Y${target.y.toFixed(3)}` : '',
         target.z !== undefined ? `Z${target.z.toFixed(3)}` : '',
     ].filter(Boolean).join(' ');
-    const gcode = `G90\nG53;\nG1 ${words} F${feed};\nG54;`;
+    const gcode = `G90
+G53;
+G1 ${words} F${feed};
+G54;`;
 
     const before = getPositionSnapshot();
     // Where the move starts: the engine's own record while it is current (no
@@ -568,6 +571,55 @@ export function assertMachineReadyForProcedure(): void {
     if ((Number.isFinite(headPower) && headPower > 0) || (state && (state.headStatus === true || state.headStatus === 'on'))) {
         throw new McpToolError('Toolhead appears to be on; refusing to run the procedure.');
     }
+}
+
+/** Rotary B feed for program rotations (deg/min): 600 = 10 deg/s, a 180 deg turn in 18 s. */
+export const ROTATE_FEED = 600;
+const ROTATE_TOLERANCE_DEG = 0.05;
+const ROTATE_TIMEOUT_MS = 120000;
+
+/**
+ * Rotate the rotary axis to an ABSOLUTE B angle on the direct path, inside a
+ * probe_program the operator approved with the B schedule enumerated. The
+ * toolhead must be at or above `requireZAtLeast` (the safe traverse height:
+ * the stock turns under a raised head). The HTTP channel executes the move
+ * synchronously and the M114 in the same batch reports B; if that echo is
+ * missing the heartbeat's `b` is polled until it agrees. Any probe contact
+ * while the stock turns is a collision (crash guard: the motion bracket is
+ * armed, no contact is expected).
+ */
+export async function rotateB(tool: string, targetDeg: number, requireZAtLeast: number): Promise<{ from: number | null; to: number; verifiedBy: 'echo' | 'heartbeat' }> {
+    probeFeedService.assertNoOvertravel();
+    const known = knownMachinePosition();
+    if (known.position.z === null || known.position.z < requireZAtLeast - 1e-9) {
+        throw new ProcedureAbort(`Rotation refused: toolhead machine Z is ${known.position.z} (${known.source}), below the required Z${requireZAtLeast}.`);
+    }
+    const snapshot = getPositionSnapshot();
+    if (!snapshot.isFourAxis) {
+        throw new ProcedureAbort('Rotation refused: the heartbeat reports no B axis.');
+    }
+    const from = snapshot.b;
+    const channel = getDirectChannel();
+    const target = Number(targetDeg.toFixed(3));
+    probeFeedService.clearExpectedContact();
+    const executed = await sendGcodeVisible(channel, tool, `G90\nG0 B${target.toFixed(3)} F${ROTATE_FEED}\nM114`);
+    if (executed.result !== 0) {
+        throw new ProcedureAbort(`Controller rejected the rotation: ${executed.text || executed.result}`);
+    }
+    const echo = String(executed.text || '').match(/\bB:(-?\d+(?:\.\d+)?)/);
+    if (echo && Math.abs(Number(echo[1]) - target) <= ROTATE_TOLERANCE_DEG) {
+        return { from, to: target, verifiedBy: 'echo' };
+    }
+    const deadline = Date.now() + ROTATE_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        await sleep(500);
+        probeFeedService.assertNoOvertravel();
+        const now = getPositionSnapshot();
+        if (now.b !== null && Math.abs(now.b - target) <= ROTATE_TOLERANCE_DEG && now.machineStatus === 'idle') {
+            return { from, to: target, verifiedBy: 'heartbeat' };
+        }
+    }
+    throw new ProcedureAbort(`Rotation to B${target} not confirmed within ${ROTATE_TIMEOUT_MS / 1000} s (echo ${echo ? echo[1] : 'none'}).`);
 }
 
 /** Longest single Z move toward the work a procedure may issue (operator law 2026-09-05). */

--- a/src/server/services/mcp/programRefs.ts
+++ b/src/server/services/mcp/programRefs.ts
@@ -1,0 +1,136 @@
+// Pure helpers for probe_program references (no machine, no server
+// imports) so they can be unit-tested: RefSpec parsing, dotted-path lookup
+// into earlier op results, bounded resolution, argument substitution.
+
+export class RefResolveError extends Error {}
+
+export interface RefSpec {
+    /** "<opId>.<path>" into an earlier op's result, e.g. "c90.top.z" (sequence probe by name) or "ns90.summary.zMean". */
+    from: string;
+    plus?: number;
+    minus?: number;
+    /** REQUIRED operator-approved bounds on the resolved value (after plus/minus). */
+    between: [number, number];
+}
+
+export function isRef(value: unknown): value is RefSpec {
+    return !!value && typeof value === 'object' && typeof (value as RefSpec).from === 'string';
+}
+
+export function round3(value: number): number {
+    return Number(value.toFixed(3));
+}
+
+/** Walk an object by dotted path; arrays may be indexed by number or by an item's name/label. */
+export function lookupPath(root: unknown, path: string[]): unknown {
+    let cursor: unknown = root;
+    for (const token of path) {
+        if (cursor === null || cursor === undefined) {
+            return undefined;
+        }
+        if (Array.isArray(cursor)) {
+            if (/^\d+$/.test(token)) {
+                cursor = cursor[Number(token)];
+            } else {
+                cursor = cursor.find((item) => item && typeof item === 'object'
+                    && ((item as { name?: string }).name === token || (item as { label?: string }).label === token));
+            }
+            continue;
+        }
+        if (typeof cursor !== 'object') {
+            return undefined;
+        }
+        cursor = (cursor as { [key: string]: unknown })[token];
+    }
+    return cursor;
+}
+
+/**
+ * Resolve one reference against the results so far. Sequence probe results
+ * are addressable as "<seqId>.<probeName>.z" (contactMachine.z) as well as
+ * by the raw shape.
+ */
+export function resolveRef(ref: RefSpec, results: { [opId: string]: unknown }): { value: number; source: string } {
+    const parts = ref.from.split('.');
+    const opId = parts[0];
+    if (!(opId in results)) {
+        throw new RefResolveError(`Reference "${ref.from}": op "${opId}" has no result yet (order the program so it runs first).`);
+    }
+    let raw = lookupPath(results[opId], parts.slice(1));
+    if ((raw === undefined || raw === null) && parts.length >= 3) {
+        // Shorthands for sequence probes: "<seq>.<probe>.z" or
+        // "<seq>.results.<probe>.z" mean results[<probe>].contactMachine.z.
+        const last = parts[parts.length - 1];
+        const head = parts.slice(1, -1);
+        const candidates = [
+            [...head, 'contactMachine', last],
+            ['results', ...head, 'contactMachine', last],
+            ['results', ...head, last],
+        ];
+        for (const candidate of candidates) {
+            raw = lookupPath(results[opId], candidate);
+            if (raw !== undefined && raw !== null) {
+                break;
+            }
+        }
+    }
+    const numeric = Number(raw);
+    if (raw === undefined || raw === null || !Number.isFinite(numeric)) {
+        throw new RefResolveError(`Reference "${ref.from}" did not resolve to a number (got ${JSON.stringify(raw)}).`);
+    }
+    let value = numeric + (Number(ref.plus) || 0) - (Number(ref.minus) || 0);
+    value = round3(value);
+    const [lo, hi] = ref.between;
+    if (value < lo - 1e-9 || value > hi + 1e-9) {
+        throw new RefResolveError(`Reference "${ref.from}" resolved to ${value}, outside the approved bounds [${lo}, ${hi}] - refusing the op.`);
+    }
+    return { value, source: `${ref.from}${ref.plus ? ` + ${ref.plus}` : ''}${ref.minus ? ` - ${ref.minus}` : ''} = ${value}` };
+}
+
+export function refMidpoint(ref: RefSpec): number {
+    return round3((ref.between[0] + ref.between[1]) / 2);
+}
+
+/** Replace every reference in an args object (one level deep, plus `steps[].z`) with `pick(ref)`. */
+export function substituteRefs(
+    args: { [key: string]: unknown },
+    pick: (ref: RefSpec, path: string) => number
+): { args: { [key: string]: unknown }; refs: { path: string; ref: RefSpec }[] } {
+    const refs: { path: string; ref: RefSpec }[] = [];
+    const out: { [key: string]: unknown } = {};
+    for (const [key, value] of Object.entries(args)) {
+        if (isRef(value)) {
+            refs.push({ path: key, ref: value });
+            out[key] = pick(value, key);
+        } else if (key === 'steps' && Array.isArray(value)) {
+            out[key] = value.map((step, index) => {
+                if (step && typeof step === 'object') {
+                    const copy: { [k: string]: unknown } = { ...(step as object) };
+                    for (const [sk, sv] of Object.entries(copy)) {
+                        if (isRef(sv)) {
+                            refs.push({ path: `steps[${index}].${sk}`, ref: sv });
+                            copy[sk] = pick(sv, `steps[${index}].${sk}`);
+                        }
+                    }
+                    return copy;
+                }
+                return step;
+            });
+        } else {
+            out[key] = value;
+        }
+    }
+    return { args: out, refs };
+}
+
+export function validateRef(ref: RefSpec, where: string): void {
+    if (!Array.isArray(ref.between) || ref.between.length !== 2
+        || !Number.isFinite(Number(ref.between[0])) || !Number.isFinite(Number(ref.between[1]))
+        || Number(ref.between[0]) >= Number(ref.between[1])) {
+        throw new RefResolveError(`${where}: a reference needs operator-approved bounds "between": [low, high] (law 3 - the page shows the range).`);
+    }
+    if (!/^[A-Za-z][A-Za-z0-9_-]*\./.test(ref.from)) {
+        throw new RefResolveError(`${where}: "from" must be "<opId>.<path>" (e.g. "c90.top.z", "ns90.summary.zMean").`);
+    }
+}
+

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs-extra';
 import logger from '../../../lib/logger';
 import { connectionManager } from '../../machine/ConnectionManager';
 import { McpJob, approvalHandoff, jobManager } from '../jobs';
+import { summarizeJobTiming } from '../jobTiming';
 import { matchFrame } from '../positionOfRecord';
 import { probeFeedService } from '../probeFeed';
 import { McpToolError, ToolRegistry } from '../registry';
@@ -391,7 +392,10 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 // "running" status to long-poll with get_gcode_job_status.
                 const finished = job.runner()
                     .then((outcome) => {
-                        job.result = outcome;
+                        // Where the time went, from the job's own events, so
+                        // agents optimise from the record (get_job_timing has
+                        // the same for running/failed jobs).
+                        job.result = { ...(outcome as object), timing: summarizeJobTiming(job.events) };
                         job.state = 'completed';
                         job.endedAt = Date.now();
                         jobManager.appendEvent(job, 'completed', { note: 'procedure finished; result stored on the job' });
@@ -711,6 +715,36 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                     : 'Ask the operator to open confirm_url, review the DIRECT-move banner '
                         + '(current Z, target, delta, feed), and approve. Their one-time code passed to '
                         + 'start_gcode_job executes the move; the position then persists.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'get_job_timing',
+        description: 'Where a job\'s time went, computed from its event log (works for running, completed and failed jobs; '
+            + 'completed procedures also carry it as result.timing): per command kind (coarse, fine, confirm, backoff, '
+            + 'retract, hop, descend, raise, ...) the count, feeds, distance, controller time (execMs), motion time '
+            + '(distance / feed), per-batch overhead, idle time and sensor windows; per station the wall time and its '
+            + 'kind breakdown; approval wait, run time, median station; settle-waits, slow steps, estimated positions, '
+            + 'event-loop stalls and frame flips. Use it to pick parameters (z_safe_delta_mm, coarse feed, '
+            + 'confirm_passes, sensor_delay_ms) instead of mining events by hand.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                job_id: { type: 'string' },
+            },
+            required: ['job_id'],
+            additionalProperties: false,
+        },
+        handler: async (args: { job_id?: string }) => {
+            const job = jobManager.get(String(args.job_id || ''));
+            if (!job) {
+                throw new McpToolError('Unknown job_id.');
+            }
+            return {
+                job: jobManager.describe(job),
+                timing: summarizeJobTiming(job.events),
+                trimmed: job.eventSeq > job.events.length,
             };
         },
     });

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -18,6 +18,7 @@ import {
     planProbeSurfacePath,
     runProbeSurfaceProcedure,
 } from '../probeSurface';
+import { describeProbeProgramAsGcode, planProbeProgram, runProbeProgramProcedure } from '../probeProgram';
 import { describeProbeVectorPlanAsGcode, planProbeVector, runProbeVectorProcedure } from '../probeVector';
 import { probeFeedService } from '../probeFeed';
 import { TRAVEL_FEED, assertMachineReadyForProcedure, moveMachineSettled } from '../probing';
@@ -645,6 +646,75 @@ ${describeProbeSurfacePlanAsGcode(plan)}`;
                 next_step: 'Ask the operator to open confirm_url, check the Z clears everything on the '
                     + 'bed (rotary included), and approve. start_gcode_job then drives the whole grid '
                     + 'and returns the frame index.',
+            };
+        },
+    });
+
+    registry.register({
+        name: 'probe_program',
+        description: 'Stage a COMPOSITE probing program for ONE human approval: an ordered list of operations - '
+            + 'rotate_b (turn the rotary axis to an absolute B, toolhead at/above the traverse height), '
+            + 'surface_path, surface_grid and sequence (the same arguments as the standalone tools) - run by one '
+            + 'runner that hands the machine from op to op, each ending raised at the traverse height. Numbers an op '
+            + 'cannot know at staging are REFERENCES to earlier results: {"from": "<opId>.<path>", "plus"?: n, '
+            + '"minus"?: n, "between": [low, high]} - e.g. expected_z_machine: {"from": "c90.top.z", "between": '
+            + '[195, 240]} where c90 is a sequence op with a probe named "top", or start_z_machine: {"from": '
+            + '"ns90.summary.zMean", "plus": 7, "between": [200, 250]}. The bounds are REQUIRED (law 3): the confirm '
+            + 'page shows them with a preview at the mid-point and the runner refuses the op (stopping the program '
+            + 'raised, keeping earlier results) if the value resolves outside them. A failed op stops the program '
+            + 'unless on_fail: "skip". Result: per-op status and the standalone tool\'s result object (stations, fits, '
+            + 'timing), plus the B schedule. Use it to string the four faces, sides and end of a rotary stock into one '
+            + 'approved operation instead of 18 approvals.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'Program name shown to the operator.' },
+                ops: {
+                    type: 'array',
+                    description: 'Ordered operations. Each: {id, kind, on_fail?, ...args}. kinds: rotate_b {b, require_z_at_least?}; '
+                        + 'surface_path / surface_grid / sequence: the standalone tool arguments, where start_z_machine, '
+                        + 'expected_z_machine, floor_z_machine and sequence descend z may be references.',
+                    items: { type: 'object' },
+                    minItems: 1,
+                    maxItems: 40,
+                },
+                reason: { type: 'string', description: 'Shown to the operator: what is being measured and why.' },
+            },
+            required: ['name', 'ops', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            const reason = String(args.reason || '').trim();
+            if (!reason) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            probeFeedService.assertNoOvertravel();
+            const plan = planProbeProgram({ name: args.name, ops: args.ops });
+            const envelope = `; reason: ${reason}
+${describeProbeProgramAsGcode(plan)}`;
+            const validation = validateGcode(envelope);
+            const job = jobManager.submit(
+                envelope,
+                `program ${plan.name} (${plan.ops.length} ops${plan.rotations.length ? `, B ${plan.rotations.join('/')}` : ''}) - ${reason.slice(0, 40)}`,
+                'cnc',
+                validation,
+                'procedure'
+            );
+            job.runner = async () => runProbeProgramProcedure(plan);
+            return {
+                job: jobManager.describe(job),
+                plan: {
+                    name: plan.name,
+                    ops: plan.ops.map((op) => ({ id: op.id, kind: op.kind, on_fail: op.on_fail, refs: op.refs })),
+                    rotations: plan.rotations,
+                    hopZ: plan.hopZ,
+                    staged: plan.staged,
+                },
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url and review the WHOLE program: every operation\'s envelope, every '
+                    + 'reference with its bounds, and the B rotation schedule. One approval covers the program; call '
+                    + 'start_gcode_job with wait_for_approval_ms, then long-poll get_gcode_job_status (a full four-face survey '
+                    + 'runs 35-75 minutes; budget the job event limit first).',
             };
         },
     });


### PR DESCRIPTION
Stacked on #80 (`mcp/46-position-of-record`).

Operator request after the four-face rotary survey (18 approvals, ~75 min): show where each procedure's time goes, and make the whole survey ONE approved operation.

## `probe_program` — one approval for a whole survey

An ordered list of operations, staged once and approved on one confirm page that enumerates every op's envelope and the B rotation schedule, run by one runner that hands the machine from op to op (each ends raised at the traverse height):

- `rotate_b` — absolute B on the direct path; refused unless the toolhead is at/above the safe traverse height; verified by the M114 in the same batch or the heartbeat's `b`. Any probe contact while the stock turns is a collision (crash guard armed).
- `surface_path`, `surface_grid`, `sequence` — the standalone tools' arguments, run by the existing runners (position of record, slow zone, hop envelope, segmented descents unchanged).
- **References** for numbers an op cannot know at staging: `{from: "c90.top.z", plus: 7, between: [200, 240]}` (a sequence probe by name; `.z` is shorthand for `contactMachine.z`) or `{from: "ns90.summary.zMean", minus: 7, between: [...]}`. Bounds are REQUIRED (law 3): the confirm page shows them with a preview plan at the mid-point, and the runner refuses the op if the value resolves outside them, stopping the program raised and keeping every earlier result under `result.ops`.
- `on_fail: "skip"` records a failure and continues (rotations always stop). Each op result is the standalone tool's result object (stations, fits, timing).

The survey becomes `rotate_b 90 → sequence (centre) → surface_path N–S (expected from the centre) → surface_path W–E → sequence (sides) → rotate_b 180 → …`. Pure reference logic lives in `programRefs.ts`.

## Timing breakdown on the record

`jobTiming.ts` (pure) computes, from a job's own events: per command kind (coarse, fine, confirm, backoff, retract, hop, descend, raise, …) the count, feeds, distance, controller time, motion time (distance / feed), per-batch overhead (~270 ms measured: four HTTP lines per batch), idle time and sensor windows; per station the wall time and kind breakdown; approval wait, run time, median station; waits (settle, slow steps, estimated positions, stalls, flips). Completed procedures carry it as `result.timing`; `get_job_timing` returns it for running and failed jobs too. Levers in the README: `z_safe_delta_mm` 20 → 5 ≈ 145 s per scan, `confirm_passes` 2, `sensor_delay_ms` 30; coarse feed is the operator's call.

## Also

- Surface scans: station 1 searches down to an explicit `floor_z_machine` (job d7ac9247838e aborted because only start − max_drop was honoured).
- `docs/COMPOSITE_PROBE_PROGRAM.md`: the on-box agent's brief, with its implemented items marked; still open: multi-segment paths in one op, tip diameter as configuration, stock-geometry reduction, live progress on the confirm page.
- Inline one-line `G53 G1` was prototyped and removed: unrequested and unverified on this firmware.

## Verification

- 8 unit checks on the reference helpers (path lookup by index/name, `.z` shorthand, plus/minus, bounds refusal, substitution incl. `steps[].z`), 3 on the timing extractor.
- `tsc -p tsconfig-server.json` filtered to `services/mcp` clean; eslint clean across the MCP tree.
- Hardware: not yet — the B180 side and then a full program are the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
