### PR TITLE
Feature: New-stock survey program - derived references, jig geometry, keep-out, groups, procedure stop, stock outline

### DIFF
--- a/.claude/skills/cnc-probing/SKILL.md
+++ b/.claude/skills/cnc-probing/SKILL.md
@@ -139,6 +139,16 @@ never resubmit. If your MCP client times out anyway, the result is still on the 
 `next_event_index` is a sequence number, not an array index: the log keeps 2000 events and
 paging stays valid when it trims.
 
+**Stopping a procedure.** `stop_gcode_job {job_id}` on a running procedure (probe_*,
+probe_program, tool setter, survey) is a cooperative stop: the runner finishes the step in
+flight (<= 1 mm or one sensor window), raises to the traverse height and ends the job in
+state `stopped` with everything measured so far in `result` (stations, contacts,
+completed ops, `derived`). The call waits up to `wait_ms` (default 20 s) and answers
+`{ok: true, stopped | stopping}`; if `stopping`, long-poll the status. It is NOT an
+emergency stop - the crash guard and the operator's machine stop are that. Stopping a
+program stops the whole program regardless of `on_fail`. A procedure that has not
+started yet is withdrawn by the same call.
+
 When a procedure is slow or aborts, the evidence is already in its events - do not grep
 server logs. `gcode` events carry `execMs` (send to controller reply) and `idleMs` (previous
 reply to this send; engine + sensor window only, so > 750 ms inside a job also raises a
@@ -252,7 +262,87 @@ reference points backwards; `on_fail: "skip"` lets an overtravel-type op fail
 without ending the program. A four-face survey is `rotate_b 90 → centre sequence →
 N-S path → W-E path → sides sequence → rotate_b 180 → …`; budget the event log
 (≈ 100 + stations × 120 per scan op) before staging and use
-`wait_for_approval_ms` to start.
+`wait_for_approval_ms` to start. Staging REFUSES a program whose estimate exceeds the
+job event limit and tells you the number to ask the operator for.
+
+**New stock, nothing known but the jig.** Geometry is NEVER a prerequisite: a program
+that references only its own earlier ops (any B0-only, stationary or off-rotary survey)
+needs nothing stored, so stage it. Only a reference to `axis.*` needs the rotary axis
+and probe length; check `get_stored_state → geometry`, and if they are unset, MEASURE
+them and store them yourself with `set_probe_geometry` (axis Z = mean of an
+opposite-face pair minus the probe length, axis X = mid of a side pair, probe length
+from `run_tool_setter accept_probe_contact`) - or write the program without `axis.*`.
+Never ask the operator to type numbers into a settings pane, and never type them into
+your program as constants. Stock size is a property of the stock, not the jig: pass the
+largest reach of THIS stock as `swept_radius_mm` on `rotate_b` if you want the
+tip-outside-the-cylinder check. Then:
+
+- **Find the top** without knowing the height: a `sequence` whose `descend` is
+  `{"from": "axis.z_contact", "plus": <largest possible radius + 5>, "between": [...]}`
+  and whose probe is `dz: -1, max_travel_mm: <that radius + 10>` (segmented descent, 1 mm
+  coarse in the last band). Without `axis`, descend to an operator-stated Z instead.
+- **Derive, don't guess**: `{"mid": ["s0.west.x", "s0.east.x"], "between": [...]}` is the
+  stock centre; `{"diff": ["s0.east.x", "s0.west.x"], "scale": 0.5, "plus":
+  "axis.z_contact", "between": [...]}` is the B90 face height (axis + half-width);
+  `{"min"|"max": [...]}` over several paths. References may sit anywhere in an op's
+  arguments (`steps[].z`, `start_x`, `expected_profile.circle.center_x`). Name your
+  probes `top`, `west*`, `east*`, `end*` and the result's `derived` section (thickness
+  per face pair, centring, width with tip, centre X, yaw, end slope) is computed for
+  you - it is planning inference, never a clearance.
+- **Keep-out for this clamping**: pass `keep_out: [{"name": "chuck jaws", "machine":
+  {"x0", "y0", "x1", "y1"}, "clearance_z"}]` (toolhead Z) - a VOLUME nothing enters, not
+  even a descent column. Stored landmarks are CROSSING obstacles: they forbid traversing
+  into or out of their box low, and a hop, column or march wholly inside one (probing
+  the stock inside the rotary-axis landmark) is allowed - the operator approves it on
+  the page. So never ask to delete or shrink the rotary landmark to make a scan pass; if
+  a check names it, the plan really does enter or leave the rotary region low. Both are
+  checked at staging AND when references resolve; a hit names the step. Jaws reach
+  ~Y269 on this jig (measured 2026-09-02); the tailstock bracket stands above the stock
+  below ~Y110 - use those as `keep_out` volumes, with the operator's confirmation.
+- **Cylinders**: `surface_path` with `expected_profile: {"circle": {"center_x": {"from":
+  "axis.x", ...}, "center_z_contact": {"from": "axis.z_contact", ...}, "radius": <operator
+  bound>}}` - each station's slow zone and drop band follow the circle; stations more than
+  0.7 R off the axis are refused. Locate the crown with `summary.highestAt.x`.
+- **Repeat per rotation**: `{"id": "faces", "kind": "group", "for_b": [0, 90, 180, 270],
+  "ops": [...]}` runs the inner ops once per angle after a `rotate_b`; write `${b}` in
+  ids/names/paths (or leave ids plain and they get `_b<angle>`).
+
+- **Side marches on stock of estimated size**: start each march OUTSIDE the largest
+  size the stock could be, set `max_travel_mm` to cover the whole uncertainty (the
+  travel is approved, so a long limit costs time, not safety), and put the first side
+  probe at mid-length, never near a corner. A march that reaches its limit records
+  `status: "no_contact"` and the sequence CONTINUES (`on_miss` default) - a miss is the
+  measurement "nothing within N mm". Only pass `on_miss: "abort"` when a later step is
+  unsafe without that contact. A reference to a missed probe refuses its op instead.
+
+**Block on the bed or in the chuck: `probe_stock_outline` (centre from an estimate).**
+Give it the estimated centre and size, the operator's `start_z_machine` /
+`floor_z_machine`, and it finds the top at `top_points` (default 3; the highest wins, a
+sample > `hole_tolerance_mm` lower is a hole and ignored - so a first probe in a drilled
+hole cannot define the surface), then marches the sides from `overextend_mm` outside the
+estimate at `top - side_depth_mm`, `points_per_side` per side, skipping along each face at
+`side_standoff_mm` off the last contact (a projection bumps the probe outward, never
+aborts), and returns `centerMachine`, `centerWork`, `sizeMm` (centre-to-centre),
+`sizePhysicalMm` (MINUS the tip diameter - external faces lie one tip radius inside their
+contacts; the centre needs no correction), `yawDeg`. Use it instead of hand-built
+sequences whenever the job is "where is this block and how big is it". Defaults are
+deliberately generous: `points_per_side` 3 (midpoint first), `side_max_travel_mm` 25,
+`overextend_mm` 5, `side_depth_mm` 2. Do NOT shorten the travel to save time: the first
+outline on the box marched 11 mm and missed a face 13.6 mm away because the centre estimate
+was 3.85 mm off - travel must cover overextend + width uncertainty + centre uncertainty +
+margin, and a march that finds nothing is only lost time. For top scans over stock that may
+be narrow or offset from the estimate, keep `spacing_mm` at 5 or less. Also an op kind
+`stock_outline` in `probe_program`. For surface scans over uneven or holed stock use
+`hop_mode: "stepped"` with `hop_lift_mm` (contact lifts and continues) instead of a big
+`z_safe_delta_mm`.
+
+**Landmarks vs the traverse height.** The rotary landmark says clearance 328; the traverse
+height is 320. Hops at the traverse height are lawful and exempt from crossing landmarks;
+so are marches (they stop on contact). A refusal naming a landmark therefore means a LOW
+hop or a descent column enters or leaves its box - fix the plan, do not touch the landmark.
+
+Hardware test order for a new program: B0 half without rotations first, then one
+rotation, then the whole program - and compare `derived` with the operator's calipers.
 
 **Speed.** Read `result.timing` (or `get_job_timing`) after a scan instead of mining
 events: per command kind it gives count, feeds, distance, controller time vs motion

--- a/src/app/ui/pages/global-modals/settings-modal/McpServer/index.tsx
+++ b/src/app/ui/pages/global-modals/settings-modal/McpServer/index.tsx
@@ -84,7 +84,6 @@ interface McpStatus {
         source: 'env' | 'config' | 'default';
     };
 }
-
 const MQTT_FIELDS: Array<{ name: keyof McpMqttSettings['values']; labelKey: string; placeholder?: string; channel?: string }> = [
     { name: 'host', labelKey: 'key-App/Settings/McpServer-MQTT host', placeholder: 'io.adafruit.com' },
     { name: 'port', labelKey: 'key-App/Settings/McpServer-MQTT port', placeholder: '8883 (TLS)' },
@@ -167,7 +166,6 @@ const McpServer: React.FC = () => {
                 if (body.approval) {
                     setApprovalHandoffAgent(body.approval.handoff !== 'code');
                 }
-
                 const { inverted: mqttInvertedNames, ...mqttValues } = body.mqtt.values;
                 setMqtt({ ...mqttValues });
                 setInverted(parseInvertedFlags(mqttInvertedNames));

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -312,10 +312,131 @@ stopping the program raised and keeping every earlier result under `result.ops`.
 "skip"` records a failure and continues (rotations always stop). Each op result is the
 standalone tool's result object. The four-face survey that took 18 approvals is one program:
 `rotate_b 90 → sequence (centre) → surface_path N–S (expected from the centre) → surface_path
-W–E → sequence (sides) → rotate_b 180 → …`. Still to do from the brief
-([docs/COMPOSITE_PROBE_PROGRAM.md](docs/COMPOSITE_PROBE_PROGRAM.md)): multi-segment paths in
-one op (stage two path ops for now), tip diameter as configuration, the stock-geometry
-reduction (section size, centring, yaw), live progress on the confirm page.
+W–E → sequence (sides) → rotate_b 180 → …`.
+
+**New stock from the jig alone (mcp/48, 2026-09-06).** What the manual four-face survey did by
+hand is now in the program tooling (work plan and hardware test order in
+[docs/NEW_STOCK_SURVEY_TODO.md](docs/NEW_STOCK_SURVEY_TODO.md)):
+
+- **Two-operand references** (`programRefs.ts`): `{mid: [a, b]}` = (a+b)/2 (stock centre from
+  two side contacts), `{diff: [a, b], scale: 0.5}` = (a−b)·scale (width, half-width),
+  `{min|max: [...]}`; `plus`/`minus` may be a number or a path, so "axis + half-width" is one
+  reference: `{diff: ["s0.east.x", "s0.west.x"], scale: 0.5, plus: "axis.z_contact", between:
+  [210, 235]}`. `.x/.y/.z` on a sequence probe read `contactMachine`. References may sit at
+  any depth of an op's arguments (`steps[1].z`, `expected_profile.circle.center_x`). Bounds
+  stay required; the page prints the formula (`describeRef`) and the runner the values.
+- **Rotary axis and probe geometry through the MCP surface** (`rotaryGeometry.ts`, tool
+  `set_probe_geometry` — operator-stated or MEASURED values with a reason, like `set_landmark`;
+  env overrides `LUBAN_MCP_ROTARY_AXIS_X/_Z`, `LUBAN_MCP_PROBE_LENGTH`,
+  `LUBAN_MCP_PROBE_TIP_DIAMETER`; read back in `get_stored_state → geometry`): axis X and
+  PHYSICAL axis Z, probe effective length and tip diameter. Programs read them as the seeded
+  namespace **`axis`** (`axis.x`, `axis.z_physical`, `axis.z_contact` = axis Z + probe length,
+  `axis.tip_radius`, `axis.probe_length`). **Never a prerequisite**: only a reference to
+  `axis.*` needs them (then a missing value is a staging error naming the tool); B0-only,
+  stationary and off-rotary work needs nothing. **Stock size is not stored anywhere** — it is a
+  property of the stock, not the jig — so a rotation takes an optional per-program
+  `swept_radius_mm` for the tip-outside-the-cylinder check. (A first cut put these in the app's
+  settings pane with a "max stock radius"; the operator rejected it on 2026-09-06 and it is
+  gone.) Measured values this jig: axis X ≈ 169.7, physical Z ≈ 112.4, probe 71.3, tip ≈ 2.5 —
+  re-measure after any probe re-fit or rotary move.
+- **Keep-out at plan time** (`envelopeChecks.ts`, law 4 in the planners): every `probe_sequence`
+  hop / descend column / march and every surface-scan station-1 descent, hop (at its lowest
+  possible height, floor + z_safe_delta) and station column is checked against the obstacle
+  landmarks (`clearanceZ` set) and the program's transient **`keep_out`** boxes (`[{name,
+  machine: {x0, y0, x1, y1}, clearance_z}]`, this clamping's chuck jaws / tailstock, shown on
+  the page, never persisted). Two obstacle semantics: stored landmarks are **crossing**
+  obstacles — their clearance forbids entering or leaving the box on a low path, exactly what the
+  direct XY guard enforces, while a hop, column or march wholly inside the box is the approved
+  procedure (the `rotary-axis` landmark covers the whole stock; probing it is the job — the first
+  cut treated it as a volume and refused every descent, caught by the on-box agent 2026-09-06);
+  program `keep_out` boxes are **volumes** nothing enters, not even a column. A hit refuses
+  staging naming the step, the obstacle and the Z; the check re-runs when references resolve at
+  run time. `rotate_b` with `swept_radius_mm` additionally refuses if the tip is inside that
+  cylinder (`insideSweptCylinder`).
+- **Discovery**: `summary.highestAt` / `lowestAt` (machine XY) locate a cylinder's crown or a
+  face's high edge by reference; `surface_path expected_profile: {circle: {center_x,
+  center_z_contact, radius, tip_radius?}}` models a cylinder along machine Y — each station's
+  slow zone and max_drop band follow `z(d) = c + √((R+rt)² − d²) − rt`, stations beyond 0.7 R
+  off the axis are refused (the tip would glance). Unknown height needs no new op: a sequence
+  whose `descend` is `axis.z_contact + (largest possible radius + 5)` and whose probe travels
+  that radius + 10 (segmented descent, 1 mm coarse in the last band).
+- **`group`**: `{id, kind: "group", for_b: [0, 90, 180, 270], ops: [...]}` expands at staging
+  into a `rotate_b` per angle followed by the inner ops with the token `${b}` replaced in every
+  string; inner ids without the token get `_b<angle>` and references between them are rewritten
+  (`programGroups.ts`). Cap 80 ops after expansion.
+- **Derived section** on the program result (`stockGeometry.ts`, `result.derived`, labelled
+  inference not clearance): face heights above the axis per B, opposite-face thickness and
+  centring offset, centre-to-centre width and PHYSICAL width (minus the tip diameter: external
+  faces lie one tip radius inside their contacts) and stock centre X per Y, yaw per 100 mm, end
+  face slope, top-face slopes — the 2026-09-05 report's arithmetic, unit-tested against it.
+  Relies on probe names `top`, `west*`, `east*`, `end*`; every op result carries its `b`.
+- **Event budget**: the plan estimates its events (100 + 120/station + 60/probe + 20/rotation);
+  staging is refused when the estimate exceeds the job event limit, naming the number to set.
+
+Still open from the brief: multi-segment paths in one op, live progress on the confirm page.
+
+**`probe_stock_outline` — top, outline and centre from an estimate (2026-09-06).** The
+operator's ask after watching the agent re-probe the centre for every side: one approved
+procedure that (1) finds the TOP at a few points around the estimated centre (`top_points`,
+default 3 along the longer axis) — the highest contact wins and a sample lower by more than
+`hole_tolerance_mm` (default 2) is a hole and ignored, so a first probe landing in a drilled hole
+does not define the surface; (2) probes the SIDES with horizontal marches from `overextend_mm`
+(default 5) outside the estimate at `top − side_depth_mm` (default 2), `points_per_side` (default
+3, midpoint first) over the middle half of each side (corners are where estimates fail), each up
+to `side_max_travel_mm` (default 25), a miss recorded as `no_contact`; (3) FITS per-side mean and
+slope into centre (machine and work frame), size centre-to-centre and PHYSICAL (MINUS the tip
+diameter: on opposite external faces each stylus centre stops one tip radius outside its face —
+the on-box agent caught the earlier "+ tip" sign error; the centre is unaffected) and yaw
+(`outlineFit.ts`, pure, unit-tested against the agent's block: centre 168.85 / 241.383, physical
+44.27 × 69.0). **Why 25 mm:** the agent's first outline marched 11 mm from X132 and found nothing
+on the west; the face was at X145.5 — the estimate's centre was 3.85 mm off and its width a few
+mm out. A short march silently turns ordinary estimate error into a missed face; a generous one
+is still sensor-gated and only costs time. Derive travel as overextend + width uncertainty +
+centre uncertainty + margin, never less than 20–25 mm. Also a
+`probe_program` op kind `stock_outline`. The motion machinery is shared in `march.ts`:
+`marchToContact` (the coarse → release → fine → confirm march every runner used to copy) and
+**`steppedTraverse`** — travel close to a surface as a TOUCH-PROBING move: 1 mm steps at F300
+with the probe expected; a contact backs off one step, retreats `hop_lift_mm` (default 2) along
+the retreat direction and continues, so the path follows the surface in steps (a gentle slope,
+one lift at the wall of a hole, one bump for a projection on a side). Over a top the retreat is
++Z, capped at the traverse height where a plain move finishes (law 2); along a side it is AWAY
+from the face, capped at the approved start line where a further contact is a fault. Between
+side points the probe backs off the last contact by `side_standoff_mm` (default 3) and skips
+along the face at that standoff; the next march starts from the arrival point (a dynamic start
+off the previous contact, never a fresh approach from the outside line). Surface scans take the
+same idea as `hop_mode: "stepped"` (`hop_lift_mm`) in place of the fixed `z_safe_delta_mm` hop
+whose only answer to a contact was to abort; `guarded` stays the default.
+
+**Traverse height beats a landmark clearance above it (job 34d787bdb2d7, 2026-09-06).** The
+`rotary-axis` landmark declares clearance 328 (the homing height) while the operator's safe
+traverse height is 320, so a sequence hop at 320 out of the rotary footprint was refused by the
+new planner check and a six-op program lost its last op. Law 2 defines the traverse height as
+safe for XY by decree: segments at or above `mcpSafeTraverseZ` are exempt from CROSSING landmarks
+(`checkMotion({traverseZ})`); a program `keep_out` VOLUME can still refuse them (it is the
+agent's explicit box). Marches (sensor-gated approaches that stop on contact) are exempt from
+crossing landmarks too — probing INTO the rotary footprint from outside is the job — never from
+volumes.
+
+**A missed march is a measurement, not a fault (2026-09-06, job 5ad5fcce6b3a).** The agent's
+six-op centre-finding program aborted on its LAST op because the first south-side march started
+beyond a corner of the stock (width and step over-estimated) and found nothing within its
+25 mm - five completed ops were thrown away with it. `probe_sequence` steps now take `on_miss`:
+`continue` (default) records `{status: "no_contact", limitMachine, maxTravelMm}` for that probe,
+retreats, raises and carries on; `abort` keeps the old behaviour. Results carry `status` on every
+entry plus `contactCount` / `noContactProbes`; a later reference to a missed probe fails to resolve
+and refuses that op (program stops raised, everything else kept). Surface scans already treated a
+no-contact station this way.
+
+**Stopping a procedure (fixed 2026-09-06, job 5ad5fcce6b3a).** `stop_gcode_job` only knew the
+firmware's `stop_print`; a procedure is a server-driven loop, so three stop calls answered
+`ok: false` while the scan kept stepping. Now `requestProcedureStop()` (probing.ts) records a
+request that every motion primitive (`moveMachineSettled`, `senseAfter`, `rotateB`) checks
+before sending: the runner throws `ProcedureStopped` at the next step boundary, its normal
+abort path raises to the traverse height, and the job ends in state `stopped`. `ProcedureAbort`
+now carries `partial` (completed stations / contacts / ops) and the runner wrapper stores it as
+`job.result`, so the earlier promise "results are on the job record" is true for every abort,
+not only for stops. A program treats a stop as program-wide regardless of `on_fail`. The tool
+waits up to `wait_ms` (default 20 s) and returns `{ok: true, stopped | stopping, job}`.
 
 ## Safety model (operator-defined, non-negotiable)
 
@@ -442,6 +563,12 @@ reduction (section size, centring, yaw), live progress on the confirm page.
   centre X≈169.5); end face contact Y128.9 (exposed span ~Y130–300). The W side at Y140 was
   flaky (twice lost the confirm re-contact — local chamfer/fibre?). Stock-top figures are
   B-dependent (square stock rotates with B).
+- **Four-face survey (2026-09-05, 71.3 mm probe, machine coords, toolhead Z at contact)**: B0
+  top 207.8, B180 206.9, B90 219.6, B270 219.9 at (170, 199); section ≈ 71.9 × 47.2; sides at
+  B180 X134.2/133.5 (W) and 205.3/206.0 (E) at Y150/Y250; end Y129.2 at X190, Y128.7 at X150;
+  stock centre X ≈ 169.7; **rotary axis physical Z ≈ 112.4, X ≈ 169.7** (now the geometry
+  settings). Stock yawed ~0.4° (free end toward +X), centreline rising ~0.3 mm/100 mm toward the
+  tailstock. Full report on the box: `~/luban-evidence/REPORT-four-face-scan-2026-09-05.md`.
 - **Chuck fixed hole (probe_circle INSIDE mode, 8 points, rms 0.021, max residual 0.041)**:
   centre (168.974, 290.969), hole − tip 3.734. Cross-feature constraint: air-blast post
   diameter + hole diameter = **10.41 mm exactly** (tip-independent); the operator estimates
@@ -464,7 +591,9 @@ reduction (section size, centring, yaw), live progress on the confirm page.
 `query_firmware_position` (raw M114) · `validate_gcode` · `submit_gcode_job` →
 `start_gcode_job` (procedures run detached: returns the result if it arrives within
 `wait_ms`, default 25 s, else a `running` status) → `get_gcode_job_status` (event log +
-stored result; long-poll with `wait_ms`/`since_event`) / `stop_gcode_job` · `move_z` (single or
+stored result; long-poll with `wait_ms`/`since_event`) / `stop_gcode_job` (procedures: cooperative
+stop at the next step boundary, raise, state `stopped`, partial `result` kept; file jobs: firmware
+stop) · `move_z` (single or
 `z_targets` batch) · `home` · `goto_work_origin` · `move_and_capture` · `list_cameras` ·
 `capture_frame` (position-stamped, `frameId`, `expectedToolRegion`) · `set_tool_region` ·
 `track_feature` (NCC between cached frames — use instead of eyeballing pixels) ·
@@ -527,7 +656,8 @@ Full agent guidance in `.claude/skills/tool-change/SKILL.md`.
   operator to close their copy. The build dirties `src/package.json` and
   `MaterialTestGcodeParams.jsx` — revert before staging.
 - **Stack**: stacked single-commit PRs `mcp/N-*`, each targeting the previous branch
-  (#15 → #79 as of 2026-09-05, then `mcp/46-position-of-record` (#80) and `mcp/47-timing-inline-g53`; next `mcp/48`. #70 stale-
+  (#15 → #79 as of 2026-09-05, then `mcp/46-position-of-record` (#80), `mcp/47-timing-inline-g53` (#81),
+  `mcp/48-new-stock-survey`; next `mcp/49`. #70 stale-
   heartbeat, #71 probe_sequence, #72 GPIO probe feed, #73 Linux/mac packaging, #74 machine
   settings + docs, #75 sensor toggles + LAN, #76 job events + even survey, #77 offset
   transient + detached procedures, #78 surface scans, #79 console input leak, mcp/46 position

--- a/src/server/services/mcp/docs/COMPOSITE_PROBE_PROGRAM.md
+++ b/src/server/services/mcp/docs/COMPOSITE_PROBE_PROGRAM.md
@@ -30,24 +30,24 @@ plus horizontal side + end marches at two rotations. Today this is 18 approvals 
    of start_z even when floor_z_machine is explicitly lower (d7ac9247838e). Add
    `first_station_search_mm` (bounded by the floor) or honour the explicit floor for station 1
    only when no expected_z is given. With (3) this is mostly moot but still a footgun.
-5. **Multi-segment paths in one op**: `segments: [{start, end}, ...]` sharing a reference, so
+5. *(open)* **Multi-segment paths in one op**: `segments: [{start, end}, ...]` sharing a reference, so
    W-E from the measured centre outward to both edges is one op (today two jobs, or an
    off-stock first station aborts - 1dc39a8210a4).
-6. **Tip radius as configuration** (`probeTipDiameterMm` in the tool-setter config): side and
+6. *(done mcp/48: `mcpProbeTipDiameter` + `axis.tip_radius`, widths reported with the tip)* **Tip radius as configuration** (`probeTipDiameterMm` in the tool-setter config): side and
    end marches report contact centre AND corrected face; width/thickness/end position come out
    corrected. Unpinned today (~2.5 mm per README, inconsistent).
-7. **Stock-geometry reduction in the result**: faces keyed by B; per face: mean/slope/flatness;
+7. *(done mcp/48: `stockGeometry.ts` → `result.derived`)* **Stock-geometry reduction in the result**: faces keyed by B; per face: mean/slope/flatness;
    across faces: section dimensions (opposite-face pair means), axis height, centring offsets,
    yaw and pitch of the stock centreline (from side pairs and pair-mean slopes), end squareness.
    All the arithmetic done by hand in REPORT-four-face-scan-2026-09-05.md.
-8. **Event budget**: a full program is ~6,000-8,000 events at today's verbosity (537 batches x
+8. *(done mcp/48: plan estimate + staging refusal; limit is a setting)* **Event budget**: a full program is ~6,000-8,000 events at today's verbosity (537 batches x
    2 events per 11-station scan + readings). Either per-op event logs, or `mcpJobEventLimit`
    default 10,000, or drop the per-batch `response` payload behind a verbosity flag. Summaries
    and per-op results must never be trimmed.
 9. **Abort semantics**: any op failure (no contact at station 1, hop-guard contact, crash
    alarm, B settle failure) -> raise to traverse Z, mark the op failed, stop the program, keep
    all earlier op results. Optional `on_fail: skip|stop` per op for overtravel-type ops.
-10. **Confirm page for long programs**: live progress (op k of n, station, ETA from the timing
+10. *(partly: budget and B schedule on the page; live progress open)* **Confirm page for long programs**: live progress (op k of n, station, ETA from the timing
     table), the B schedule, total extents, and the token TTL is irrelevant once
     wait_for_approval_ms hands off - but the page should keep working as a monitor for the
     ~40-70 min run.

--- a/src/server/services/mcp/docs/NEW_STOCK_SURVEY_TODO.md
+++ b/src/server/services/mcp/docs/NEW_STOCK_SURVEY_TODO.md
@@ -1,0 +1,306 @@
+# New-stock rotary survey in ONE approval: implementation TODO (mcp/48)
+
+Status: **W1-W6 implemented 2026-09-06 (unit-tested, tsc/eslint clean), hardware test pending** -
+see section 5 for the test order; the confirm-page live progress (W6, second bullet) is the only
+item not built. Also in this PR: `stop_gcode_job` now stops procedures cooperatively (see README
+"Stopping a procedure"). REVISED after the operator's review (2026-09-06): W2 is an MCP tool
+(`set_probe_geometry`), not a settings pane; there is NO stored stock radius (per-program
+`swept_radius_mm` on `rotate_b`); geometry is never a prerequisite; W3 landmarks are CROSSING
+obstacles (probing inside the rotary landmark is allowed), program `keep_out` boxes are volumes.
+The W2/W3 text below is the original plan - read it with those corrections. Added the same day on
+operator request: `probe_stock_outline` (top with hole rejection, sides from an over-extended
+estimate skipping along the face at a standoff, centre/size/yaw fit; `march.ts` shared march +
+stepped traverse; surface `hop_mode: stepped`), the traverse-height exemption from crossing
+landmarks, and marches exempt from crossing landmarks. Written so any agent can pick this up cold.
+Target branch: `mcp/48-new-stock-survey`, stacked on `mcp/47-timing-inline-g53` (PR #81,
+commit `f7cea5119`, itself stacked on `mcp/46-position-of-record`, PR #80). One commit per
+PR, `--no-verify`, trailer `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>`; PR body
+ends with the Claude Code footer. Push to remote `fork` (tyeth/Luban) only, never `origin`.
+
+## 0. Pick-up notes (read first)
+
+- Worktree: `C:\dev\software\snapmaker\Luban-mcp`. MCP server code lives in
+  `src/server/services/mcp/`; the README there is the design record and MUST be updated with
+  every item below (sections "Motion laws", "Machine facts", "Tool surface", "Open threads",
+  stack list).
+- Checks before every commit (run from the repo root):
+  - `npx tsc -p tsconfig-server.json --noEmit 2>&1 | grep services/mcp` (must print nothing)
+  - `npx eslint src/server/services/mcp --ext .ts`
+  - pure-module unit checks: `TS_NODE_COMPILER_OPTIONS='{"module":"commonjs","esModuleInterop":true}' npx ts-node --transpile-only <test.ts>`.
+    Pure modules (`programRefs.ts`, `jobTiming.ts`, `surfaceScan.ts`, `positionOfRecord.ts`)
+    must not import server modules (config/settings.base is ESM-only and breaks ts-node). Keep
+    new logic in pure modules for the same reason. Earlier scratch tests lived in a session
+    scratchpad and are gone: re-create the ones you need (they are small; the expected numbers
+    are in this document and the README).
+  - Files written from python need `newline='\n'` (CRLF fails eslint linebreak-style).
+- CI: `gh workflow run build-on-pull-request.yml --ref <branch> -f platforms=linux`; artifact
+  `Snapmaker-luban-4.15.2-linux-amd64.deb`. Stage every green build on the Ubuntu box
+  (`pi@192.168.1.153`, `~/Downloads/`, repo `~/dev/Luban` checked out to the same commit).
+  SSH/SCP must use `/c/Windows/System32/OpenSSH/ssh.exe` and `scp.exe` (git-bash ssh is
+  refused). GitHub calls use the per-command `tyeth` token (memory note
+  `github-account-per-push-override`); never `gh auth switch`, never store the token.
+- Evidence on the box: `~/luban-evidence/REPORT-four-face-scan-2026-09-05.md` (the manual
+  survey this work must reproduce), `stage_*.json` / `start_*.json` (the exact arguments used
+  for every manual step), `mcpcall.py` (raw JSON-RPC helper), `scan_<job>_events.json`.
+- Laws (README "Motion laws") are not negotiable: one motion per instruction; XY > 1 mm only
+  at the safe traverse Z (320) except surface-scan hops (contact + <= 20 mm, hop <= 60 mm); no
+  fabricated clearances (every number is measured, operator-given, or bounded and approved);
+  landmarks are obstacles; contact sensors are crash sensors; the confirm page is the only
+  motion gate; coarse step <= 1 mm; every descent toward the work in <= 5 mm segments.
+
+## 1. Where the tooling stands (mcp/47, hardware status)
+
+| piece | state |
+|---|---|
+| `probe_program` (rotate_b, surface_path, surface_grid, sequence; one confirm page; one runner) | implemented, **not yet run on hardware** |
+| references `{from, plus, minus, between}` resolved at run time, refused outside bounds | implemented (`programRefs.ts`), unit-tested |
+| `rotate_b` (direct path, Z >= traverse, M114 / heartbeat `b` verification) | implemented, not hardware-tested (manual rotations used file jobs `G90 / G0 Bnnn`) |
+| slow zone, 1 mm coarse cap, segmented descents, position of record, approval hand-off | implemented; band-1 grid (133 stations) verified on `c7600c574`; later builds staged only |
+| job timing breakdown (`result.timing`, `get_job_timing`) | implemented, pure module |
+| landmarks (`landmarks.ts`: store + `obstaclesOnPath`) | used ONLY by the direct XY move guard (`tools/camera.ts`); no procedure planner checks them |
+| probe geometry (effective length 71.3, tip diameter ~2.5) | **not stored anywhere**; every report carries the numbers by hand |
+| rotary axis position | **not stored anywhere**; derived by hand in the report (physical Z ~112.4) |
+
+The manual survey (2026-09-05, 18 approvals, ~75 min) proved every sub-step; this PR turns
+it into one program for stock whose dimensions are unknown at staging.
+
+## 2. Acceptance target
+
+A rectangular bar in the rotary jig, dimensions unknown, is surveyed by ONE approved
+`probe_program` that produces: the top of each of the four faces (centre probe + N-S path +
+W-E path), both sides at two Y stations and the free end at two X stations (B0 and B90
+suffice for sides/end; the program may do all four). Every number a later op needs comes from
+earlier ops or the jig configuration through bounded references. Second target: a cylinder,
+same jig, crown line along the axis plus a cross-axis profile at several B angles.
+
+Numbers from the manual survey to reproduce (machine coords, toolhead Z at contact, probe
+71.3 mm): B0 top 207.8, B180 top 206.9, B90 top 219.6, B270 top 219.9; section 71.9 x 47.2;
+sides at B180 X134.2 / 133.5 (west) and 205.3 / 206.0 (east) at Y150 / Y250, Z200; end Y129.2
+at X190, Y128.7 at X150, Z202; stock centre X ~169.7; axis physical Z ~112.4. The stock runs
+along machine **Y** (chuck toward +Y, free end near Y129); N-S paths are at fixed X.
+
+## 3. Work items
+
+Order matters: W1 and W2 are prerequisites for the example program; W3 is the safety item
+that makes a single click acceptable on freshly clamped stock; W4 and W5 follow.
+
+### W1. Two-operand references (`programRefs.ts`, pure)
+
+Problem: new stock needs the width from two side contacts, the centre as their midpoint, and
+the B90 face height as axis + half-width. Today a reference is one source plus an offset.
+
+Shape (keep `from` refs exactly as they are; add operand forms):
+
+```
+{ from: "s0.west.x", plus?, minus?, between: [lo, hi] }                      // unchanged
+{ mid:  ["s0.west.x", "s0.east.x"], plus?, minus?, between }                  // (a + b) / 2
+{ diff: ["s0.east.x", "s0.west.x"], scale?: 0.5, plus?, minus?, between }     // (a - b) * scale
+{ min:  ["ns0.summary.zMin", "we0.summary.zMin"], between }                   // min(a, b, ...)
+{ max:  [...], between }
+```
+
+- Operands are dotted paths (`<opId>.<path>`, same shorthands as `from`: `<seq>.<probe>.z`,
+  `.x`, `.y` -> `contactMachine.*`). `plus` / `minus` may be a number OR a path string (so
+  "axis.z_contact + half-width" is one reference). No deeper nesting: resolution stays one
+  level so the confirm page can print the formula on one line.
+- Evaluation order: operator -> `scale` (default 1) -> `+ plus - minus` -> round3 -> bounds.
+  `between` stays REQUIRED (law 3); `refMidpoint` unchanged (mid of the bounds).
+- `isRef`: object with exactly one of `from | mid | diff | min | max`. `validateRef` checks
+  every operand path against the `<opId>.` pattern. Add `refOperands(ref): string[]` and use
+  it in `planProbeProgram` where today only `ref.from` is checked to run BEFORE the
+  referencing op (the `refs.some(...)` block), and in the page text.
+- `source` string for the page/events, e.g. `mid(s0.west.x=134.2, s0.east.x=205.3) = 169.75`.
+- Update the `REFERENCE` preview line in `planProbeProgram`, and the `probe_program` schema
+  and description in `tools/probing.ts` (refs are `object`; describe the forms).
+- Tests: mid, diff with scale, min/max, path-valued `plus`, out-of-bounds refusal, operand
+  op-ordering refusal, shorthand `.x` on sequence probes.
+
+### W2. Rotary axis and probe geometry as configuration
+
+Problem: the axis position and the probe geometry are jig/tool constants, re-derived by hand
+every survey. Stored once, every rotation's expected face height is derived, and the page can
+show the swept cylinder.
+
+- Settings (configstore; same pattern as `mcpJobEventLimit` in `jobs.ts`,
+  `services/api/api-mcp.js`, `app/ui/pages/global-modals/settings-modal/McpServer/index.tsx`,
+  i18n `resource.json`), each with an env override for the box:
+  - `mcpRotaryAxisX` (machine X of the axis line, ~169.7 measured) and `mcpRotaryAxisZ`
+    (PHYSICAL machine Z of the axis, ~112.4). UI labels: "Rotary axis X / Z (machine,
+    physical)".
+  - `mcpProbeEffectiveLength` (71.3 this fitting; toolhead Z at contact - length = physical
+    surface Z) and `mcpProbeTipDiameter` (~2.5; side contacts are centre +/- radius).
+  - `mcpRotaryMaxRadius` (jig clearance radius about the axis; anything inside it moves when
+    B moves).
+- Expose them in `getPositionSnapshot()` as `rotary: {axisX, axisZ, maxRadius} | null` and
+  `probe: {effectiveLength, tipDiameter} | null`, and through `get_position` and
+  `get_mcp_diagnostics`.
+- Program namespace: at run start seed `results.axis = { x, z_physical, z_contact:
+  z_physical + effectiveLength, max_radius, tip_radius }`; `planProbeProgram` accepts operand
+  op id `axis` without an op of that id, only when the settings are set (otherwise a
+  reference to `axis.*` is a staging error naming the settings to fill in). Then
+  `{ from: "axis.z_contact", plus: 36, between: [...] }` is the B90 face expectation.
+- `rotate_b`: keep `require_z_at_least >= traverse`; additionally print the swept cylinder on
+  the page (axis, max radius, in toolhead-Z terms `z_contact + max_radius`) so the operator
+  sees that 320 clears it. No new motion behaviour.
+- Docs: README "Machine facts" (axis, probe geometry, how they were measured, and when they
+  must be re-measured: any re-fit of the probe, any move of the rotary module).
+
+### W3. Keep-out checks at plan time (new pure module `envelopeChecks.ts` + planners)
+
+Problem: landmarks are enforced only on direct XY moves. A program on freshly clamped stock
+must be refused at staging if any descent column, side/end march, or low hop enters the
+chuck/tailstock volume. Today the agent guards this by hand (the Z202 end marches were
+"clear of the live centre" only because the agent checked).
+
+- Extract the 2D segment-vs-AABB slab test from `landmarks.ts:obstaclesOnPath` into
+  `envelopeChecks.ts` (pure): `segmentHitsBox(x0, y0, x1, y1, box, margin)` and
+  `checkSegmentAtZ(seg, z, obstacles, margin)`. `landmarks.ts` calls it.
+- Obstacle model for the check is the existing `Landmark` shape `{ name, machine: {x0, y0,
+  x1, y1}, clearanceZ }` (clearanceZ is TOOLHEAD Z, operator-set, tool length included).
+- Program-level transient obstacles: `probe_program` arg `keep_out: [{ name, machine: {x0,
+  y0, x1, y1}, clearance_z }]` for this clamping (jaw Y range, tailstock). Merged with the
+  stored landmarks for the checks and printed on the page under "KEEP-OUT"; never persisted.
+- What to check (every planner exposes its motion list so the check is data-driven):
+  1. `sequence`: each `hop` at hopZ (trivially clear unless a landmark's clearanceZ > hopZ,
+     which the check still catches); each `descend` column: the point (x, y) at the target Z;
+     each `probe` march: segment from `start` to `start + unit * maxTravelMm` at start.z
+     (for dz marches: the column from start.z down to start.z - maxTravelMm).
+  2. `surface_path` / `surface_grid`: station 1 descent column to the floor Z; every hop
+     segment at the LOWEST hop height it can use (expected contact + z_safe_delta, floor
+     bounded); every station column down to `max(lastContact - max_drop, floor)` (the plan
+     already prints these numbers).
+  3. `rotate_b`: with `axis` configured (W2), refuse if the position of record has the
+     toolhead inside the swept cylinder (belt and braces; Z >= traverse already covers it).
+- Refusal is a staging error (`McpToolError`) naming the op, the step, the obstacle and the
+  Z. The same check re-runs after references resolve at run time (the live plan may differ
+  from the mid-point preview); a run-time hit stops the program raised like any op failure.
+- The standalone tools (`probe_sequence`, `probe_surface_*`) get the check for free once it
+  lives in the planners.
+- Tests (pure): column inside/outside a box, segment crossing a box at Z below/above the
+  clearance, margin behaviour, a surface hop at contact + 20 crossing a jaw box.
+
+### W4. Discovery for unknown height and for cylinders
+
+- `ZSummary` (`surfaceScan.ts`): add `highestAt: {x, y}` and `lowestAt: {x, y}` (samples
+  carry x/y already). `{ from: "cross0.summary.highestAt.x", between: [...] }` then locates
+  the crown of a cylinder or the high edge of a face.
+- Unknown height, first descent: no new op kind. Pattern (document in the skill): a
+  `sequence` whose `descend` is `{ from: "axis.z_contact", plus: <max_radius + 5>, between }`
+  and whose probe is `dz: -1, max_travel_mm: <max_radius + 10>`. The runner already segments
+  the descent (5 mm, F600, async crash guard) and walks the last band at 1 mm / F100.
+- Cylinder cross-axis profile: `surface_path` gets an optional
+  `expected_profile: { circle: { center_x, center_z_contact, radius } }` (each a number or a
+  reference). Per station the expected contact Z is `center_z + sqrt(r^2 - (x - center_x)^2)`
+  with `r = radius + tip_radius`. `slowZoneFor` takes this per-station expectation instead of
+  the previous station; the `max_drop_mm` band is measured from the expectation, not from the
+  previous contact. The planner refuses stations with `|x - center_x| > 0.7 * radius` (contact
+  angle > 45 deg: the tip glances and the side channel would read it as a crash).
+- Rectangular faces: no change; the previous-station expectation is right for flat faces.
+- `probe_program` result: add `derived` (optional, computed from `axis` and whichever ops are
+  present): section width/height, centre XY, tilt per 100 mm, using the formulas of the
+  2026-09-05 report so the report writes itself. Pure function, unit-tested against the
+  report's numbers (71.9 x 47.2, centre X 169.7, yaw +0.7 / 100).
+
+### W5. Rotation template (`probeProgram.ts`, plan-time expansion)
+
+- New op kind `group`: `{ id, kind: "group", for_b: [0, 90, 180, 270], ops: [...] }`.
+  Expanded BEFORE validation into `rotate_b` + the inner ops per angle, so the runner and the
+  page see plain ops. Substitution: the literal `${b}` in any string (ids, `name`, reference
+  paths) becomes the angle; inner op ids become `<id>_b<angle>` when they contain no `${b}`.
+- `MAX_OPS` 40 -> 80 after expansion; the page lists the expanded ops with one header line per
+  group ("GROUP faces: 4 rotations x 4 ops").
+- Test: expansion of a 2-angle group, id uniqueness, `${b}` inside a `from` path.
+
+### W6. Operational limits for a 30-minute program
+
+- Event budget: `estimateEventBudget(plan)` = 100 + sum(stations x 120) + sequences x
+  (60 per probe + 20) + rotations x 20. Staging refuses when the estimate exceeds
+  `jobEventLimit()`, naming the setting (Settings -> MCP Server, or
+  `LUBAN_MCP_JOB_EVENT_LIMIT`) and the number to set. Put the estimate in the plan result and
+  on the page. Measured: 763 events for an 8-station path; a four-face survey with two
+  11-station paths per face plus sides/ends is ~12k, so the operator should set 15000-20000.
+- Confirm page live progress: the runner already broadcasts `mcp:activity` per op; the
+  approved page can poll `/api/mcp/jobs/<id>` and show `op N/M <id>` (nice-to-have, last).
+- Approval: `start_gcode_job wait_for_approval_ms` (<= 120 s) already covers the hand-off.
+
+## 4. The program this enables (rectangular bar, nothing known but the jig)
+
+Assumes W1-W3 and `axis` configured (x 169.7, z_physical 112.4, max_radius 45, probe 71.3 /
+2.5). All numbers are machine coordinates; `between` bounds are the operator's envelope.
+
+```json
+{ "name": "new bar survey", "reason": "four faces, sides and end of freshly clamped stock",
+  "keep_out": [{ "name": "chuck jaws", "machine": { "x0": 120, "y0": 262, "x1": 220, "y1": 300 }, "clearance_z": 260 }],
+  "ops": [
+    { "id": "top0", "kind": "sequence", "steps": [
+        { "kind": "hop", "x": 170, "y": 199 },
+        { "kind": "descend", "z": { "from": "axis.z_contact", "plus": 50, "between": [225, 240] } },
+        { "kind": "probe", "name": "top", "dz": -1, "max_travel_mm": 55 } ] },
+    { "id": "sides0", "kind": "sequence", "steps": [
+        { "kind": "hop", "x": 118, "y": 150 },
+        { "kind": "descend", "z": { "from": "top0.top.z", "minus": 7, "between": [190, 235] } },
+        { "kind": "probe", "name": "west", "dx": 1, "max_travel_mm": 40 },
+        { "kind": "hop", "x": 222, "y": 150 },
+        { "kind": "descend", "z": { "from": "top0.top.z", "minus": 7, "between": [190, 235] } },
+        { "kind": "probe", "name": "east", "dx": -1, "max_travel_mm": 40 },
+        { "kind": "hop", "x": 170, "y": 110 },
+        { "kind": "descend", "z": { "from": "top0.top.z", "minus": 5, "between": [190, 235] } },
+        { "kind": "probe", "name": "end", "dy": 1, "max_travel_mm": 30 } ] },
+    { "id": "ns0", "kind": "surface_path",
+      "start_x": { "mid": ["sides0.west.x", "sides0.east.x"], "between": [160, 180] }, "start_y": 255,
+      "end_x":   { "mid": ["sides0.west.x", "sides0.east.x"], "between": [160, 180] }, "end_y": 135,
+      "spacing_mm": 15, "expected_z_machine": { "from": "top0.top.z", "between": [195, 235] },
+      "start_z_machine": { "from": "top0.top.z", "plus": 7, "between": [200, 245] },
+      "z_safe_delta_mm": 5, "max_drop_mm": 10, "confirm_passes": 2, "sensor_delay_ms": 50 },
+    { "id": "we0", "kind": "surface_path",
+      "start_x": { "from": "sides0.west.x", "plus": 6, "between": [130, 160] }, "start_y": 199,
+      "end_x":   { "from": "sides0.east.x", "minus": 6, "between": [180, 215] }, "end_y": 199,
+      "spacing_mm": 12, "expected_z_machine": { "from": "top0.top.z", "between": [195, 235] },
+      "start_z_machine": { "from": "top0.top.z", "plus": 7, "between": [200, 245] },
+      "z_safe_delta_mm": 5, "max_drop_mm": 10, "confirm_passes": 2 },
+    { "id": "r90", "kind": "rotate_b", "b": 90 },
+    { "id": "top90", "kind": "sequence", "steps": [
+        { "kind": "hop", "x": 170, "y": 199 },
+        { "kind": "descend", "z": { "diff": ["sides0.east.x", "sides0.west.x"], "scale": 0.5, "plus": "axis.z_contact", "between": [210, 235] } },
+        { "kind": "probe", "name": "top", "dz": -1, "max_travel_mm": 20 } ] },
+    { "id": "ns90", "kind": "surface_path", "...": "as ns0 with top90.top.z" },
+    { "id": "r180", "kind": "rotate_b", "b": 180 }, { "id": "top180", "...": "as top0, expecting top0.top.z +/- 3" },
+    { "id": "r270", "kind": "rotate_b", "b": 270 }, { "id": "top270", "...": "as top90" },
+    { "id": "r0", "kind": "rotate_b", "b": 0 }
+  ] }
+```
+
+Notes: the `descend` before `top90` is "axis + half of the measured width", the value the
+manual survey derived by hand (219.6 ~= 112.4 + 71.3 + 35.9). The end march at Y110 -> +Y
+must stay >= 5 mm below the top and clear of the jaw keep-out; the planner proves it. With W5
+the four `top / ns / we` triples collapse into one `group`.
+
+Cylinder variant: replace `sides0` by a cross-axis `surface_path` at Y199 with
+`expected_profile.circle` (centre from `axis`, radius bounded by the operator), take the crown
+from `summary.highestAt.x`, then run the along-axis path at that X, repeated at B 0/90/180/270.
+
+## 5. Verification plan
+
+1. Pure tests for W1, W3, W4 (profile maths, `derived`), W5, W6 estimate. tsc + eslint clean.
+2. Stage a program on the box WITHOUT rotations first (top0 + sides0 + ns0 + we0 at B0) and
+   compare against the 2026-09-05 numbers (B0 top 207.8, sides ~133.9 / 205.7 at Y150). Read
+   `result.timing` and `result.derived`.
+3. Then the B90 half (r90 + top90 + ns90): the derived descend must land within 3 mm of 219.6.
+4. Then the full four-face program in one approval; record wall time, event count against the
+   estimate, settle-wait count (must stay 0), `slow_step` events, any refused reference.
+5. Update the evidence on the box (REPORT style), the README timing table if station time
+   changed, the `cnc-probing` skill (+ the claude.ai `.skill` bundle: `python -m
+   scripts.package_skill` from the skill-creator plugin cache), and
+   `docs/COMPOSITE_PROBE_PROGRAM.md` (mark items 5, 6, 7, 8, 10 done as they land).
+
+## 6. Decisions already taken (do not re-open without the operator)
+
+- References stay one level deep and every reference keeps `between`; no free arithmetic
+  expressions. The confirm page must be readable by the operator at a glance.
+- Coarse feed stays F100 unless the operator says otherwise; `z_safe_delta_mm` 5 is the
+  agent's lever for time, not a default change.
+- Inline `G53 G1 ...` (one HTTP line per move, ~100 s per 11-station scan) is NOT part of
+  this work: removed from mcp/47 as unrequested; it would be its own PR with the
+  gantry-height verification test described in the README.
+- Landmarks remain toolhead-Z clearances set by the operator; the program's `keep_out` is
+  transient and shown on the page, never persisted silently.

--- a/src/server/services/mcp/envelopeChecks.ts
+++ b/src/server/services/mcp/envelopeChecks.ts
@@ -1,0 +1,266 @@
+/* eslint-disable camelcase */
+// keep_out is an MCP tool argument (snake_case by convention).
+// Pure keep-out geometry for procedure planners (mcp/48, law 4: landmarks
+// are obstacles). Until now only the direct XY move guard consulted the
+// landmark store; a staged procedure could plan a descent column, a side
+// march or a low surface hop straight into the chuck and the operator had to
+// catch it on the confirm page. Every planner now hands its motion list
+// through checkMotion() and refuses at staging.
+//
+// No machine or server imports: unit-testable with ts-node.
+
+export interface ObstacleBox {
+    name: string;
+    /** Machine-coordinate XY extent. */
+    machine: { x0: number; y0: number; x1: number; y1: number };
+    /** Minimum safe TOOLHEAD machine Z over the box (operator-set, tool length included). */
+    clearanceZ: number;
+    /**
+     * What the box forbids below its clearance:
+     *  - 'crossing': entering or leaving the box on a low horizontal path
+     *    (a stored landmark such as "rotary-axis" X140-200 x Y0-350: you do
+     *    not TRAVERSE across the rotary low, but probing INTO it is the whole
+     *    point of a procedure the operator approves on the page - a descent
+     *    column or a march wholly inside the box is allowed);
+     *  - 'volume': nothing enters, not even a column (a program's keep_out:
+     *    the chuck jaws, the tailstock).
+     */
+    mode: 'crossing' | 'volume';
+}
+
+export interface MotionSegment {
+    /** What the segment is, for the refusal message ("steps[3] descend column", "hop s4 -> s5"). */
+    what: string;
+    /**
+     * 'hop': a plain move expecting no contact (crash guard); 'column': a
+     * vertical descent (segmented, guarded); 'march': a sensor-gated probing
+     * move that STOPS on contact (a -Z or side march, a stepped traverse).
+     * Marches are exempt from 'crossing' landmarks - probing INTO the rotary
+     * footprint from outside is the job - but never from 'volume' keep-outs.
+     */
+    kind?: 'hop' | 'column' | 'march';
+    from: { x: number; y: number; z: number };
+    to: { x: number; y: number; z: number };
+}
+
+export interface Violation {
+    what: string;
+    obstacle: string;
+    /** Lowest toolhead Z the segment reaches while over the (inflated) box. */
+    z: number;
+    clearanceZ: number;
+}
+
+export const OBSTACLE_MARGIN_MM = 5;
+
+/** 2D segment-vs-AABB slab test; the box is inflated by `margin` on every side. */
+export function segmentHitsBox2D(
+    x0: number, y0: number, x1: number, y1: number,
+    box: { x0: number; y0: number; x1: number; y1: number },
+    margin: number = OBSTACLE_MARGIN_MM
+): boolean {
+    const bx0 = Math.min(box.x0, box.x1) - margin;
+    const by0 = Math.min(box.y0, box.y1) - margin;
+    const bx1 = Math.max(box.x0, box.x1) + margin;
+    const by1 = Math.max(box.y0, box.y1) + margin;
+    const dx = x1 - x0;
+    const dy = y1 - y0;
+    let tMin = 0;
+    let tMax = 1;
+    for (const [p, d, lo, hi] of [[x0, dx, bx0, bx1], [y0, dy, by0, by1]] as [number, number, number, number][]) {
+        if (Math.abs(d) < 1e-12) {
+            if (p < lo || p > hi) {
+                return false;
+            }
+        } else {
+            let t1 = (lo - p) / d;
+            let t2 = (hi - p) / d;
+            if (t1 > t2) {
+                [t1, t2] = [t2, t1];
+            }
+            tMin = Math.max(tMin, t1);
+            tMax = Math.min(tMax, t2);
+            if (tMin > tMax) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+export function pointInBox2D(x: number, y: number, box: { x0: number; y0: number; x1: number; y1: number }, margin: number = OBSTACLE_MARGIN_MM): boolean {
+    return x >= Math.min(box.x0, box.x1) - margin && x <= Math.max(box.x0, box.x1) + margin
+        && y >= Math.min(box.y0, box.y1) - margin && y <= Math.max(box.y0, box.y1) + margin;
+}
+
+/**
+ * Every (segment, obstacle) pair the obstacle forbids: the segment's lowest Z
+ * is below the clearance and, for a 'volume' box, the segment touches the
+ * inflated box at all; for a 'crossing' box, the segment touches it with at
+ * least one endpoint OUTSIDE it (it enters or leaves low). A vertical column
+ * (from.xy == to.xy) is a segment of zero XY length: forbidden inside a
+ * volume, allowed inside a crossing box.
+ */
+export function checkMotion(
+    segments: MotionSegment[],
+    obstacles: ObstacleBox[],
+    options: { margin?: number; traverseZ?: number } = {}
+): Violation[] {
+    const margin = options.margin === undefined ? OBSTACLE_MARGIN_MM : options.margin;
+    const out: Violation[] = [];
+    for (const seg of segments) {
+        const lowZ = Math.min(seg.from.z, seg.to.z);
+        for (const ob of obstacles) {
+            if (lowZ >= ob.clearanceZ - 1e-9) {
+                continue;
+            }
+            // Law 2 defines the safe traverse height (mcpSafeTraverseZ, 320):
+            // XY travel there is safe by the operator's decree, so a stored
+            // landmark whose clearance sits above it (the rotary-axis landmark
+            // says 328, the homing height) cannot refuse a traverse-height hop
+            // (job 34d787bdb2d7 lost its sixth op to exactly that). A program
+            // keep_out VOLUME still can - it is this clamping's explicit box.
+            if (ob.mode === 'crossing' && options.traverseZ !== undefined && lowZ >= options.traverseZ - 1e-9) {
+                continue;
+            }
+            if (!segmentHitsBox2D(seg.from.x, seg.from.y, seg.to.x, seg.to.y, ob.machine, margin)) {
+                continue;
+            }
+            if (ob.mode === 'crossing' && seg.kind === 'march') {
+                continue; // a sensor-gated approach into the footprint is the procedure itself
+            }
+            if (ob.mode === 'crossing'
+                && pointInBox2D(seg.from.x, seg.from.y, ob.machine, margin)
+                && pointInBox2D(seg.to.x, seg.to.y, ob.machine, margin)) {
+                continue; // wholly inside: the approved procedure works here
+            }
+            out.push({ what: seg.what, obstacle: ob.name, z: Number(lowZ.toFixed(3)), clearanceZ: ob.clearanceZ });
+        }
+    }
+    return out;
+}
+
+export function describeViolations(violations: Violation[]): string {
+    return violations
+        .map((v) => `${v.what} reaches toolhead Z ${v.z} over / into "${v.obstacle}" (clearance Z ${v.clearanceZ})`)
+        .join('; ');
+}
+
+/**
+ * Motion list of a probe sequence plan (hop / descend / probe steps, already
+ * simulated by the planner): hops at the traverse height, descend columns,
+ * marches from their start to their far limit.
+ */
+export function sequenceMotion(plan: {
+    hopZ: number;
+    staged: { x: number; y: number; z: number };
+    steps: ({ kind: 'hop'; x: number; y: number }
+        | { kind: 'descend'; z: number }
+        | { kind: 'probe'; name: string; unit: { x: number; y: number; z: number }; maxTravelMm: number; start: { x: number; y: number; z: number } })[];
+}): MotionSegment[] {
+    const out: MotionSegment[] = [];
+    const virtual = { x: plan.staged.x, y: plan.staged.y, z: plan.hopZ };
+    plan.steps.forEach((step, index) => {
+        const at = `steps[${index}]`;
+        if (step.kind === 'hop') {
+            out.push({ kind: 'hop', what: `${at} hop`, from: { ...virtual, z: plan.hopZ }, to: { x: step.x, y: step.y, z: plan.hopZ } });
+            virtual.x = step.x;
+            virtual.y = step.y;
+            virtual.z = plan.hopZ;
+        } else if (step.kind === 'descend') {
+            out.push({ kind: 'column', what: `${at} descend column`, from: { ...virtual }, to: { x: virtual.x, y: virtual.y, z: step.z } });
+            virtual.z = step.z;
+        } else {
+            const s = step.start;
+            const limit = {
+                x: Number((s.x + step.unit.x * step.maxTravelMm).toFixed(3)),
+                y: Number((s.y + step.unit.y * step.maxTravelMm).toFixed(3)),
+                z: Number((s.z + step.unit.z * step.maxTravelMm).toFixed(3)),
+            };
+            out.push({ kind: 'march', what: `${at} probe "${step.name}" march`, from: { ...s }, to: limit });
+            virtual.x = s.x;
+            virtual.y = s.y;
+            virtual.z = plan.hopZ;
+        }
+    });
+    return out;
+}
+
+/**
+ * Motion list of a surface scan plan, conservatively: the first station's
+ * descent from the traverse height to the plan's absolute floor; every hop
+ * at the LOWEST height it could use (any contact is >= the absolute floor,
+ * so the hop is >= floor + z_safe_delta); every station's column down to the
+ * absolute floor.
+ */
+export function surfaceMotion(plan: {
+    hopZ: number;
+    absoluteFloorZ: number;
+    zSafeDeltaMm: number;
+    hopMode?: 'guarded' | 'stepped';
+    stations: { label: string; x: number; y: number }[];
+}): MotionSegment[] {
+    const out: MotionSegment[] = [];
+    const lowestHopZ = Number((plan.absoluteFloorZ + plan.zSafeDeltaMm).toFixed(3));
+    plan.stations.forEach((st, index) => {
+        if (index === 0) {
+            out.push({ kind: 'column', what: `station ${st.label} descent`, from: { x: st.x, y: st.y, z: plan.hopZ }, to: { x: st.x, y: st.y, z: plan.absoluteFloorZ } });
+            return;
+        }
+        const prev = plan.stations[index - 1];
+        out.push({ kind: plan.hopMode === 'stepped' ? 'march' : 'hop', what: `hop ${prev.label} -> ${st.label}`, from: { x: prev.x, y: prev.y, z: lowestHopZ }, to: { x: st.x, y: st.y, z: lowestHopZ } });
+        out.push({ kind: 'march', what: `station ${st.label} march`, from: { x: st.x, y: st.y, z: lowestHopZ }, to: { x: st.x, y: st.y, z: plan.absoluteFloorZ } });
+    });
+    return out;
+}
+
+export class KeepOutError extends Error {}
+
+/** Validate a program's transient keep_out argument into obstacle boxes. */
+export function normalizeKeepOut(raw: unknown, where: string = 'keep_out'): ObstacleBox[] {
+    if (raw === undefined || raw === null) {
+        return [];
+    }
+    if (!Array.isArray(raw) || raw.length > 20) {
+        throw new KeepOutError(`${where}: must be an array of up to 20 {name, machine: {x0, y0, x1, y1}, clearance_z}.`);
+    }
+    return raw.map((item, index) => {
+        const at = `${where}[${index}]`;
+        if (!item || typeof item !== 'object') {
+            throw new KeepOutError(`${at}: must be an object.`);
+        }
+        const o = item as { name?: unknown; machine?: unknown; clearance_z?: unknown };
+        const name = String(o.name || '').trim();
+        if (!name) {
+            throw new KeepOutError(`${at}: name is required (shown on the confirm page).`);
+        }
+        const m = (o.machine || {}) as { x0?: unknown; y0?: unknown; x1?: unknown; y1?: unknown };
+        const nums = [m.x0, m.y0, m.x1, m.y1].map(Number);
+        if (nums.some((n) => !Number.isFinite(n))) {
+            throw new KeepOutError(`${at}: machine {x0, y0, x1, y1} must be finite machine coordinates.`);
+        }
+        const clearanceZ = Number(o.clearance_z);
+        if (!Number.isFinite(clearanceZ) || clearanceZ < 0 || clearanceZ > 400) {
+            throw new KeepOutError(`${at}: clearance_z (minimum safe TOOLHEAD machine Z over the box) is required, 0-400.`);
+        }
+        return {
+            name,
+            machine: { x0: Math.min(nums[0], nums[2]), y0: Math.min(nums[1], nums[3]), x1: Math.max(nums[0], nums[2]), y1: Math.max(nums[1], nums[3]) },
+            clearanceZ,
+            mode: 'volume',
+        };
+    });
+}
+
+/**
+ * Is the probe tip inside the rotary's swept cylinder (axis along machine Y
+ * at X = axisX, physical Z = axisZ, radius r)? Used before a rotation.
+ */
+export function insideSweptCylinder(
+    toolhead: { x: number; z: number },
+    probeLength: number,
+    axis: { x: number; zPhysical: number; radius: number }
+): boolean {
+    const tipZ = toolhead.z - probeLength;
+    return Math.hypot(toolhead.x - axis.x, tipZ - axis.zPhysical) < axis.radius;
+}

--- a/src/server/services/mcp/landmarks.ts
+++ b/src/server/services/mcp/landmarks.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import DataStorage from '../../DataStorage';
 import logger from '../../lib/logger';
+import { ObstacleBox, segmentHitsBox2D } from './envelopeChecks';
 
 const log = logger('service:mcp:landmarks');
 
@@ -113,35 +114,20 @@ export class LandmarkStore {
             if (l.clearanceZ === null || toolheadZ >= l.clearanceZ) {
                 return false;
             }
-            const bx0 = l.machine.x0 - marginMm;
-            const by0 = l.machine.y0 - marginMm;
-            const bx1 = l.machine.x1 + marginMm;
-            const by1 = l.machine.y1 + marginMm;
-            // 2D segment-vs-AABB slab test.
-            const dx = x1 - x0;
-            const dy = y1 - y0;
-            let tMin = 0;
-            let tMax = 1;
-            for (const [p, d, lo, hi] of [[x0, dx, bx0, bx1], [y0, dy, by0, by1]] as [number, number, number, number][]) {
-                if (Math.abs(d) < 1e-12) {
-                    if (p < lo || p > hi) {
-                        return false;
-                    }
-                } else {
-                    let t1 = (lo - p) / d;
-                    let t2 = (hi - p) / d;
-                    if (t1 > t2) {
-                        [t1, t2] = [t2, t1];
-                    }
-                    tMin = Math.max(tMin, t1);
-                    tMax = Math.min(tMax, t2);
-                    if (tMin > tMax) {
-                        return false;
-                    }
-                }
-            }
-            return true;
+            return segmentHitsBox2D(x0, y0, x1, y1, l.machine, marginMm);
         });
+    }
+
+    /**
+     * Obstacle landmarks (clearanceZ set) for the procedure planners
+     * (envelopeChecks), in 'crossing' mode: a landmark's clearance forbids
+     * TRAVERSING across its box low, not probing inside it - the rotary-axis
+     * landmark covers the whole stock, and probing the stock is the job.
+     */
+    public obstacleBoxes(): ObstacleBox[] {
+        return this.load().landmarks
+            .filter((l) => l.clearanceZ !== null)
+            .map((l) => ({ name: l.name, machine: { ...l.machine }, clearanceZ: l.clearanceZ as number, mode: 'crossing' as const }));
     }
 
     /**

--- a/src/server/services/mcp/march.ts
+++ b/src/server/services/mcp/march.ts
@@ -1,0 +1,345 @@
+import { mcpBroadcast } from './index';
+import { probeFeedService } from './probeFeed';
+import {
+    COARSE_FEED,
+    FINE_FEED,
+    MAX_RETREAT_MM,
+    ProcedureAbort,
+    TRAVEL_FEED,
+    moveMachineSettled,
+    senseAfter,
+    senseReleaseAfter,
+} from './probing';
+
+// Shared sensor-gated motion primitives (mcp/48, operator request 2026-09-06):
+//
+//  - marchToContact(): the proven coarse -> release -> fine -> confirm march
+//    every runner carries a copy of (probe_vector, probe_sequence, tool
+//    setter, surface scans), with the same numbers, as one function. A miss
+//    (limit reached without contact) is RETURNED, not thrown: the caller
+//    decides (a measurement of "nothing within N mm" is usually fine).
+//
+//  - steppedTraverse(): a move between two points close to a surface as a
+//    TOUCH-PROBING move: 1 mm steps with the probe channel expected, and a
+//    contact means "the surface is closer here" - back off one step, retreat
+//    `liftMm` along the retreat direction (up, for a top; away from the face,
+//    for a side), continue. The result is a step profile of the surface
+//    between the points (gentle for a slope, one big lift for the wall of a
+//    hole, one bump for a projection on a side) instead of the fixed "last
+//    contact + N mm" clearance whose only answer to a contact was to abort.
+//    Retreats are capped: for a top, at the traverse height, above which a
+//    plain move finishes (law 2); for a side, at the approved start line,
+//    where a further contact is a fault (something stands where the operator
+//    approved empty space).
+
+export type Xyz = { x: number; y: number; z: number };
+
+export interface MarchParams {
+    coarseStepMm: number;
+    fineStepMm: number;
+    backoffMm: number;
+    sensorDelayMs: number;
+    confirmPasses: number;
+}
+
+export interface MarchContact {
+    /** Distance along the unit vector from the start (median of the confirm passes). */
+    s: number;
+    point: Xyz;
+    passContacts: number[];
+    spreadMm: number;
+    coarseContactS: number;
+}
+
+export type Announce = (phase: string, note?: string) => void;
+
+export function makeAnnounce(tool: string, phases: { phase: string; note?: string }[]): Announce {
+    return (phase: string, note?: string) => {
+        phases.push({ phase, note });
+        mcpBroadcast('mcp:activity', { tool, phase, note });
+    };
+}
+
+const r3 = (v: number) => Number(v.toFixed(3));
+
+export function pointAlong(start: Xyz, unit: Xyz, s: number): Xyz {
+    return { x: r3(start.x + unit.x * s), y: r3(start.y + unit.y * s), z: r3(start.z + unit.z * s) };
+}
+
+function wordsAlong(start: Xyz, unit: Xyz, s: number): { x?: number; y?: number; z?: number } {
+    const p = pointAlong(start, unit, s);
+    const words: { x?: number; y?: number; z?: number } = {};
+    if (Math.abs(unit.x) > 1e-9) {
+        words.x = p.x;
+    }
+    if (Math.abs(unit.y) > 1e-9) {
+        words.y = p.y;
+    }
+    if (Math.abs(unit.z) > 1e-9) {
+        words.z = p.z;
+    }
+    return words;
+}
+
+/**
+ * March from `start` along `unit` (unit vector, dz <= 0) up to `maxTravelMm`
+ * on the probe channel. Returns the contact, or null when the limit was
+ * reached without one (the probe is then AT the limit: the caller retreats).
+ * Throws ProcedureAbort on an inconsistent probe (stuck, lost re-contact).
+ * The expected-contact set is the caller's: set it before, clear it after
+ * the retreat.
+ */
+export async function marchToContact(
+    tag: string,
+    name: string,
+    start: Xyz,
+    unit: Xyz,
+    maxTravelMm: number,
+    params: MarchParams,
+    announce: Announce
+): Promise<MarchContact | null> {
+    const releaseTimeoutMs = Math.max(params.sensorDelayMs * 4, 3500);
+    const move = async (tool: string, s: number, feed: number) => {
+        await moveMachineSettled(tool, wordsAlong(start, unit, s), feed);
+    };
+    let s = 0;
+    let coarseContactS: number | null = null;
+    while (maxTravelMm - s > 1e-9) {
+        const t0 = Date.now();
+        s = Math.min(s + params.coarseStepMm, maxTravelMm);
+        await move(`${tag}:coarse:${name}`, s, COARSE_FEED);
+        const sensed = await senseAfter('probe', t0, params.sensorDelayMs);
+        if (sensed.contact) {
+            coarseContactS = s;
+            announce(`coarse-contact-${name}`, `${s.toFixed(3)} mm along`);
+            break;
+        }
+    }
+    if (coarseContactS === null) {
+        return null;
+    }
+    let released = false;
+    while (s > 1e-9 && coarseContactS - s < MAX_RETREAT_MM + 1e-9) {
+        const t0 = Date.now();
+        s = Math.max(s - params.coarseStepMm, 0);
+        await move(`${tag}:release:${name}`, s, COARSE_FEED);
+        const sensed = await senseReleaseAfter('probe', t0, releaseTimeoutMs);
+        if (!sensed.contact) {
+            released = true;
+            break;
+        }
+    }
+    if (!released) {
+        throw new ProcedureAbort(`March "${name}": still triggered ${MAX_RETREAT_MM} mm back - stuck probe or feed fault.`);
+    }
+    let fineContactS: number | null = null;
+    while (maxTravelMm - s > 1e-9) {
+        const t0 = Date.now();
+        s = Math.min(s + params.fineStepMm, maxTravelMm);
+        await move(`${tag}:fine:${name}`, s, FINE_FEED);
+        const sensed = await senseAfter('probe', t0, params.sensorDelayMs);
+        if (sensed.contact) {
+            fineContactS = s;
+            break;
+        }
+    }
+    if (fineContactS === null) {
+        throw new ProcedureAbort(`March "${name}": fine approach lost the contact.`);
+    }
+    const passContacts: number[] = [];
+    const cycleLimit = Math.min(fineContactS + Math.max(0.5, params.backoffMm), maxTravelMm);
+    let reference = fineContactS;
+    for (let pass = 1; pass <= params.confirmPasses; pass++) {
+        const t0 = Date.now();
+        s = Math.max(reference - params.backoffMm, 0);
+        await move(`${tag}:backoff:${name}`, s, FINE_FEED);
+        const lifted = await senseReleaseAfter('probe', t0, releaseTimeoutMs);
+        if (lifted.contact) {
+            throw new ProcedureAbort(`March "${name}": hysteresis exceeds the backoff ${params.backoffMm} mm.`);
+        }
+        let passContact: number | null = null;
+        while (cycleLimit - s > 1e-9) {
+            const t1 = Date.now();
+            s = Math.min(s + params.fineStepMm, cycleLimit);
+            await move(`${tag}:confirm:${name}`, s, FINE_FEED);
+            const sensed = await senseAfter('probe', t1, params.sensorDelayMs);
+            if (sensed.contact) {
+                passContact = s;
+                break;
+            }
+        }
+        if (passContact === null) {
+            throw new ProcedureAbort(`March "${name}": confirm pass ${pass} lost the contact.`);
+        }
+        passContacts.push(r3(passContact));
+        reference = passContact;
+    }
+    const sorted = [...passContacts].sort((a, b) => a - b);
+    const measuredS = sorted[Math.floor((sorted.length - 1) / 2)];
+    const spreadMm = r3(sorted[sorted.length - 1] - sorted[0]);
+    const point = pointAlong(start, unit, measuredS);
+    announce(`measured-${name}`, `(${point.x}, ${point.y}, ${point.z}) spread ${spreadMm}`);
+    return { s: measuredS, point, passContacts, spreadMm, coarseContactS };
+}
+
+/** Move along the march vector to distance `s` from its start (0 = the start; the probe may still be in contact: keep it expected). */
+export async function retreatAlong(tag: string, name: string, start: Xyz, unit: Xyz, s: number): Promise<void> {
+    await moveMachineSettled(`${tag}:retreat:${name}`, wordsAlong(start, unit, s), TRAVEL_FEED);
+}
+
+export const STEPPED_HOP_STEP_MM = 1;
+export const STEPPED_HOP_FEED = 300;
+
+export interface SteppedTraverseParams {
+    /** Unit vector of the retreat on contact: (0,0,1) over a top, away from the face along a side. */
+    retreatUnit: Xyz;
+    /** Retreat per contact (mm). */
+    liftMm: number;
+    /** Total retreat allowed from the start plane (mm): traverse height minus z over a top; the start line along a side. */
+    maxLiftTotalMm: number;
+    /**
+     * At the cap: 'plain-move' finishes with one plain move (law 2, at the
+     * traverse height); 'stop-lifting' keeps stepping and a further contact is a fault.
+     */
+    onMax: 'plain-move' | 'stop-lifting';
+    sensorDelayMs: number;
+    /** Give up after this many lifts on one traverse (default 60). */
+    maxLifts?: number;
+}
+
+export interface SteppedTraverseResult {
+    /** Where the toolhead arrived: `to` displaced by the total retreat along retreatUnit. */
+    position: Xyz;
+    /** Total retreat from the start plane (mm). */
+    liftTotalMm: number;
+    lifts: { x: number; y: number; z: number; liftMm: number }[];
+    steps: number;
+    toppedOut: boolean;
+}
+
+/**
+ * Touch-probing traverse from `from` to `to` (see the file header). Both are
+ * full machine points; the traverse direction is `to - from`. The
+ * expected-contact set includes 'probe' while it runs and is cleared on
+ * return. Returns the arrival position, which lies on the line through `to`
+ * along retreatUnit.
+ */
+export async function steppedTraverse(
+    tag: string,
+    name: string,
+    from: Xyz,
+    to: Xyz,
+    params: SteppedTraverseParams,
+    announce: Announce
+): Promise<SteppedTraverseResult> {
+    const d = { x: to.x - from.x, y: to.y - from.y, z: to.z - from.z };
+    const length = Math.hypot(d.x, d.y, d.z);
+    const lifts: SteppedTraverseResult['lifts'] = [];
+    let liftTotal = 0;
+    let steps = 0;
+    if (length < 1e-9) {
+        return { position: { ...to }, liftTotalMm: 0, lifts, steps, toppedOut: false };
+    }
+    const u = { x: d.x / length, y: d.y / length, z: d.z / length };
+    const ru = params.retreatUnit;
+    const at = (s: number): Xyz => ({
+        x: r3(from.x + u.x * s + ru.x * liftTotal),
+        y: r3(from.y + u.y * s + ru.y * liftTotal),
+        z: r3(from.z + u.z * s + ru.z * liftTotal),
+    });
+    const words = (p: Xyz) => {
+        const w: { x?: number; y?: number; z?: number } = {};
+        if (Math.abs(u.x) > 1e-9 || Math.abs(ru.x) > 1e-9) {
+            w.x = p.x;
+        }
+        if (Math.abs(u.y) > 1e-9 || Math.abs(ru.y) > 1e-9) {
+            w.y = p.y;
+        }
+        if (Math.abs(u.z) > 1e-9 || Math.abs(ru.z) > 1e-9) {
+            w.z = p.z;
+        }
+        return w;
+    };
+    const maxLifts = params.maxLifts ?? 60;
+    let liftingStopped = false;
+    probeFeedService.setExpectedContact(['probe']);
+    try {
+        let s = 0;
+        while (length - s > 1e-9) {
+            const next = Math.min(s + STEPPED_HOP_STEP_MM, length);
+            const p = at(next);
+            const t0 = Date.now();
+            await moveMachineSettled(`${tag}:hop:${name}`, words(p), STEPPED_HOP_FEED);
+            steps += 1;
+            const sensed = await senseAfter('probe', t0, params.sensorDelayMs);
+            if (!sensed.contact) {
+                s = next;
+                continue;
+            }
+            // The surface is closer here: back off one step, wait for the
+            // release, retreat, try the same step again.
+            const back = at(s);
+            const t1 = Date.now();
+            await moveMachineSettled(`${tag}:hop-back:${name}`, words(back), STEPPED_HOP_FEED);
+            const released = await senseReleaseAfter('probe', t1, Math.max(params.sensorDelayMs * 4, 3500));
+            if (released.contact) {
+                throw new ProcedureAbort(`Stepped traverse "${name}": probe still triggered after backing off ${STEPPED_HOP_STEP_MM} mm `
+                    + `at (${back.x}, ${back.y}, ${back.z}).`);
+            }
+            if (liftingStopped) {
+                throw new ProcedureAbort(`Stepped traverse "${name}": contact at (${p.x}, ${p.y}, ${p.z}) with the retreat already at its cap `
+                    + `${params.maxLiftTotalMm} mm - something stands where the approved plan has empty space.`);
+            }
+            if (lifts.length >= maxLifts) {
+                throw new ProcedureAbort(`Stepped traverse "${name}": ${maxLifts} retreats without clearing the surface - stopping.`);
+            }
+            const lift = Math.min(params.liftMm, params.maxLiftTotalMm - liftTotal);
+            if (lift <= 1e-9) {
+                liftingStopped = true;
+                if (params.onMax === 'plain-move') {
+                    probeFeedService.clearExpectedContact();
+                    await moveMachineSettled(`${tag}:hop-top:${name}`, words(at(length)), TRAVEL_FEED);
+                    return { position: at(length), liftTotalMm: r3(liftTotal), lifts, steps, toppedOut: true };
+                }
+                throw new ProcedureAbort(`Stepped traverse "${name}": contact at (${p.x}, ${p.y}, ${p.z}) with no retreat left (cap ${params.maxLiftTotalMm} mm).`);
+            }
+            liftTotal = r3(liftTotal + lift);
+            lifts.push({ x: p.x, y: p.y, z: p.z, liftMm: r3(lift) });
+            const lifted = at(s);
+            announce(`hop-lift-${name}`, `surface closer at (${p.x}, ${p.y}, ${p.z}): retreat ${r3(lift)} mm (total ${liftTotal})`);
+            await moveMachineSettled(`${tag}:hop-lift:${name}`, words(lifted), TRAVEL_FEED);
+            if (liftTotal >= params.maxLiftTotalMm - 1e-9) {
+                if (params.onMax === 'plain-move') {
+                    // At the traverse height nothing can be in the way (law 2).
+                    probeFeedService.clearExpectedContact();
+                    await moveMachineSettled(`${tag}:hop-top:${name}`, words(at(length)), TRAVEL_FEED);
+                    return { position: at(length), liftTotalMm: liftTotal, lifts, steps, toppedOut: true };
+                }
+                liftingStopped = true;
+            }
+        }
+        return { position: at(length), liftTotalMm: liftTotal, lifts, steps, toppedOut: liftingStopped };
+    } finally {
+        probeFeedService.clearExpectedContact();
+    }
+}
+
+/** Convenience for travel over a top: horizontal from -> to at toolhead Z `z`, lifting toward the traverse height on contact. */
+export async function steppedTraverseZ(
+    tag: string,
+    name: string,
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+    z: number,
+    params: { liftMm: number; maxZ: number; sensorDelayMs: number },
+    announce: Announce
+): Promise<{ z: number; lifts: SteppedTraverseResult['lifts']; steps: number; toppedOut: boolean }> {
+    const result = await steppedTraverse(tag, name, { x: from.x, y: from.y, z }, { x: to.x, y: to.y, z }, {
+        retreatUnit: { x: 0, y: 0, z: 1 },
+        liftMm: params.liftMm,
+        maxLiftTotalMm: Math.max(0, r3(params.maxZ - z)),
+        onMax: 'plain-move',
+        sensorDelayMs: params.sensorDelayMs,
+    }, announce);
+    return { z: result.position.z, lifts: result.lifts, steps: result.steps, toppedOut: result.toppedOut };
+}

--- a/src/server/services/mcp/outlineFit.ts
+++ b/src/server/services/mcp/outlineFit.ts
@@ -1,0 +1,169 @@
+// Pure geometry for probe_stock_outline (no server imports): the top height
+// from several samples with hole rejection, and a rectangle fit from side
+// contacts - centre, size, yaw. Every number is a tip-CENTRE machine
+// coordinate unless the tip diameter is supplied.
+
+export type Side = 'west' | 'east' | 'south' | 'north';
+
+export const SIDES: Side[] = ['west', 'east', 'south', 'north'];
+
+/** Unit march direction for each side (toward the stock). */
+export const SIDE_UNIT: { [side in Side]: { x: number; y: number } } = {
+    west: { x: 1, y: 0 },
+    east: { x: -1, y: 0 },
+    south: { x: 0, y: 1 },
+    north: { x: 0, y: -1 },
+};
+
+export interface TopSample {
+    x: number;
+    y: number;
+    z: number | null;
+    label: string;
+}
+
+export interface TopEstimate {
+    /** Highest contact = the top surface (toolhead Z). */
+    z: number | null;
+    /** Samples lower than the top by more than the tolerance (a hole, a pocket, a chamfer). */
+    holes: string[];
+    /** Samples agreeing with the top within the tolerance. */
+    agreeing: string[];
+    missing: string[];
+    spreadMm: number | null;
+}
+
+export function estimateTop(samples: TopSample[], holeToleranceMm: number): TopEstimate {
+    const hits = samples.filter((s): s is TopSample & { z: number } => s.z !== null);
+    if (!hits.length) {
+        return { z: null, holes: [], agreeing: [], missing: samples.map((s) => s.label), spreadMm: null };
+    }
+    const top = Math.max(...hits.map((s) => s.z));
+    const agreeing = hits.filter((s) => top - s.z <= holeToleranceMm + 1e-9);
+    return {
+        z: top,
+        holes: hits.filter((s) => top - s.z > holeToleranceMm + 1e-9).map((s) => s.label),
+        agreeing: agreeing.map((s) => s.label),
+        missing: samples.filter((s) => s.z === null).map((s) => s.label),
+        spreadMm: Number((top - Math.min(...agreeing.map((s) => s.z))).toFixed(3)),
+    };
+}
+
+export interface SideContact {
+    side: Side;
+    label: string;
+    /** Tip-centre machine coordinates of the contact (null = nothing within the travel). */
+    x: number | null;
+    y: number | null;
+    z: number;
+}
+
+export interface SideFit {
+    side: Side;
+    contacts: number;
+    /** Mean of the side's constant coordinate (x for west/east, y for south/north), tip centre. */
+    mean: number | null;
+    /** Slope of that coordinate along the side (mm per 100 mm), from >= 2 contacts. */
+    slopePer100Mm: number | null;
+}
+
+export interface OutlineFit {
+    sides: SideFit[];
+    /** Tip-centre rectangle: centre and centre-to-centre size of the stylus-centre contacts. */
+    centerMachine: { x: number | null; y: number | null };
+    sizeMm: { x: number | null; y: number | null };
+    /**
+     * Physical size = centre-to-centre size MINUS the tip diameter: on opposite
+     * EXTERNAL faces each stylus centre stops one tip radius outside its face
+     * (on-box agent's correction 2026-09-06; the earlier "+ tip" was wrong).
+     * The centre is unaffected. null without a stored tip diameter.
+     */
+    sizePhysicalMm: { x: number | null; y: number | null };
+    /** Yaw about Z in degrees (+ = the +Y end of the stock is displaced toward +X), mean of the side slopes. */
+    yawDeg: number | null;
+    note: string;
+}
+
+function round3(v: number): number {
+    return Number(v.toFixed(3));
+}
+
+function slopePer100(points: { s: number; v: number }[]): number | null {
+    if (points.length < 2) {
+        return null;
+    }
+    const n = points.length;
+    const ms = points.reduce((a, p) => a + p.s, 0) / n;
+    const mv = points.reduce((a, p) => a + p.v, 0) / n;
+    let num = 0;
+    let den = 0;
+    for (const p of points) {
+        num += (p.s - ms) * (p.v - mv);
+        den += (p.s - ms) * (p.s - ms);
+    }
+    return den < 1e-12 ? null : round3((num / den) * 100);
+}
+
+export function fitOutline(contacts: SideContact[], tipDiameterMm: number | null): OutlineFit {
+    const sides: SideFit[] = SIDES.map((side) => {
+        const hits = contacts.filter((c) => c.side === side && c.x !== null && c.y !== null) as (SideContact & { x: number; y: number })[];
+        if (!hits.length) {
+            return { side, contacts: 0, mean: null, slopePer100Mm: null };
+        }
+        const alongY = side === 'west' || side === 'east';
+        const values = hits.map((h) => (alongY ? h.x : h.y));
+        const mean = round3(values.reduce((a, v) => a + v, 0) / values.length);
+        // Slope of the side: x vs y for west/east, y vs x for south/north.
+        const slope = slopePer100(hits.map((h) => (alongY ? { s: h.y, v: h.x } : { s: h.x, v: h.y })));
+        return { side, contacts: hits.length, mean, slopePer100Mm: slope };
+    });
+    const by = (side: Side) => sides.find((s) => s.side === side) as SideFit;
+    const west = by('west').mean;
+    const east = by('east').mean;
+    const south = by('south').mean;
+    const north = by('north').mean;
+    const cx = west !== null && east !== null ? round3((west + east) / 2) : null;
+    const cy = south !== null && north !== null ? round3((south + north) / 2) : null;
+    const sx = west !== null && east !== null ? round3(east - west) : null;
+    const sy = south !== null && north !== null ? round3(north - south) : null;
+    // Yaw: west/east slopes are dx/dy (positive = the +Y end sits toward +X);
+    // south/north slopes are dy/dx, whose sign convention is the opposite for
+    // the same rotation, so they enter negated.
+    const yawSamples: number[] = [];
+    for (const s of sides) {
+        if (s.slopePer100Mm === null) {
+            continue;
+        }
+        yawSamples.push(s.side === 'west' || s.side === 'east' ? s.slopePer100Mm : -s.slopePer100Mm);
+    }
+    const yawDeg = yawSamples.length
+        ? Number((Math.atan((yawSamples.reduce((a, v) => a + v, 0) / yawSamples.length) / 100) * 180 / Math.PI).toFixed(3))
+        : null;
+    const parts: string[] = [];
+    if (cx !== null && cy !== null) {
+        parts.push(`centre (${cx}, ${cy}) machine`);
+    } else if (cx !== null) {
+        parts.push(`centre X ${cx} (Y needs both south and north)`);
+    } else if (cy !== null) {
+        parts.push(`centre Y ${cy} (X needs both west and east)`);
+    }
+    if (sx !== null || sy !== null) {
+        parts.push(`size ${sx ?? '?'} x ${sy ?? '?'} mm centre-to-centre${tipDiameterMm !== null
+            ? ` = ${sx === null ? '?' : round3(sx - tipDiameterMm)} x ${sy === null ? '?' : round3(sy - tipDiameterMm)} physical (minus the ${tipDiameterMm} mm tip)`
+            : ' (physical = minus the tip diameter)'}`);
+    }
+    if (yawDeg !== null) {
+        parts.push(`yaw ${yawDeg} deg`);
+    }
+    return {
+        sides,
+        centerMachine: { x: cx, y: cy },
+        sizeMm: { x: sx, y: sy },
+        sizePhysicalMm: {
+            x: sx === null || tipDiameterMm === null ? null : round3(sx - tipDiameterMm),
+            y: sy === null || tipDiameterMm === null ? null : round3(sy - tipDiameterMm),
+        },
+        yawDeg,
+        note: parts.length ? `Outline: ${parts.join('; ')}. Tip-centre coordinates; each true face lies one tip radius INSIDE its contact (toward the stock).` : 'Outline: no side contacts.',
+    };
+}

--- a/src/server/services/mcp/probeOutline.ts
+++ b/src/server/services/mcp/probeOutline.ts
@@ -1,0 +1,603 @@
+/* eslint-disable camelcase */
+// MCP tool arguments are snake_case by convention.
+import { MotionSegment, ObstacleBox, checkMotion, describeViolations } from './envelopeChecks';
+import { landmarkStore } from './landmarks';
+import {
+    MarchParams,
+    Xyz,
+    makeAnnounce,
+    marchToContact,
+    pointAlong,
+    retreatAlong,
+    steppedTraverse,
+    steppedTraverseZ,
+} from './march';
+import {
+    SIDES,
+    SIDE_UNIT,
+    Side,
+    SideContact,
+    TopSample,
+    estimateTop,
+    fitOutline,
+} from './outlineFit';
+import { probeFeedService } from './probeFeed';
+import { DESCENT_GUARD_MM } from './probeSequence';
+import {
+    COARSE_FEED,
+    DESCENT_SEGMENT_MM,
+    ProcedureAbort,
+    ProcedureStopped,
+    RECHECK_TOLERANCE_MM,
+    TRAVEL_FEED,
+    assertChannelReady,
+    assertMachineReadyForProcedure,
+    descendInSegments,
+    expectMachinePosition,
+    knownMachinePosition,
+    moveMachineSettled,
+    senseAfter,
+} from './probing';
+import { McpToolError } from './registry';
+import { probeGeometry } from './rotaryGeometry';
+import { getMachineSizeByIdentifier, getPositionSnapshot, safeTraverseZ } from './tools/machine';
+import { connectionManager } from '../machine/ConnectionManager';
+
+// probe_stock_outline (operator request 2026-09-06): find a block's top and
+// its true outline - and so its centre - from an ESTIMATE of where it is and
+// how big it is, in one approved procedure, without re-probing the centre
+// for every side:
+//
+//   1. TOP: -Z marches at a few points around the estimated centre (default
+//      three along the longer axis). The top is the HIGHEST contact; a sample
+//      lower by more than hole_tolerance_mm is a hole / pocket and is
+//      ignored (the first probe landing in a drilled hole must not define
+//      the surface). Between the points the probe travels close above the
+//      surface as a STEPPED TRAVERSE (march.ts): a contact means the surface
+//      is higher there - back off, lift, continue.
+//   2. SIDES: for each requested side, horizontal marches toward the stock
+//      from OUTSIDE the estimate (over-extended by overextend_mm) at
+//      top - side_depth_mm, at points_per_side positions along the side
+//      (midpoint first, then away from the corners). The travel is
+//      side_max_travel_mm (default 25): the on-box agent's first outline lost
+//      a whole side to an 11 mm march when the estimate's centre was 3.85 mm
+//      off and its width a few mm out - a short march silently turns ordinary
+//      estimate error into a missed face, a generous one only costs time.
+//      A march that reaches its travel limit records no_contact and the
+//      procedure continues. Between points on one side
+//      the probe SKIPS ALONG THE FACE: it backs off the last contact by
+//      side_standoff_mm and travels at that standoff as a stepped traverse
+//      whose retreat is AWAY from the face (a projection bumps it outward,
+//      capped at the approved start line); the next march starts from where
+//      it arrives (a dynamic start off the previous contact, never a fresh
+//      approach from the outside line). Between sides it goes over the top
+//      at the traverse height (law 2).
+//   3. FIT: per side the mean coordinate and slope; centre, size (plus the
+//      tip diameter when known), yaw. Reported in machine AND work frames.
+//
+// Laws: every move is enumerated on the confirm page; no clearance is
+// invented (start_z_machine and floor_z_machine are the operator's; side
+// depth hangs off the MEASURED top); the crash guard stays armed for every
+// move that expects no contact; descents are segmented; coarse <= 1 mm.
+
+export interface OutlineTopPoint {
+    label: string;
+    x: number;
+    y: number;
+}
+
+export interface OutlineSidePoint {
+    side: Side;
+    label: string;
+    /** March start (outside the estimate), machine XY; Z = top - side_depth at run time. */
+    start: { x: number; y: number };
+    unit: { x: number; y: number };
+    travelMm: number;
+}
+
+export interface ProbeOutlinePlan {
+    tool: 'probe_stock_outline';
+    center: { x: number; y: number };
+    size: { x: number; y: number };
+    overextendMm: number;
+    startZMachine: number;
+    floorZMachine: number;
+    topPoints: OutlineTopPoint[];
+    holeToleranceMm: number;
+    sideDepthMm: number;
+    sides: Side[];
+    sidePoints: OutlineSidePoint[];
+    hopLiftMm: number;
+    /** Along a side: back off the last contact by this and travel at that standoff to the next point. */
+    sideStandoffMm: number;
+    march: MarchParams;
+    hopZ: number;
+    staged: Xyz;
+    tipDiameterMm: number | null;
+}
+
+interface OutlineArgs {
+    center_x?: unknown;
+    center_y?: unknown;
+    size_x_mm?: unknown;
+    size_y_mm?: unknown;
+    overextend_mm?: unknown;
+    start_z_machine?: unknown;
+    floor_z_machine?: unknown;
+    top_points?: unknown;
+    hole_tolerance_mm?: unknown;
+    side_depth_mm?: unknown;
+    points_per_side?: unknown;
+    sides?: unknown;
+    hop_lift_mm?: unknown;
+    side_standoff_mm?: unknown;
+    side_max_travel_mm?: unknown;
+    coarse_step_mm?: unknown;
+    fine_step_mm?: unknown;
+    backoff_mm?: unknown;
+    sensor_delay_ms?: unknown;
+    confirm_passes?: unknown;
+}
+
+function num(value: unknown, name: string, min: number, max: number, fallback?: number): number {
+    if (value === undefined || value === null || value === '') {
+        if (fallback === undefined) {
+            throw new McpToolError(`${name} is required.`);
+        }
+        return fallback;
+    }
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < min || n > max) {
+        throw new McpToolError(`${name} must be a number in ${min}..${max} (got ${JSON.stringify(value)}).`);
+    }
+    return n;
+}
+
+const round3 = (v: number) => Number(v.toFixed(3));
+
+const SIDE_ARROW: { [side in Side]: string } = { west: '+X', east: '-X', south: '+Y', north: '-Y' };
+
+/**
+ * Offsets along a side for n points over the middle half of the side (corners
+ * are where estimates go wrong), MIDPOINT FIRST so the first contact of a side
+ * is the most likely one, then outward alternating.
+ */
+function offsetsFor(n: number, length: number): number[] {
+    if (n === 1) {
+        return [0];
+    }
+    const span = length / 2;
+    const evenly = Array.from({ length: n }, (_, i) => round3(-span / 2 + (span * i) / (n - 1)));
+    return [...evenly].sort((a, b) => Math.abs(a) - Math.abs(b) || a - b);
+}
+
+/** Conservative motion list: side depth at its lowest possible value (floor - side_depth). */
+export function outlineMotion(plan: ProbeOutlinePlan): MotionSegment[] {
+    const out: MotionSegment[] = [];
+    const first = plan.topPoints[0];
+    out.push({ kind: 'column', what: `top point "${first.label}" descent`, from: { ...first, z: plan.hopZ }, to: { ...first, z: plan.floorZMachine } });
+    for (let i = 1; i < plan.topPoints.length; i++) {
+        const a = plan.topPoints[i - 1];
+        const b = plan.topPoints[i];
+        out.push({ kind: 'march', what: `stepped traverse ${a.label} -> ${b.label}`, from: { ...a, z: plan.floorZMachine }, to: { ...b, z: plan.floorZMachine } });
+        out.push({ kind: 'march', what: `top point "${b.label}" march`, from: { ...b, z: plan.startZMachine }, to: { ...b, z: plan.floorZMachine } });
+    }
+    const lowSide = round3(plan.floorZMachine - plan.sideDepthMm);
+    let previous: OutlineSidePoint | null = null;
+    for (const p of plan.sidePoints) {
+        if (previous && previous.side === p.side) {
+            out.push({ kind: 'march', what: `stepped traverse ${previous.label} -> ${p.label}`, from: { ...previous.start, z: lowSide }, to: { ...p.start, z: lowSide } });
+        } else {
+            out.push({ kind: 'column', what: `side start "${p.label}" descent`, from: { ...p.start, z: plan.hopZ }, to: { ...p.start, z: lowSide } });
+        }
+        out.push({
+            kind: 'march',
+            what: `side march "${p.label}"`,
+            from: { ...p.start, z: lowSide },
+            to: { x: round3(p.start.x + p.unit.x * p.travelMm), y: round3(p.start.y + p.unit.y * p.travelMm), z: lowSide },
+        });
+        previous = p;
+    }
+    return out;
+}
+
+export function planProbeOutline(args: OutlineArgs, extraObstacles: ObstacleBox[] = []): ProbeOutlinePlan {
+    const snapshot = getPositionSnapshot();
+    const { x, y, z } = snapshot.machine;
+    if (x === null || y === null || z === null) {
+        throw new McpToolError('Current machine position unknown; cannot anchor the outline procedure.');
+    }
+    const hopZ = safeTraverseZ();
+    const cx = num(args.center_x, 'center_x', -50, 500, x);
+    const cy = num(args.center_y, 'center_y', -50, 500, y);
+    const sx = num(args.size_x_mm, 'size_x_mm (estimated stock size along machine X)', 2, 400);
+    const sy = num(args.size_y_mm, 'size_y_mm (estimated stock size along machine Y)', 2, 400);
+    const overextend = num(args.overextend_mm, 'overextend_mm', 3, 60, 5);
+    const startZ = num(args.start_z_machine, 'start_z_machine (toolhead Z above the top where the -Z search starts - operator-stated, never a guess)', 1, hopZ);
+    const floorZ = num(args.floor_z_machine, 'floor_z_machine (deepest toolhead Z the top search may reach)', 0, hopZ);
+    if (floorZ >= startZ) {
+        throw new McpToolError(`floor_z_machine ${floorZ} must be below start_z_machine ${startZ}.`);
+    }
+    if (startZ - floorZ > 150) {
+        throw new McpToolError('start_z_machine - floor_z_machine exceeds 150 mm.');
+    }
+    const topCount = Math.round(num(args.top_points, 'top_points', 1, 5, 3));
+    const holeTol = num(args.hole_tolerance_mm, 'hole_tolerance_mm', 0.2, 50, 2);
+    const sideDepth = num(args.side_depth_mm, 'side_depth_mm', 1, 40, 2);
+    const perSide = Math.round(num(args.points_per_side, 'points_per_side', 1, 4, 3));
+    const hopLift = num(args.hop_lift_mm, 'hop_lift_mm', 0.5, 10, 2);
+    const sideStandoff = num(args.side_standoff_mm, 'side_standoff_mm', 1, 20, 3);
+    let sides: Side[] = SIDES;
+    if (args.sides !== undefined) {
+        if (!Array.isArray(args.sides) || !args.sides.length || args.sides.some((s) => !SIDES.includes(String(s) as Side))) {
+            throw new McpToolError(`sides must list one or more of ${SIDES.join(', ')}.`);
+        }
+        sides = Array.from(new Set(args.sides.map((s) => String(s) as Side)));
+    }
+
+    // Top points: centre, then +/- a quarter of the LONGER estimated axis,
+    // then the shorter axis for 4-5 points.
+    const longX = sx >= sy;
+    const q = (longX ? sx : sy) / 4;
+    const q2 = (longX ? sy : sx) / 4;
+    const topOffsets: { dx: number; dy: number }[] = [
+        { dx: 0, dy: 0 },
+        longX ? { dx: q, dy: 0 } : { dx: 0, dy: q },
+        longX ? { dx: -q, dy: 0 } : { dx: 0, dy: -q },
+        longX ? { dx: 0, dy: q2 } : { dx: q2, dy: 0 },
+        longX ? { dx: 0, dy: -q2 } : { dx: -q2, dy: 0 },
+    ];
+    const topPoints: OutlineTopPoint[] = topOffsets.slice(0, topCount).map((o, i) => ({
+        label: i === 0 ? 'top_centre' : `top_${i}`,
+        x: round3(cx + o.dx),
+        y: round3(cy + o.dy),
+    }));
+
+    // Side points: start outside the estimate by overextend_mm and march
+    // side_max_travel_mm - generous by default (25) so the combined error of
+    // the centre and the width estimate cannot hide a face; never less than
+    // what reaches the estimate itself plus 10 mm.
+    const travel = Math.min(150, num(args.side_max_travel_mm, 'side_max_travel_mm', 5, 150, Math.max(25, round3(2 * overextend + 10))));
+    if (travel < overextend + 5) {
+        throw new McpToolError(`side_max_travel_mm ${travel} does not even reach the estimated face (overextend ${overextend} mm + 5): raise it.`);
+    }
+    const sidePoints: OutlineSidePoint[] = [];
+    for (const side of sides) {
+        const along = side === 'west' || side === 'east' ? sy : sx;
+        offsetsFor(perSide, along).forEach((off, j) => {
+            const label = `${side}_${j + 1}`;
+            let start: { x: number; y: number };
+            if (side === 'west') {
+                start = { x: round3(cx - sx / 2 - overextend), y: round3(cy + off) };
+            } else if (side === 'east') {
+                start = { x: round3(cx + sx / 2 + overextend), y: round3(cy + off) };
+            } else if (side === 'south') {
+                start = { x: round3(cx + off), y: round3(cy - sy / 2 - overextend) };
+            } else {
+                start = { x: round3(cx + off), y: round3(cy + sy / 2 + overextend) };
+            }
+            sidePoints.push({ side, label, start, unit: SIDE_UNIT[side], travelMm: travel });
+        });
+    }
+
+    const size = getMachineSizeByIdentifier(connectionManager.getConnectionStatus().machineIdentifier);
+    if (size) {
+        const limits = sidePoints.map((p) => ({ x: p.start.x + p.unit.x * p.travelMm, y: p.start.y + p.unit.y * p.travelMm }));
+        const points = [...topPoints, ...sidePoints.map((p) => p.start), ...limits];
+        for (const p of points) {
+            if (p.x < -25 || p.x > size.x + 40 || p.y < -25 || p.y > size.y + 40) {
+                throw new McpToolError(`Point (${round3(p.x)}, ${round3(p.y)}) is outside the machine envelope - shrink the estimate or overextend_mm.`);
+            }
+        }
+    }
+
+    const geometry = probeGeometry();
+    const plan: ProbeOutlinePlan = {
+        tool: 'probe_stock_outline',
+        center: { x: cx, y: cy },
+        size: { x: sx, y: sy },
+        overextendMm: overextend,
+        startZMachine: round3(startZ),
+        floorZMachine: round3(floorZ),
+        topPoints,
+        holeToleranceMm: holeTol,
+        sideDepthMm: sideDepth,
+        sides,
+        sidePoints,
+        hopLiftMm: hopLift,
+        sideStandoffMm: sideStandoff,
+        march: {
+            coarseStepMm: Math.min(Math.max(Number(args.coarse_step_mm) || 1, 0.2), 1), // operator law: never 2 mm
+            fineStepMm: Math.min(Math.max(Number(args.fine_step_mm) || 0.1, 0.02), 0.5),
+            backoffMm: Math.min(Math.max(Number(args.backoff_mm) || 1, Number(args.fine_step_mm) || 0.1), 3),
+            sensorDelayMs: Math.min(Math.max(Number(args.sensor_delay_ms) || 300, 30), 10000),
+            confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 3), 1), 10),
+        },
+        hopZ,
+        staged: { x, y, z },
+        tipDiameterMm: geometry ? geometry.tipDiameter : null,
+    };
+
+    // Law 4: keep-out. Side marches enter the stock's region deliberately
+    // (kind 'march' - exempt from crossing landmarks, checked against volumes).
+    const violations = checkMotion(outlineMotion(plan), [...landmarkStore.obstacleBoxes(), ...extraObstacles], { traverseZ: hopZ });
+    if (violations.length) {
+        throw new McpToolError(`Outline refused (law 4, landmarks are obstacles): ${describeViolations(violations)}. `
+            + 'Move the estimate, shrink overextend_mm / side points, or have the operator adjust the landmark.');
+    }
+    return plan;
+}
+
+export function describeProbeOutlinePlanAsGcode(plan: ProbeOutlinePlan): string {
+    const lines = [
+        `; STOCK OUTLINE: estimated centre (${plan.center.x}, ${plan.center.y}), estimated size ${plan.size.x} x ${plan.size.y} mm, over-extended by ${plan.overextendMm} mm`,
+        `; 1) TOP at ${plan.topPoints.length} point(s): -Z marches from start_z_machine Z${plan.startZMachine} to the floor Z${plan.floorZMachine}; the HIGHEST contact is the top,`,
+        `;    a sample lower by more than ${plan.holeToleranceMm} mm is a hole and is ignored. Between points: STEPPED TRAVERSE at last contact + ${plan.hopLiftMm} mm`,
+        `;    (1 mm steps, F300, probe expected: a contact backs off 1 mm, lifts ${plan.hopLiftMm} mm and continues; never above Z${plan.hopZ}).`,
+        `; 2) SIDES ${plan.sides.join(', ')}: horizontal marches toward the stock from ${plan.overextendMm} mm outside the estimate at top - ${plan.sideDepthMm} mm,`,
+        `;    up to ${plan.sidePoints[0] ? plan.sidePoints[0].travelMm : 0} mm each; a march that finds nothing records no_contact and the procedure continues.`,
+        `;    Between points on one side: back off the last contact by ${plan.sideStandoffMm} mm and skip along the face at that standoff as a`,
+        `;    stepped traverse (1 mm steps, probe expected; a bump retreats ${plan.hopLiftMm} mm AWAY from the face, capped at the start line);`,
+        `;    the next march starts from the arrival point. Between sides: over the top at Z${plan.hopZ} (law 2).`,
+        `; 3) FIT: side means + slopes -> centre, size${plan.tipDiameterMm === null ? '' : ` (physical = minus the ${plan.tipDiameterMm} mm tip)`}, yaw; machine and work frames.`,
+        `; march: coarse ${plan.march.coarseStepMm} mm F${COARSE_FEED}, fine ${plan.march.fineStepMm}, backoff ${plan.march.backoffMm}, ${plan.march.confirmPasses} confirm pass(es), sensor ${plan.march.sensorDelayMs} ms`,
+        `; anchored at machine (${plan.staged.x.toFixed(2)}, ${plan.staged.y.toFixed(2)}, ${plan.staged.z.toFixed(2)}) - re-verified before motion`,
+        'G90',
+        `G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; raise to the safe traverse height (law 2)`,
+    ];
+    const first = plan.topPoints[0];
+    lines.push(`G1 X${first.x.toFixed(3)} Y${first.y.toFixed(3)} F${TRAVEL_FEED}; traverse to "${first.label}"`);
+    lines.push(`G1 Z${Math.min(plan.startZMachine + DESCENT_GUARD_MM, plan.hopZ).toFixed(3)} F${TRAVEL_FEED}; descend in <= ${DESCENT_SEGMENT_MM} mm segments (crash guard armed)`);
+    lines.push(`; ...guarded 1 mm steps to Z${plan.startZMachine} (ANY contact aborts: the surface is above start_z_machine)`);
+    plan.topPoints.forEach((tp, i) => {
+        if (i > 0) {
+            lines.push(`; stepped traverse to "${tp.label}" (${tp.x}, ${tp.y}) at last contact + ${plan.hopLiftMm} mm`);
+        }
+        lines.push(`; --- "${tp.label}" (${tp.x}, ${tp.y}): march -Z in ${plan.march.coarseStepMm} mm steps, floor Z${plan.floorZMachine} ---`);
+        lines.push(`G1 Z${plan.floorZMachine.toFixed(3)} F${COARSE_FEED}; deepest allowed - no contact by here = no_contact at this point`);
+        lines.push(`; ...on contact: release, ${plan.march.fineStepMm} mm fine, ${plan.march.confirmPasses} confirm cycle(s)`);
+    });
+    let previous: OutlineSidePoint | null = null;
+    for (const p of plan.sidePoints) {
+        const limit = { x: round3(p.start.x + p.unit.x * p.travelMm), y: round3(p.start.y + p.unit.y * p.travelMm) };
+        if (!previous || previous.side !== p.side) {
+            lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; raise to the traverse height`);
+            lines.push(`G1 X${p.start.x.toFixed(3)} Y${p.start.y.toFixed(3)} F${TRAVEL_FEED}; traverse to side start "${p.label}"`);
+            lines.push(`; descend in <= ${DESCENT_SEGMENT_MM} mm segments, then guarded 1 mm steps, to Z = top - ${plan.sideDepthMm} (runtime; ANY contact here = the stock is larger than estimate + overextend: ABORT)`);
+        } else {
+            lines.push(`; skip along the face ${previous.label} -> "${p.label}" at ${plan.sideStandoffMm} mm off the last contact (stepped traverse, retreat away from the face), then march on from there`);
+        }
+        lines.push(`; --- "${p.label}": march ${SIDE_ARROW[p.side]} from (${p.start.x}, ${p.start.y}) up to (${limit.x}, ${limit.y}) ---`);
+        lines.push(`G1 X${limit.x.toFixed(3)} Y${limit.y.toFixed(3)} F${COARSE_FEED}; travel limit - no contact by here = no_contact for this side point`);
+        lines.push(`G1 X${p.start.x.toFixed(3)} Y${p.start.y.toFixed(3)} F${TRAVEL_FEED}; retreat to the march start`);
+        previous = p;
+    }
+    lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; finish at the safe traverse height (also on any abort)`);
+    return lines.join('\n');
+}
+
+export interface OutlineResult {
+    tool: 'probe_stock_outline';
+    top: ReturnType<typeof estimateTop>;
+    topSamples: (TopSample & { spreadMm?: number })[];
+    sides: SideContact[];
+    fit: ReturnType<typeof fitOutline>;
+    centerMachine: { x: number | null; y: number | null };
+    centerWork: { x: number | null; y: number | null } | null;
+    sizeMm: { x: number | null; y: number | null };
+    sizePhysicalMm: { x: number | null; y: number | null };
+    yawDeg: number | null;
+    lifts: { during: string; x: number; y: number; fromZ: number; toZ: number }[];
+    phases: { phase: string; note?: string }[];
+    note: string;
+    aborted?: boolean;
+}
+
+export async function runProbeOutlineProcedure(plan: ProbeOutlinePlan): Promise<OutlineResult> {
+    assertMachineReadyForProcedure();
+    assertChannelReady('probe', 'stock outline');
+    const phases: { phase: string; note?: string }[] = [];
+    const announce = makeAnnounce(plan.tool, phases);
+    const tag = 'outline';
+    const topSamples: OutlineResult['topSamples'] = [];
+    const contacts: SideContact[] = [];
+    const lifts: OutlineResult['lifts'] = [];
+
+    const build = (aborted: boolean): OutlineResult => {
+        const top = estimateTop(topSamples, plan.holeToleranceMm);
+        const fit = fitOutline(contacts, plan.tipDiameterMm);
+        const offset = getPositionSnapshot().originOffset;
+        const centerWork = fit.centerMachine.x !== null && fit.centerMachine.y !== null
+            ? { x: round3(fit.centerMachine.x + offset.x), y: round3(fit.centerMachine.y + offset.y) }
+            : null;
+        return {
+            tool: plan.tool,
+            top,
+            topSamples,
+            sides: contacts,
+            fit,
+            centerMachine: fit.centerMachine,
+            centerWork,
+            sizeMm: fit.sizeMm,
+            sizePhysicalMm: fit.sizePhysicalMm,
+            yawDeg: fit.yawDeg,
+            lifts,
+            phases,
+            note: `${aborted ? 'ABORTED. ' : ''}Top ${top.z === null ? 'not found' : `Z${top.z} (toolhead; ${top.agreeing.length} agreeing sample(s)`
+                + `${top.holes.length ? `, holes: ${top.holes.join(', ')}` : ''})`}. ${fit.note}`
+                + `${centerWork ? ` Work-frame centre (${centerWork.x}, ${centerWork.y}) with the current origin offset.` : ''}`,
+            aborted: aborted || undefined,
+        };
+    };
+
+    const guardedDescent = async (label: string, toZ: number, what: string) => {
+        const known = knownMachinePosition();
+        const zNow = known.position.z;
+        if (zNow === null) {
+            throw new ProcedureAbort(`Machine Z unknown before the descent at "${label}" - refusing to guess.`);
+        }
+        if (zNow < toZ - RECHECK_TOLERANCE_MM) {
+            throw new ProcedureAbort(`"${label}": the toolhead is at Z${zNow} (${known.source}), BELOW the descent target Z${toZ} - a descent never rises.`);
+        }
+        const guardTop = toZ + DESCENT_GUARD_MM;
+        probeFeedService.clearExpectedContact();
+        if (zNow > guardTop + 1e-9) {
+            await descendInSegments(`${tag}:descend:${label}`, zNow, guardTop, 'probe', plan.march.sensorDelayMs);
+        }
+        let gz = Math.min(Math.max(zNow, toZ), guardTop);
+        while (gz - toZ > 1e-9) {
+            const t0 = Date.now();
+            gz = Math.max(gz - 1, toZ);
+            await moveMachineSettled(`${tag}:descend-guard:${label}`, { z: gz }, COARSE_FEED);
+            const sensed = await senseAfter('probe', t0, plan.march.sensorDelayMs);
+            if (sensed.contact) {
+                throw new ProcedureAbort(`UNEXPECTED CONTACT at Z${gz.toFixed(3)} during the guarded descent at "${label}": ${what} Machine held.`);
+            }
+        }
+    };
+
+    try {
+        await expectMachinePosition(plan.staged, 'staged position', (message) => new McpToolError(
+            `The machine is not at the position this outline was staged from. ${message} Stage probe_stock_outline again.`
+        ));
+        probeFeedService.clearExpectedContact();
+        await moveMachineSettled(`${tag}:raise`, { z: plan.hopZ }, TRAVEL_FEED);
+
+        // ---- 1. top
+        const first = plan.topPoints[0];
+        await moveMachineSettled(`${tag}:traverse`, { x: first.x, y: first.y }, TRAVEL_FEED);
+        announce('traverse', `(${first.x}, ${first.y}) at Z${plan.hopZ}`);
+        await guardedDescent(first.label, plan.startZMachine, 'the surface is above start_z_machine.');
+        let currentZ = plan.startZMachine;
+        let lastContactZ: number | null = null;
+        for (let i = 0; i < plan.topPoints.length; i++) {
+            const tp = plan.topPoints[i];
+            if (i > 0) {
+                const prev = plan.topPoints[i - 1];
+                const hopZ = Math.min(round3((lastContactZ === null ? plan.startZMachine : lastContactZ) + plan.hopLiftMm), plan.hopZ);
+                if (hopZ > currentZ + 1e-9) {
+                    probeFeedService.clearExpectedContact();
+                    await moveMachineSettled(`${tag}:lift:${tp.label}`, { z: hopZ }, TRAVEL_FEED);
+                }
+                const traverse = await steppedTraverseZ(tag, tp.label, prev, tp, hopZ, {
+                    liftMm: plan.hopLiftMm, maxZ: plan.hopZ, sensorDelayMs: plan.march.sensorDelayMs,
+                }, announce);
+                for (const l of traverse.lifts) {
+                    lifts.push({ during: `${prev.label} -> ${tp.label}`, x: l.x, y: l.y, fromZ: round3(l.z), toZ: round3(l.z + l.liftMm) });
+                }
+                currentZ = traverse.z;
+                await expectMachinePosition({ x: tp.x, y: tp.y, z: currentZ }, `top point "${tp.label}"`, (m) => new ProcedureAbort(m));
+            }
+            probeFeedService.setExpectedContact(['probe']);
+            const travel = round3(currentZ - plan.floorZMachine);
+            const contact = travel > plan.march.fineStepMm
+                ? await marchToContact(tag, tp.label, { x: tp.x, y: tp.y, z: currentZ }, { x: 0, y: 0, z: -1 }, travel, plan.march, announce)
+                : null;
+            if (contact) {
+                topSamples.push({ label: tp.label, x: tp.x, y: tp.y, z: contact.point.z, spreadMm: contact.spreadMm });
+                lastContactZ = contact.point.z;
+                currentZ = contact.point.z;
+            } else {
+                topSamples.push({ label: tp.label, x: tp.x, y: tp.y, z: null });
+                currentZ = plan.floorZMachine;
+                announce(`no-contact-${tp.label}`, `nothing down to the floor Z${plan.floorZMachine} (a hole, or the surface is below the floor)`);
+            }
+            probeFeedService.clearExpectedContact();
+        }
+        const top = estimateTop(topSamples, plan.holeToleranceMm);
+        if (top.z === null) {
+            throw new ProcedureAbort(`No top surface found at any of the ${plan.topPoints.length} point(s) between Z${plan.startZMachine} and the floor Z${plan.floorZMachine}.`);
+        }
+        announce('top', `Z${top.z} from ${top.agreeing.join(', ')}${top.holes.length ? `; holes ${top.holes.join(', ')}` : ''}${top.missing.length ? `; no contact at ${top.missing.join(', ')}` : ''}`);
+
+        // ---- 2. sides
+        const sideZ = round3(top.z - plan.sideDepthMm);
+        let previous: OutlineSidePoint | null = null;
+        // Distance from the previous point's start line at which the probe
+        // rests after its march (contact - standoff, or 0 after a miss).
+        let restS = 0;
+        for (const p of plan.sidePoints) {
+            const line: Xyz = { x: p.start.x, y: p.start.y, z: sideZ };
+            const unit: Xyz = { x: p.unit.x, y: p.unit.y, z: 0 };
+            let startS = 0;
+            if (!previous || previous.side !== p.side) {
+                probeFeedService.clearExpectedContact();
+                await moveMachineSettled(`${tag}:raise:${p.label}`, { z: plan.hopZ }, TRAVEL_FEED);
+                await moveMachineSettled(`${tag}:traverse:${p.label}`, { x: p.start.x, y: p.start.y }, TRAVEL_FEED);
+                announce(`traverse-${p.label}`, `(${p.start.x}, ${p.start.y}) at Z${plan.hopZ}`);
+                await guardedDescent(p.label, sideZ, `the stock (or a fixture) is under the side start - larger than the estimate + ${plan.overextendMm} mm. Raise overextend_mm.`);
+                currentZ = sideZ;
+            } else {
+                // Skip along the face from the previous rest point (restS off
+                // the start line) to the same offset on this point's line, as
+                // a stepped traverse whose retreat is AWAY from the face and
+                // capped at the start line (restS). The march then starts
+                // from wherever that arrives.
+                const prevLine: Xyz = { x: previous.start.x, y: previous.start.y, z: sideZ };
+                const fromPoint = pointAlong(prevLine, unit, restS);
+                const toPoint = pointAlong(line, unit, restS);
+                const traverse = await steppedTraverse(tag, p.label, fromPoint, toPoint, {
+                    retreatUnit: { x: -unit.x, y: -unit.y, z: 0 },
+                    liftMm: plan.hopLiftMm,
+                    maxLiftTotalMm: restS,
+                    onMax: 'stop-lifting',
+                    sensorDelayMs: plan.march.sensorDelayMs,
+                }, announce);
+                for (const l of traverse.lifts) {
+                    lifts.push({ during: `${previous.label} -> ${p.label}`, x: l.x, y: l.y, fromZ: sideZ, toZ: sideZ });
+                }
+                startS = round3(restS - traverse.liftTotalMm);
+                announce(`skip-${p.label}`, `along the face from ${previous.label}: ${traverse.lifts.length} bump(s), march starts ${startS} mm in from the start line`);
+            }
+            const startPoint = pointAlong(line, unit, startS);
+            await expectMachinePosition(startPoint, `side start "${p.label}"`, (m) => new ProcedureAbort(m));
+            probeFeedService.setExpectedContact(['probe']);
+            const travel = round3(p.travelMm - startS);
+            const contact = travel > plan.march.fineStepMm
+                ? await marchToContact(tag, p.label, startPoint, unit, travel, plan.march, announce)
+                : null;
+            if (contact) {
+                contacts.push({ side: p.side, label: p.label, x: contact.point.x, y: contact.point.y, z: sideZ });
+                restS = Math.max(0, round3(startS + contact.s - plan.sideStandoffMm));
+            } else {
+                contacts.push({ side: p.side, label: p.label, x: null, y: null, z: sideZ });
+                announce(`no-contact-${p.label}`, `nothing within ${travel} mm of the start point - the face is not where the estimate says on this side`);
+                restS = 0;
+            }
+            // Back off the face (or all the way to the start line after a
+            // miss) - the probe may still be in contact, so keep it expected.
+            await retreatAlong(tag, p.label, line, unit, restS);
+            probeFeedService.clearExpectedContact();
+            previous = p;
+        }
+
+        probeFeedService.clearExpectedContact();
+        await moveMachineSettled(`${tag}:final-raise`, { z: plan.hopZ }, TRAVEL_FEED);
+        const result = build(false);
+        announce('outline-complete', result.note);
+        return result;
+    } catch (err) {
+        const isTrip = !!probeFeedService.getTrip();
+        if (!isTrip) {
+            try {
+                const reading = probeFeedService.getReading('probe');
+                if (!reading || !reading.triggered) {
+                    probeFeedService.clearExpectedContact();
+                    await moveMachineSettled(`${tag}:abort-raise`, { z: plan.hopZ }, TRAVEL_FEED);
+                    announce('abort-raised', `Z${plan.hopZ}`);
+                } else {
+                    announce('abort-held', 'probe still triggered - holding position for the operator');
+                }
+            } catch (retreatErr) {
+                // Logged by the activity stream.
+            }
+        }
+        if (err instanceof ProcedureAbort) {
+            const Ctor = err instanceof ProcedureStopped ? ProcedureStopped : ProcedureAbort;
+            throw new Ctor(`Stock outline aborted: ${err.message} ${topSamples.length} top sample(s) and ${contacts.length} side march(es) so far are on the job record.`, build(true));
+        }
+        throw err;
+    } finally {
+        probeFeedService.clearExpectedContact();
+    }
+}

--- a/src/server/services/mcp/probeProgram.ts
+++ b/src/server/services/mcp/probeProgram.ts
@@ -1,8 +1,16 @@
 /* eslint-disable camelcase */
 // MCP tool arguments are snake_case by convention (planProbeProgram takes the
 // probe_program arguments verbatim).
+import { KeepOutError, ObstacleBox, insideSweptCylinder, normalizeKeepOut } from './envelopeChecks';
+import { ExpandedGroup, GroupExpandError, expandProgramGroups } from './programGroups';
 import { mcpBroadcast } from './index';
 import { probeFeedService } from './probeFeed';
+import {
+    ProbeOutlinePlan,
+    describeProbeOutlinePlanAsGcode,
+    planProbeOutline,
+    runProbeOutlineProcedure,
+} from './probeOutline';
 import {
     ProbeSequencePlan,
     describeProbeSequencePlanAsGcode,
@@ -18,22 +26,28 @@ import {
 } from './probeSurface';
 import {
     ProcedureAbort,
+    ProcedureStopped,
     ROTATE_FEED,
     TRAVEL_FEED,
     assertMachineReadyForProcedure,
     knownMachinePosition,
     moveMachineSettled,
+    procedureStopRequested,
     rotateB,
 } from './probing';
 import {
     RefResolveError,
     RefSpec,
+    describeRef,
     refMidpoint,
+    refOpIds,
     resolveRef,
     substituteRefs,
     validateRef,
 } from './programRefs';
 import { McpToolError } from './registry';
+import { AxisNamespace, missingGeometryNote, programSeedNamespaces } from './rotaryGeometry';
+import { deriveStockSection } from './stockGeometry';
 import { getPositionSnapshot, safeTraverseZ } from './tools/machine';
 
 // A composite probing PROGRAM: an ordered list of operations - rotate the
@@ -55,10 +69,10 @@ import { getPositionSnapshot, safeTraverseZ } from './tools/machine';
 // rotation requires the toolhead at or above the safe traverse height, and
 // every operation ends raised at that height.
 
-export { isRef, lookupPath, resolveRef, substituteRefs } from './programRefs';
+export { describeRef, isRef, lookupPath, refOpIds, resolveRef, substituteRefs } from './programRefs';
 export type { RefSpec } from './programRefs';
 
-export type ProgramOpKind = 'rotate_b' | 'surface_path' | 'surface_grid' | 'sequence';
+export type ProgramOpKind = 'rotate_b' | 'surface_path' | 'surface_grid' | 'sequence' | 'stock_outline';
 
 export interface ProgramOp {
     id: string;
@@ -79,40 +93,104 @@ export interface ProbeProgramPlan {
     /** Preview descriptions (refs at their mid-point) for the confirm page. */
     previews: { id: string; text: string }[];
     rotations: number[];
+    /** Namespaces seeded into the results before op 1 (jig/tool constants: `axis`). */
+    seeds: { axis?: AxisNamespace };
+    /** Transient obstacle boxes for THIS clamping (chuck jaws, tailstock), checked with the stored landmarks. */
+    keepOut: ObstacleBox[];
+    /** `group` ops expanded at staging (for the page header). */
+    groups: ExpandedGroup[];
+    /** Estimated job events this program writes (100 + 120/station + 60/probe + 20/rotation). */
+    eventBudget: number;
 }
 
-const MAX_OPS = 40;
+const MAX_OPS = 80;
+
+/** Job-event estimate per op (measured: 763 events for an 8-station path; a sequence probe ~60). */
+function eventBudgetFor(sub: SubPlan | { kind: 'rotate_b' }): number {
+    if (sub.kind === 'rotate_b') {
+        return 20;
+    }
+    if (sub.kind === 'sequence') {
+        return 20 + sub.plan.steps.length * 20 + sub.plan.steps.filter((st) => st.kind === 'probe').length * 60;
+    }
+    if (sub.kind === 'stock_outline') {
+        return 60 + sub.plan.topPoints.length * 80 + sub.plan.sidePoints.length * 90;
+    }
+    return 40 + sub.plan.stations.length * 120;
+}
 const ID_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,31}$/;
 
 type SubPlan =
     | { kind: 'surface_path'; plan: ProbeSurfacePlan }
     | { kind: 'surface_grid'; plan: ProbeSurfacePlan }
-    | { kind: 'sequence'; plan: ProbeSequencePlan };
+    | { kind: 'sequence'; plan: ProbeSequencePlan }
+    | { kind: 'stock_outline'; plan: ProbeOutlinePlan };
 
-function buildSubPlan(kind: ProgramOpKind, args: { [key: string]: unknown }): SubPlan {
+function buildSubPlan(kind: ProgramOpKind, args: { [key: string]: unknown }, keepOut: ObstacleBox[]): SubPlan {
     if (kind === 'surface_path') {
-        return { kind, plan: planProbeSurfacePath(args as Parameters<typeof planProbeSurfacePath>[0]) };
+        return { kind, plan: planProbeSurfacePath(args as Parameters<typeof planProbeSurfacePath>[0], keepOut) };
     }
     if (kind === 'surface_grid') {
-        return { kind, plan: planProbeSurfaceGrid(args as Parameters<typeof planProbeSurfaceGrid>[0]) };
+        return { kind, plan: planProbeSurfaceGrid(args as Parameters<typeof planProbeSurfaceGrid>[0], keepOut) };
     }
     if (kind === 'sequence') {
-        return { kind, plan: planProbeSequence(args as Parameters<typeof planProbeSequence>[0]) };
+        return { kind, plan: planProbeSequence(args as Parameters<typeof planProbeSequence>[0], keepOut) };
+    }
+    if (kind === 'stock_outline') {
+        return { kind, plan: planProbeOutline(args as Parameters<typeof planProbeOutline>[0], keepOut) };
     }
     throw new McpToolError(`Unsupported op kind ${kind}.`);
 }
 
 function describeSubPlan(sub: SubPlan): string {
-    return sub.kind === 'sequence' ? describeProbeSequencePlanAsGcode(sub.plan) : describeProbeSurfacePlanAsGcode(sub.plan);
+    if (sub.kind === 'sequence') {
+        return describeProbeSequencePlanAsGcode(sub.plan);
+    }
+    if (sub.kind === 'stock_outline') {
+        return describeProbeOutlinePlanAsGcode(sub.plan);
+    }
+    return describeProbeSurfacePlanAsGcode(sub.plan);
 }
 
-export function planProbeProgram(args: { name?: unknown; ops?: unknown }): ProbeProgramPlan {
+async function runSubPlan(sub: SubPlan): Promise<object> {
+    if (sub.kind === 'sequence') {
+        return runProbeSequenceProcedure(sub.plan);
+    }
+    if (sub.kind === 'stock_outline') {
+        return runProbeOutlineProcedure(sub.plan);
+    }
+    return runProbeSurfaceProcedure(sub.plan);
+}
+
+export function planProbeProgram(args: { name?: unknown; ops?: unknown; keep_out?: unknown }): ProbeProgramPlan {
     const name = String(args.name || '').trim();
     if (!name) {
         throw new McpToolError('name is required (shown to the operator).');
     }
-    if (!Array.isArray(args.ops) || args.ops.length < 1 || args.ops.length > MAX_OPS) {
-        throw new McpToolError(`ops is required: 1-${MAX_OPS} operations of kind rotate_b | surface_path | surface_grid | sequence.`);
+    let keepOut: ObstacleBox[];
+    try {
+        keepOut = normalizeKeepOut(args.keep_out);
+    } catch (err) {
+        if (err instanceof KeepOutError) {
+            throw new McpToolError(err.message);
+        }
+        throw err;
+    }
+    if (!Array.isArray(args.ops) || args.ops.length < 1) {
+        throw new McpToolError('ops is required: operations of kind rotate_b | surface_path | surface_grid | sequence | stock_outline | group.');
+    }
+    let expandedOps: unknown[];
+    let groups: ExpandedGroup[];
+    try {
+        ({ ops: expandedOps, groups } = expandProgramGroups(args.ops));
+    } catch (err) {
+        if (err instanceof GroupExpandError) {
+            throw new McpToolError(err.message);
+        }
+        throw err;
+    }
+    if (expandedOps.length > MAX_OPS) {
+        throw new McpToolError(`${expandedOps.length} operations after group expansion exceeds the cap of ${MAX_OPS}.`);
     }
     const snapshot = getPositionSnapshot();
     const { x, y, z } = snapshot.machine;
@@ -120,13 +198,16 @@ export function planProbeProgram(args: { name?: unknown; ops?: unknown }): Probe
         throw new McpToolError('Current machine position unknown; cannot anchor the program.');
     }
     const hopZ = safeTraverseZ();
+    const seeds = programSeedNamespaces();
+    const seeded = new Set(Object.keys(seeds));
     const ids = new Set<string>();
     const ops: ProgramOp[] = [];
     const previews: { id: string; text: string }[] = [];
     const rotations: number[] = [];
     let anyRotate = false;
+    let eventBudget = 100;
 
-    (args.ops as unknown[]).forEach((raw, index) => {
+    expandedOps.forEach((raw, index) => {
         const where = `ops[${index}]`;
         if (!raw || typeof raw !== 'object') {
             throw new McpToolError(`${where}: must be an object.`);
@@ -136,13 +217,16 @@ export function planProbeProgram(args: { name?: unknown; ops?: unknown }): Probe
         if (!ID_PATTERN.test(id)) {
             throw new McpToolError(`${where}: id is required (letters, digits, _ or -, max 32 chars) - other ops reference results by it.`);
         }
+        if (id === 'axis') {
+            throw new McpToolError(`${where}: "axis" is the seeded jig-geometry namespace, not an op id.`);
+        }
         if (ids.has(id)) {
             throw new McpToolError(`${where}: duplicate id "${id}".`);
         }
         ids.add(id);
         const kind = String(op.kind || '') as ProgramOpKind;
-        if (!['rotate_b', 'surface_path', 'surface_grid', 'sequence'].includes(kind)) {
-            throw new McpToolError(`${where}: kind must be rotate_b, surface_path, surface_grid or sequence.`);
+        if (!['rotate_b', 'surface_path', 'surface_grid', 'sequence', 'stock_outline'].includes(kind)) {
+            throw new McpToolError(`${where}: kind must be rotate_b, surface_path, surface_grid, sequence or stock_outline.`);
         }
         const onFail = op.on_fail === 'skip' ? 'skip' : 'stop';
         const opArgs: { [key: string]: unknown } = {};
@@ -161,13 +245,30 @@ export function planProbeProgram(args: { name?: unknown; ops?: unknown }): Probe
             if (!Number.isFinite(requireZ) || requireZ < hopZ) {
                 throw new McpToolError(`${where} (rotate_b): require_z_at_least must be >= the safe traverse height ${hopZ} (law 2: the stock turns under a raised head).`);
             }
+            // Stock size belongs to the program, not the jig: an optional
+            // swept radius (largest reach of THIS stock and clamping about the
+            // axis) adds a tip-outside-the-cylinder check before the turn.
+            let sweptRadius: number | null = null;
+            if (opArgs.swept_radius_mm !== undefined && opArgs.swept_radius_mm !== null) {
+                sweptRadius = Number(opArgs.swept_radius_mm);
+                if (!Number.isFinite(sweptRadius) || sweptRadius <= 0 || sweptRadius > 200) {
+                    throw new McpToolError(`${where} (rotate_b): swept_radius_mm must be 0-200 (largest reach of the stock and clamping about the axis).`);
+                }
+                if (!seeds.axis) {
+                    throw new McpToolError(`${where} (rotate_b): swept_radius_mm needs the rotary axis and probe length. ${missingGeometryNote()}`);
+                }
+            }
             if (!snapshot.isFourAxis) {
                 throw new McpToolError(`${where} (rotate_b): the heartbeat reports no B axis - is the rotary module installed and selected in Machine Settings?`);
             }
             anyRotate = true;
             rotations.push(b);
-            ops.push({ id, kind, args: { b, require_z_at_least: requireZ }, on_fail: 'stop', refs: [] });
-            previews.push({ id, text: `; ROTATE STOCK: B -> ${b} deg (absolute), requires toolhead machine Z >= ${requireZ}\nG90\nG0 B${b.toFixed(3)} F${ROTATE_FEED}; verified by M114 (B within 0.05 deg)` });
+            eventBudget += eventBudgetFor({ kind: 'rotate_b' });
+            ops.push({ id, kind, args: { b, require_z_at_least: requireZ, swept_radius_mm: sweptRadius }, on_fail: 'stop', refs: [] });
+            const swept = sweptRadius !== null && seeds.axis
+                ? `\n; swept cylinder (this stock): axis X${seeds.axis.x}, physical Z${seeds.axis.z_physical}, radius ${sweptRadius} -> the probe tip clears it with the toolhead at Z >= ${(seeds.axis.z_contact + sweptRadius).toFixed(3)}`
+                : '';
+            previews.push({ id, text: `; ROTATE STOCK: B -> ${b} deg (absolute), requires toolhead machine Z >= ${requireZ}${swept}\nG90\nG0 B${b.toFixed(3)} F${ROTATE_FEED}; verified by M114 (B within 0.05 deg)` });
             return;
         }
 
@@ -187,18 +288,25 @@ export function planProbeProgram(args: { name?: unknown; ops?: unknown }): Probe
             }
             throw err;
         }
-        if (refs.some((r) => !ids.has(r.ref.from.split('.')[0]) || r.ref.from.split('.')[0] === id)) {
-            const bad = refs.find((r) => !ids.has(r.ref.from.split('.')[0]) || r.ref.from.split('.')[0] === id) as { ref: RefSpec };
-            throw new McpToolError(`${where}: reference "${bad.ref.from}" points at an op that does not run BEFORE this one.`);
+        for (const r of refs) {
+            const missing = refOpIds(r.ref).find((dep) => dep === id || (!ids.has(dep) && !seeded.has(dep)));
+            if (missing === 'axis') {
+                throw new McpToolError(`${where}: reference ${describeRef(r.ref)} reads the "axis" namespace, which is not configured. ${missingGeometryNote()}`);
+            }
+            if (missing) {
+                throw new McpToolError(`${where}: reference ${describeRef(r.ref)} reads "${missing}", which is not an op that runs BEFORE this one`
+                    + `${seeded.size ? ` (or a seeded namespace: ${Array.from(seeded).join(', ')})` : ''}.`);
+            }
         }
         let preview: SubPlan;
         try {
-            preview = buildSubPlan(kind, previewArgs);
+            preview = buildSubPlan(kind, previewArgs, keepOut);
         } catch (err) {
             throw new McpToolError(`${where} ("${id}", ${kind}): ${(err as Error).message}`);
         }
         ops.push({ id, kind, args: opArgs, on_fail: onFail, refs });
-        const refLines = refs.map((r) => `; REFERENCE ${r.path} = ${r.ref.from}${r.ref.plus ? ` + ${r.ref.plus}` : ''}${r.ref.minus ? ` - ${r.ref.minus}` : ''}, `
+        eventBudget += eventBudgetFor(preview);
+        const refLines = refs.map((r) => `; REFERENCE ${r.path} = ${describeRef(r.ref)}, `
             + `approved bounds [${r.ref.between[0]}, ${r.ref.between[1]}] - preview below uses ${refMidpoint(r.ref)}; the runner REFUSES the op outside the bounds`);
         previews.push({ id, text: [...refLines, describeSubPlan(preview)].join('\n') });
     });
@@ -210,12 +318,17 @@ export function planProbeProgram(args: { name?: unknown; ops?: unknown }): Probe
         staged: { x, y, z, b: snapshot.b },
         previews,
         rotations: anyRotate ? rotations : [],
+        seeds,
+        keepOut,
+        groups,
+        eventBudget,
     };
 }
 
 export function describeProbeProgramAsGcode(plan: ProbeProgramPlan): string {
     const lines = [
-        `; PROBE PROGRAM "${plan.name}": ${plan.ops.length} operations, ONE approval`,
+        `; PROBE PROGRAM "${plan.name}": ${plan.ops.length} operations, ONE approval; about ${plan.eventBudget} job events`,
+        ...plan.groups.map((g) => `; GROUP "${g.id}": ${g.innerCount} op(s) repeated at B ${g.angles.join(' / ')} deg (each preceded by a rotation)`),
         `; anchored at machine (${plan.staged.x}, ${plan.staged.y}, ${plan.staged.z})${plan.staged.b === null ? '' : ` B${plan.staged.b}`}`,
         '; every operation runs through its own runner (position of record, crash guard, hop envelope, slow zone,',
         `; <= 5 mm descent segments) and ends raised at the safe traverse height Z${plan.hopZ}; the next op starts there.`,
@@ -224,8 +337,20 @@ export function describeProbeProgramAsGcode(plan: ProbeProgramPlan): string {
             : '; no rotations in this program.',
         '; A failed operation (no contact where required, hop-guard contact, alarm, rotation not settled) stops the program',
         '; raised at the traverse height and keeps every earlier result; on_fail: skip records the failure and continues.',
-        '; References ({from: "<op>.<path>"}) resolve at run time from earlier results and are REFUSED outside their approved bounds.',
+        '; References ({from: "<op>.<path>"}, mid/diff/min/max of paths, +/- a number or path) resolve at run time from earlier',
+        '; results and are REFUSED outside their approved bounds.',
     ];
+    if (plan.keepOut.length) {
+        lines.push(`; KEEP-OUT for this clamping (${plan.keepOut.length}, checked with the stored landmarks against every hop, column and march):`);
+        for (const k of plan.keepOut) {
+            lines.push(`;   "${k.name}": machine X ${k.machine.x0}..${k.machine.x1}, Y ${k.machine.y0}..${k.machine.y1}, toolhead must stay at Z >= ${k.clearanceZ} over it (+5 mm margin)`);
+        }
+    }
+    if (plan.seeds.axis) {
+        const a = plan.seeds.axis;
+        lines.push(`; JIG GEOMETRY (operator settings, namespace "axis"): axis X${a.x}, physical Z${a.z_physical}, probe ${a.probe_length} mm`
+            + ` -> axis.z_contact ${a.z_contact}${a.tip_radius === null ? '' : `, tip radius ${a.tip_radius}`}`);
+    }
     plan.ops.forEach((op, index) => {
         lines.push('');
         lines.push(`; ===== OP ${index + 1}/${plan.ops.length} "${op.id}" (${op.kind}${op.on_fail === 'skip' ? ', on_fail: skip' : ''}) =====`);
@@ -240,17 +365,47 @@ export function describeProbeProgramAsGcode(plan: ProbeProgramPlan): string {
 export interface ProgramOpResult {
     id: string;
     kind: ProgramOpKind;
+    /** Rotary angle the op ran at (last verified rotation, or the staged B). */
+    b: number | null;
     status: 'completed' | 'failed' | 'skipped';
     resolvedRefs: { path: string; from: string; value: number }[];
     startedAt: number;
     endedAt: number;
     result?: object;
+    /** What a failed op measured before it aborted (stations / contacts). */
+    partial?: object;
     error?: string;
+}
+
+/** The program's result object - returned on success and carried as `partial` on an abort/stop. */
+function programResult(
+    plan: ProbeProgramPlan,
+    report: ProgramOpResult[],
+    stoppedAt: string | null,
+    startedAt: number,
+    phases: { phase: string; note?: string }[]
+): object {
+    return {
+        name: plan.name,
+        ops: report,
+        completedOps: report.filter((r) => r.status === 'completed').length,
+        stoppedAt,
+        rotations: plan.rotations,
+        axis: plan.seeds.axis || null,
+        derived: deriveStockSection(
+            report.filter((r) => r.status === 'completed').map((r) => ({ id: r.id, kind: r.kind, b: r.b, result: r.result })),
+            plan.seeds.axis || null
+        ),
+        durationMs: Date.now() - startedAt,
+        phases,
+        note: `Program ${stoppedAt ? `stopped at "${stoppedAt}"` : 'complete'}: ${report.filter((r) => r.status === 'completed').length}/${plan.ops.length} operations. `
+            + 'Each op result is the same object its standalone tool returns (stations / results, fits, timing).',
+    };
 }
 
 export async function runProbeProgramProcedure(plan: ProbeProgramPlan): Promise<object> {
     assertMachineReadyForProcedure();
-    const results: { [opId: string]: unknown } = {};
+    const results: { [opId: string]: unknown } = { ...plan.seeds };
     const report: ProgramOpResult[] = [];
     const phases: { phase: string; note?: string }[] = [];
     const announce = (phase: string, note?: string) => {
@@ -259,6 +414,7 @@ export async function runProbeProgramProcedure(plan: ProbeProgramPlan): Promise<
     };
     const startedAt = Date.now();
     let stoppedAt: string | null = null;
+    let currentB: number | null = plan.staged.b;
 
     for (let index = 0; index < plan.ops.length; index++) {
         const op = plan.ops[index];
@@ -270,9 +426,23 @@ export async function runProbeProgramProcedure(plan: ProbeProgramPlan): Promise<
             if (op.kind === 'rotate_b') {
                 const b = Number(op.args.b);
                 const requireZ = Number(op.args.require_z_at_least);
+                const axis = plan.seeds.axis;
+                const sweptRadius = op.args.swept_radius_mm === null || op.args.swept_radius_mm === undefined ? null : Number(op.args.swept_radius_mm);
+                if (axis && sweptRadius !== null) {
+                    // Belt and braces over the Z >= traverse rule: the tip must
+                    // be outside this stock's swept cylinder before it turns.
+                    const known = knownMachinePosition();
+                    const { x: kx, z: kz } = known.position;
+                    if (kx !== null && kz !== null
+                        && insideSweptCylinder({ x: kx, z: kz }, axis.probe_length, { x: axis.x, zPhysical: axis.z_physical, radius: sweptRadius })) {
+                        throw new ProcedureAbort(`Rotation refused: the probe tip (toolhead machine X${kx} Z${kz}, ${known.source}) is inside the `
+                            + `stock's swept cylinder (axis X${axis.x}, physical Z${axis.z_physical}, radius ${sweptRadius}).`);
+                    }
+                }
                 const outcome = await rotateB(`probe_program:${op.id}`, b, requireZ);
+                currentB = outcome.to;
                 results[op.id] = outcome;
-                report.push({ id: op.id, kind: op.kind, status: 'completed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), result: outcome });
+                report.push({ id: op.id, kind: op.kind, b: currentB, status: 'completed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), result: outcome });
                 announce(`op-${op.id}-done`, `B ${outcome.from === null ? '?' : outcome.from} -> ${outcome.to} deg`);
                 continue;
             }
@@ -280,23 +450,25 @@ export async function runProbeProgramProcedure(plan: ProbeProgramPlan): Promise<
             // machine's current (raised) position, run the existing runner.
             const { args: liveArgs } = substituteRefs(op.args, (ref, path) => {
                 const r = resolveRef(ref, results);
-                resolved.push({ path, from: ref.from, value: r.value });
+                resolved.push({ path, from: describeRef(ref), value: r.value });
                 announce(`op-${op.id}-ref`, `${path} = ${r.source}`);
                 return r.value;
             });
-            const sub = buildSubPlan(op.kind, liveArgs);
-            const outcome = sub.kind === 'sequence'
-                ? await runProbeSequenceProcedure(sub.plan)
-                : await runProbeSurfaceProcedure(sub.plan);
+            const sub = buildSubPlan(op.kind, liveArgs, plan.keepOut);
+            const outcome = await runSubPlan(sub);
             results[op.id] = outcome;
-            report.push({ id: op.id, kind: op.kind, status: 'completed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), result: outcome });
+            report.push({ id: op.id, kind: op.kind, b: currentB, status: 'completed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), result: outcome });
             announce(`op-${op.id}-done`);
         } catch (err) {
             const message = (err as Error).message;
-            report.push({ id: op.id, kind: op.kind, status: 'failed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), error: message });
+            const partial = (err as { partial?: object }).partial;
+            report.push({ id: op.id, kind: op.kind, b: currentB, status: 'failed', resolvedRefs: resolved, startedAt: opStarted, endedAt: Date.now(), partial, error: message });
             announce(`op-${op.id}-failed`, message);
             const trip = probeFeedService.getTrip();
-            if (trip || op.on_fail === 'stop' || op.kind === 'rotate_b') {
+            // A requested stop (stop_gcode_job) ends the PROGRAM, whatever the
+            // op's on_fail says.
+            const stop = procedureStopRequested();
+            if (trip || stop || op.on_fail === 'stop' || op.kind === 'rotate_b') {
                 stoppedAt = op.id;
                 // Every sub-runner raises to the traverse height on its own
                 // abort; make sure of it here for the program as a whole
@@ -315,6 +487,7 @@ export async function runProbeProgramProcedure(plan: ProbeProgramPlan): Promise<
                     report.push({
                         id: later.id,
                         kind: later.kind,
+                        b: currentB,
                         status: 'skipped',
                         resolvedRefs: [],
                         startedAt: Date.now(),
@@ -324,22 +497,14 @@ export async function runProbeProgramProcedure(plan: ProbeProgramPlan): Promise<
                 }
                 const completed = report.filter((r) => r.status === 'completed').length;
                 const tail = trip ? 'A safety alarm is latched - the operator must clear it.' : 'Machine raised to the traverse height.';
-                throw new ProcedureAbort(`Program "${plan.name}" stopped at op "${op.id}" (${index + 1}/${plan.ops.length}): ${message} `
-                    + `${completed} earlier op(s) completed; their results are on the job record under result.ops. ${tail}`);
+                const Ctor = stop || err instanceof ProcedureStopped ? ProcedureStopped : ProcedureAbort;
+                throw new Ctor(`Program "${plan.name}" stopped at op "${op.id}" (${index + 1}/${plan.ops.length}): ${message} `
+                    + `${completed} earlier op(s) completed; their results are on the job record under result.ops. ${tail}`,
+                programResult(plan, report, op.id, startedAt, phases));
             }
             announce(`op-${op.id}-skipped`, 'on_fail: skip - continuing');
         }
     }
 
-    return {
-        name: plan.name,
-        ops: report,
-        completedOps: report.filter((r) => r.status === 'completed').length,
-        stoppedAt,
-        rotations: plan.rotations,
-        durationMs: Date.now() - startedAt,
-        phases,
-        note: `Program complete: ${report.filter((r) => r.status === 'completed').length}/${plan.ops.length} operations. `
-            + 'Each op result is the same object its standalone tool returns (stations / results, fits, timing).',
-    };
+    return programResult(plan, report, stoppedAt, startedAt, phases);
 }

--- a/src/server/services/mcp/probeSequence.ts
+++ b/src/server/services/mcp/probeSequence.ts
@@ -1,13 +1,16 @@
 /* eslint-disable camelcase */
 // MCP tool arguments are snake_case by convention (planProbeSequence takes
 // the probe_sequence arguments verbatim).
+import { ObstacleBox, checkMotion, describeViolations, sequenceMotion } from './envelopeChecks';
 import { mcpBroadcast } from './index';
+import { landmarkStore } from './landmarks';
 import { probeFeedService } from './probeFeed';
 import {
     COARSE_FEED,
     FINE_FEED,
     MAX_RETREAT_MM,
     ProcedureAbort,
+    ProcedureStopped,
     TRAVEL_FEED,
     assertChannelReady,
     RECHECK_TOLERANCE_MM,
@@ -59,6 +62,15 @@ interface SequenceStepProbe {
     unit: { x: number; y: number; z: number };
     maxTravelMm: number;
     start: { x: number; y: number; z: number }; // simulated position at march start
+    /**
+     * Reaching max_travel_mm without contact: record a no_contact result and
+     * carry on with the next step (default), or abort the whole sequence.
+     * Operator, 2026-09-06 (job 5ad5fcce6b3a): a side march that missed the
+     * stock at a corner aborted a six-op program with five ops complete -
+     * "less than ideal usually". The limit itself was approved, so a miss is
+     * a measurement ("nothing within N mm"), not a fault.
+     */
+    onMiss: 'continue' | 'abort';
 }
 type SequenceStep = SequenceStepHop | SequenceStepDescend | SequenceStepProbe;
 
@@ -82,7 +94,7 @@ export function planProbeSequence(args: {
     backoff_mm?: number;
     sensor_delay_ms?: number;
     confirm_passes?: number;
-}): ProbeSequencePlan {
+}, extraObstacles: ObstacleBox[] = []): ProbeSequencePlan {
     if (!Array.isArray(args.steps) || args.steps.length < 1 || args.steps.length > 60) {
         throw new McpToolError('steps is required: 1-60 entries of {kind: hop|descend|probe, ...}.');
     }
@@ -155,12 +167,17 @@ export function planProbeSequence(args: {
             if (!inEnvelope(limit.x, limit.y) || limit.z < 0) {
                 throw new McpToolError(`${at}: the march limit leaves the machine envelope.`);
             }
+            const onMissRaw = raw.on_miss === undefined ? 'continue' : String(raw.on_miss);
+            if (onMissRaw !== 'continue' && onMissRaw !== 'abort') {
+                throw new McpToolError(`${at}: on_miss must be "continue" (default: record no_contact, carry on) or "abort".`);
+            }
             steps.push({
                 kind: 'probe',
                 name,
                 unit,
                 maxTravelMm: travel,
                 start: { ...virtual },
+                onMiss: onMissRaw,
             });
             names.add(name);
             probeCount += 1;
@@ -173,6 +190,15 @@ export function planProbeSequence(args: {
     });
     if (probeCount === 0) {
         throw new McpToolError('The sequence has no probe steps - use move_z / a gcode job for pure motion.');
+    }
+
+    // Law 4 (mcp/48): every hop, descend column and march is checked against
+    // the obstacle landmarks and the program's transient keep-out boxes at
+    // staging - refused, not left for the operator to spot on the page.
+    const violations = checkMotion(sequenceMotion({ hopZ, staged, steps }), [...landmarkStore.obstacleBoxes(), ...extraObstacles], { traverseZ: hopZ });
+    if (violations.length) {
+        throw new McpToolError(`Sequence refused (law 4, landmarks are obstacles): ${describeViolations(violations)}. `
+            + 'Raise the descend / march Z above the clearance, move the step, or have the operator adjust the landmark.');
     }
 
     return {
@@ -254,7 +280,8 @@ export function describeProbeSequencePlanAsGcode(plan: ProbeSequencePlan): strin
                 lines.push(`G1 ${text} F${COARSE_FEED}; coarse ${n} - settle, check probe, stop at contact`);
             }
             lines.push(`; ...on contact: retreat/release, ${plan.fineStepMm} mm fine approach, `
-                + `${plan.confirmPasses} confirm cycle(s) (lift ${plan.backoffMm} mm); ABORTS at the limit without contact`);
+                + `${plan.confirmPasses} confirm cycle(s) (lift ${plan.backoffMm} mm); at the limit without contact: `
+                + `${step.onMiss === 'abort' ? 'ABORTS the sequence' : 'records no_contact, retreats and CONTINUES with the next step (on_miss: continue)'}`);
             lines.push(`G1 X${step.start.x.toFixed(3)} Y${step.start.y.toFixed(3)} Z${step.start.z.toFixed(3)} `
                 + `F${TRAVEL_FEED}; retreat to the march start (also on any abort)`);
             lines.push(`G1 Z${plan.hopZ.toFixed(3)} F${TRAVEL_FEED}; raise to traverse height`);
@@ -287,10 +314,14 @@ export async function runProbeSequenceProcedure(plan: ProbeSequencePlan): Promis
     const releaseTimeoutMs = Math.max(plan.sensorDelayMs * 4, 3500);
     const results: {
         name: string;
-        contactMachine: { x: number; y: number; z: number };
-        contactDistanceMm: number;
+        status: 'contact' | 'no_contact';
+        contactMachine: { x: number; y: number; z: number } | null;
+        contactDistanceMm: number | null;
         confirmPassContacts: number[];
         spreadMm: number;
+        /** no_contact: where the march ended (its approved limit), machine coords. */
+        limitMachine?: { x: number; y: number; z: number };
+        maxTravelMm?: number;
     }[] = [];
 
     let stepIndex = 0;
@@ -360,7 +391,29 @@ export async function runProbeSequenceProcedure(plan: ProbeSequencePlan): Promis
                     }
                 }
                 if (coarseContactS === null) {
-                    throw new ProcedureAbort(`March "${step.name}": no contact within ${step.maxTravelMm} mm.`);
+                    if (step.onMiss === 'abort') {
+                        throw new ProcedureAbort(`March "${step.name}": no contact within ${step.maxTravelMm} mm (on_miss: abort).`);
+                    }
+                    // A miss is a measurement: nothing within the approved
+                    // travel. Record it, retreat to the start, raise, carry on.
+                    const limit = pointAlong(step.start, step.unit, step.maxTravelMm);
+                    results.push({
+                        name: step.name,
+                        status: 'no_contact',
+                        contactMachine: null,
+                        contactDistanceMm: null,
+                        confirmPassContacts: [],
+                        spreadMm: 0,
+                        limitMachine: limit,
+                        maxTravelMm: step.maxTravelMm,
+                    });
+                    announce(`no-contact-${step.name}`, `nothing within ${step.maxTravelMm} mm (limit at ${limit.x}, ${limit.y}, ${limit.z}); continuing`);
+                    await moveMachineSettled(`seq:retreat:${step.name}`, {
+                        x: step.start.x, y: step.start.y, z: step.start.z,
+                    }, TRAVEL_FEED);
+                    probeFeedService.clearExpectedContact();
+                    await moveMachineSettled(`seq:raise:${step.name}`, { z: plan.hopZ }, TRAVEL_FEED);
+                    continue;
                 }
                 let released = false;
                 while (s > 1e-9 && coarseContactS - s < MAX_RETREAT_MM + 1e-9) {
@@ -424,6 +477,7 @@ export async function runProbeSequenceProcedure(plan: ProbeSequencePlan): Promis
                 const contact = pointAlong(step.start, step.unit, measuredS);
                 results.push({
                     name: step.name,
+                    status: 'contact',
                     contactMachine: contact,
                     contactDistanceMm: measuredS,
                     confirmPassContacts: passContacts,
@@ -441,13 +495,17 @@ export async function runProbeSequenceProcedure(plan: ProbeSequencePlan): Promis
             }
         }
 
-        announce('sequence-complete', `${results.length} contacts`);
+        const contacts = results.filter((r) => r.status === 'contact');
+        const misses = results.filter((r) => r.status === 'no_contact').map((r) => r.name);
+        announce('sequence-complete', `${contacts.length} contacts${misses.length ? `, ${misses.length} no_contact (${misses.join(', ')})` : ''}`);
         return {
             results,
+            contactCount: contacts.length,
+            noContactProbes: misses,
             phases,
-            note: `Probe sequence complete: ${results.length} contacts, all MACHINE coordinates. `
-                + 'Worst confirm spread '
-                + `${Math.max(...results.map((r) => r.spreadMm)).toFixed(3)} mm.`,
+            note: `Probe sequence complete: ${contacts.length} contacts${misses.length ? `, ${misses.length} march(es) found nothing within their approved travel (${misses.join(', ')})` : ''}, `
+                + 'all MACHINE coordinates. Worst confirm spread '
+                + `${(contacts.length ? Math.max(...contacts.map((r) => r.spreadMm)) : 0).toFixed(3)} mm.`,
         };
     } catch (err) {
         const isTrip = !!probeFeedService.getTrip();
@@ -465,8 +523,10 @@ export async function runProbeSequenceProcedure(plan: ProbeSequencePlan): Promis
             }
         }
         if (err instanceof ProcedureAbort) {
-            throw new McpToolError(`Probe sequence aborted at step ${stepIndex}: ${err.message} `
-                + `Completed contacts: ${JSON.stringify(results)} Phases: ${JSON.stringify(phases)}`);
+            const partial = { results, phases, aborted: true, abortedAtStep: stepIndex };
+            const Ctor = err instanceof ProcedureStopped ? ProcedureStopped : ProcedureAbort;
+            throw new Ctor(`Probe sequence aborted at step ${stepIndex}: ${err.message} `
+                + `${results.length} contact(s) measured before the abort are on the job record.`, partial);
         }
         throw err;
     } finally {

--- a/src/server/services/mcp/probeSurface.ts
+++ b/src/server/services/mcp/probeSurface.ts
@@ -1,7 +1,10 @@
 /* eslint-disable camelcase */
 // MCP tool arguments are snake_case by convention (the plan builders take the
 // probe_surface_path / probe_surface_grid arguments verbatim).
+import { ObstacleBox, checkMotion, describeViolations, surfaceMotion } from './envelopeChecks';
 import { mcpBroadcast } from './index';
+import { landmarkStore } from './landmarks';
+import { steppedTraverseZ } from './march';
 import { probeFeedService } from './probeFeed';
 import { DESCENT_GUARD_MM } from './probeSequence';
 import {
@@ -9,6 +12,7 @@ import {
     FINE_FEED,
     MAX_RETREAT_MM,
     ProcedureAbort,
+    ProcedureStopped,
     TRAVEL_FEED,
     assertChannelReady,
     RECHECK_TOLERANCE_MM,
@@ -22,13 +26,17 @@ import {
     senseReleaseAfter,
 } from './probing';
 import { McpToolError } from './registry';
+import { probeGeometry } from './rotaryGeometry';
 import {
+    CIRCLE_MAX_OFFSET_FRACTION,
+    CircleProfile,
     ContactSample,
     HOP_SEGMENT_MM,
     SurfacePlanError,
     SurfaceStation,
     assertHopsWithin,
     buildZMatrix,
+    circleExpectedZ,
     coarseStepFor,
     fitLine,
     fitPlane,
@@ -104,6 +112,22 @@ export interface ProbeSurfacePlan {
     expectedZMachine: number | null;
     /** floor_z_machine was given explicitly: station 1 may search down to it (not just start_z - max_drop). */
     floorExplicit: boolean;
+    /**
+     * Expected contact PROFILE (mcp/48): per-station expected Z from a model
+     * of the surface (a cylinder along the rotary axis) instead of the
+     * previous station - the slow zone and the max_drop band follow the model.
+     */
+    profile: CircleProfile | null;
+    /**
+     * How the probe travels between stations (mcp/48, operator 2026-09-06):
+     * 'guarded' (default) hops at last contact + z_safe_delta expecting NO
+     * contact (a contact aborts); 'stepped' travels at last contact +
+     * hop_lift_mm as a touch-probing traverse - a contact backs off, lifts
+     * hop_lift_mm and continues, so the height follows the surface in steps
+     * (gentle slope or the wall of a hole) instead of a fixed clearance.
+     */
+    hopMode: 'guarded' | 'stepped';
+    hopLiftMm: number;
     path?: {
         start: { x: number; y: number };
         end: { x: number; y: number };
@@ -133,6 +157,9 @@ interface CommonArgs {
     confirm_passes?: number;
     slow_zone_mm?: number;
     expected_z_machine?: unknown;
+    expected_profile?: unknown;
+    hop_mode?: unknown;
+    hop_lift_mm?: unknown;
 }
 
 function toToolError<T>(fn: () => T): T {
@@ -146,11 +173,56 @@ function toToolError<T>(fn: () => T): T {
     }
 }
 
+/**
+ * expected_profile: { circle: { center_x, center_z_contact, radius, tip_radius? } }
+ * - a cylinder along machine Y. Every station must lie within 0.7 R of the
+ * axis (contact angle <= ~45 deg) and its expected Z inside the march window.
+ */
+function parseProfile(raw: unknown, stations: SurfaceStation[], startZ: number, floorZ: number): CircleProfile | null {
+    if (raw === undefined || raw === null) {
+        return null;
+    }
+    const circle = (raw as { circle?: unknown }).circle as { [k: string]: unknown } | undefined;
+    if (!circle || typeof circle !== 'object') {
+        throw new McpToolError('expected_profile must be {circle: {center_x, center_z_contact, radius, tip_radius?}}.');
+    }
+    const centerX = Number(circle.center_x);
+    const centerZ = Number(circle.center_z_contact);
+    const radius = Number(circle.radius);
+    if (!Number.isFinite(centerX) || !Number.isFinite(centerZ) || !Number.isFinite(radius) || radius <= 0 || radius > 200) {
+        throw new McpToolError('expected_profile.circle needs finite center_x, center_z_contact (toolhead Z with the tip on the axis) and radius (0-200).');
+    }
+    let tipRadius: number;
+    if (circle.tip_radius !== undefined) {
+        tipRadius = Number(circle.tip_radius);
+        if (!Number.isFinite(tipRadius) || tipRadius < 0 || tipRadius > 15) {
+            throw new McpToolError('expected_profile.circle.tip_radius must be 0-15 mm.');
+        }
+    } else {
+        const geometry = probeGeometry();
+        tipRadius = geometry && geometry.tipDiameter !== null ? geometry.tipDiameter / 2 : 0;
+    }
+    const profile: CircleProfile = { kind: 'circle', centerX, centerZContact: centerZ, radius, tipRadius };
+    for (const st of stations) {
+        const z = circleExpectedZ(profile, st.x);
+        if (z === null) {
+            throw new McpToolError(`Station ${st.label} (X${st.x}) lies more than ${CIRCLE_MAX_OFFSET_FRACTION} x radius from the cylinder axis `
+                + `X${centerX} - the tip would glance off the curve (contact angle > 45 deg). Shorten the path.`);
+        }
+        if (z > startZ + 1e-9 || z < floorZ - 1e-9) {
+            throw new McpToolError(`Station ${st.label}: the circle profile expects contact at Z${z}, outside the march window `
+                + `floor Z${floorZ.toFixed(3)} .. start Z${startZ.toFixed(3)}.`);
+        }
+    }
+    return profile;
+}
+
 /** Everything both scans share once the stations exist. */
 function finishPlan(
     kind: SurfaceScanKind,
     stations: SurfaceStation[],
-    args: CommonArgs
+    args: CommonArgs,
+    extraObstacles: ObstacleBox[] = []
 ): Omit<ProbeSurfacePlan, 'path' | 'grid'> {
     const env = toToolError(() => resolveEnvelope(args));
     const worstHopMm = toToolError(() => assertHopsWithin(stations, env.maxHopMm));
@@ -202,6 +274,29 @@ function finishPlan(
         expectedZ = Number(expectedZ.toFixed(3));
     }
 
+    const profile = parseProfile(args.expected_profile, stations, startZ, floorZ);
+    const hopMode = args.hop_mode === undefined || args.hop_mode === null || args.hop_mode === '' ? 'guarded' : String(args.hop_mode);
+    if (hopMode !== 'guarded' && hopMode !== 'stepped') {
+        throw new McpToolError('hop_mode must be "guarded" (hop at last contact + z_safe_delta, contact aborts) or "stepped" (touch-probing traverse that lifts on contact).');
+    }
+    const hopLiftMm = args.hop_lift_mm === undefined ? 2 : Number(args.hop_lift_mm);
+    if (!Number.isFinite(hopLiftMm) || hopLiftMm < 0.5 || hopLiftMm > 10) {
+        throw new McpToolError('hop_lift_mm must be 0.5-10.');
+    }
+
+    // Law 4 (mcp/48): station-1 descent, every hop at its lowest possible
+    // height (floor + z_safe_delta) and every march column down to the floor
+    // are checked against obstacle landmarks and the program's keep-out boxes.
+    const violations = checkMotion(
+        surfaceMotion({ hopZ, absoluteFloorZ: floorZ, zSafeDeltaMm: hopMode === 'stepped' ? hopLiftMm : env.zSafeDeltaMm, hopMode, stations }),
+        [...landmarkStore.obstacleBoxes(), ...extraObstacles],
+        { traverseZ: hopZ }
+    );
+    if (violations.length) {
+        throw new McpToolError(`Scan refused (law 4, landmarks are obstacles): ${describeViolations(violations)}. `
+            + 'Raise floor_z_machine, shorten the path / grid, or have the operator adjust the landmark.');
+    }
+
     return {
         kind,
         tool: kind === 'path' ? 'probe_surface_path' : 'probe_surface_grid',
@@ -225,10 +320,14 @@ function finishPlan(
         sensorDelayMs: Math.min(Math.max(Number(args.sensor_delay_ms) || 300, 30), 10000),
         confirmPasses: Math.min(Math.max(Math.round(Number(args.confirm_passes) || 3), 1), 10),
         slowZoneMm: Math.min(Math.max(Number(args.slow_zone_mm) || 1, 0.3), env.zSafeDeltaMm),
-        expectedZMachine: expectedZ,
+        expectedZMachine: profile && expectedZ === null ? circleExpectedZ(profile, stations[0].x) : expectedZ,
         floorExplicit: args.floor_z_machine !== undefined && args.floor_z_machine !== null && args.floor_z_machine !== '',
+        profile,
+        hopMode,
+        hopLiftMm,
     };
 }
+
 
 export function planProbeSurfacePath(args: CommonArgs & {
     start_x?: unknown;
@@ -240,7 +339,7 @@ export function planProbeSurfacePath(args: CommonArgs & {
     length_mm?: unknown;
     stations?: unknown;
     spacing_mm?: unknown;
-}): ProbeSurfacePlan {
+}, extraObstacles: ObstacleBox[] = []): ProbeSurfacePlan {
     const path = toToolError(() => planPathStations({
         start_x: args.start_x,
         start_y: args.start_y,
@@ -253,7 +352,7 @@ export function planProbeSurfacePath(args: CommonArgs & {
         spacing_mm: args.spacing_mm,
     }));
     return {
-        ...finishPlan('path', path.stations, args),
+        ...finishPlan('path', path.stations, args, extraObstacles),
         path: { start: path.start, end: path.end, unit: path.unit, lengthMm: path.lengthMm, spacingMm: path.spacingMm },
     };
 }
@@ -270,10 +369,10 @@ export function planProbeSurfaceGrid(args: CommonArgs & {
     pitch_mm?: unknown;
     x_count?: unknown;
     y_count?: unknown;
-}): ProbeSurfacePlan {
+}, extraObstacles: ObstacleBox[] = []): ProbeSurfacePlan {
     const grid = toToolError(() => planGridStations(args));
     return {
-        ...finishPlan('grid', grid.stations, args),
+        ...finishPlan('grid', grid.stations, args, extraObstacles),
         grid: { xs: grid.xs, ys: grid.ys, pitchXMm: grid.pitchXMm, pitchYMm: grid.pitchYMm, bounds: grid.bounds },
     };
 }
@@ -310,6 +409,15 @@ export function describeProbeSurfacePlanAsGcode(plan: ProbeSurfacePlan): string 
         `;   ${plan.fineStepMm} mm steps take over down to ${(plan.slowZoneMm + 2 * plan.coarseStepMm).toFixed(1)} mm BELOW it (coarse resumes below that).`,
         `;   Worst press into the probe: ${plan.fineStepMm} mm where the surface lies in the zone; one coarse step (${plan.coarseStepMm} mm)`,
         `;   where it is higher; station 1 without expected_z_machine uses ${coarseStepFor(plan, plan.expectedZMachine !== null)} mm coarse steps (cap 1).`,
+        ...(plan.hopMode === 'stepped' ? [
+            `; HOP MODE stepped: between stations the probe travels at last contact + ${plan.hopLiftMm} mm as a TOUCH-PROBING traverse (1 mm steps, F300,`,
+            `;   probe expected): a contact backs off 1 mm, lifts ${plan.hopLiftMm} mm and continues - the height follows the surface in steps (never above Z${plan.hopZ}).`,
+        ] : []),
+        ...(plan.profile ? [
+            `; EXPECTED PROFILE: cylinder along machine Y, axis X${plan.profile.centerX}, tip-on-axis Z${plan.profile.centerZContact}, radius ${plan.profile.radius}`
+                + ` (tip radius ${plan.profile.tipRadius}); every station's slow zone and max_drop band follow the model, not the previous station:`,
+            `;   ${plan.stations.map((st) => `${st.label} Z${circleExpectedZ(plan.profile as CircleProfile, st.x)}`).join(', ')}`,
+        ] : []),
         `; anchored at machine (${plan.staged.x.toFixed(2)}, ${plan.staged.y.toFixed(2)}, ${plan.staged.z.toFixed(2)})`
             + ' - re-verified before any motion, and before EVERY march',
         ';',
@@ -544,6 +652,7 @@ function buildResult(plan: ProbeSurfacePlan, results: SurfaceStationResult[], ph
         noContactStations: noContact,
         summary,
         worstConfirmSpreadMm: Number(worstSpread.toFixed(3)),
+        profile: plan.profile,
         envelope: {
             zSafeDeltaMm: plan.zSafeDeltaMm,
             maxHopMm: plan.maxHopMm,
@@ -627,7 +736,7 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
     const results: SurfaceStationResult[] = [];
     // Reference height for the envelope: the last REAL contact (toolhead Z).
     let reference: number | null = null;
-    const hopHeightFor = (ref: number) => Number(Math.min(ref + plan.zSafeDeltaMm, plan.hopZ).toFixed(3));
+    const hopHeightFor = (ref: number) => Number(Math.min(ref + (plan.hopMode === 'stepped' ? plan.hopLiftMm : plan.zSafeDeltaMm), plan.hopZ).toFixed(3));
 
     let stationIndex = 0;
     try {
@@ -678,22 +787,40 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
                 // header for the operator's authorisation and its bounds.
                 const previous = plan.stations[station.index - 2];
                 probeFeedService.clearExpectedContact();
-                const segs = hopSegments({ x: previous.x, y: previous.y }, { x: station.x, y: station.y });
-                for (let j = 0; j < segs.length; j++) {
-                    const t0 = Date.now();
-                    await moveMachineSettled(`${plan.tool}:hop:${station.label}`, { x: segs[j].x, y: segs[j].y }, TRAVEL_FEED);
-                    const sensed = await senseAfter('probe', t0, plan.sensorDelayMs);
-                    if (sensed.contact) {
-                        throw new ProcedureAbort(`UNEXPECTED CONTACT during the hop to "${station.label}" at `
-                            + `(${segs[j].x}, ${segs[j].y}, ${currentZ}) - the surface rises more than ${plan.zSafeDeltaMm} mm `
-                            + 'above the last contact. Machine held.');
+                if (plan.hopMode === 'stepped') {
+                    const traverse = await steppedTraverseZ(plan.tool, station.label, previous, station, currentZ, {
+                        liftMm: plan.hopLiftMm, maxZ: plan.hopZ, sensorDelayMs: plan.sensorDelayMs,
+                    }, announce);
+                    currentZ = traverse.z;
+                    announce(`hop-${station.label}`, `${station.hopFromPreviousMm} mm to (${station.x}, ${station.y}), stepped traverse: `
+                        + `${traverse.lifts.length} lift(s), arrived at Z${currentZ}`);
+                } else {
+                    const segs = hopSegments({ x: previous.x, y: previous.y }, { x: station.x, y: station.y });
+                    for (let j = 0; j < segs.length; j++) {
+                        const t0 = Date.now();
+                        await moveMachineSettled(`${plan.tool}:hop:${station.label}`, { x: segs[j].x, y: segs[j].y }, TRAVEL_FEED);
+                        const sensed = await senseAfter('probe', t0, plan.sensorDelayMs);
+                        if (sensed.contact) {
+                            throw new ProcedureAbort(`UNEXPECTED CONTACT during the hop to "${station.label}" at `
+                                + `(${segs[j].x}, ${segs[j].y}, ${currentZ}) - the surface rises more than ${plan.zSafeDeltaMm} mm `
+                                + 'above the last contact. Machine held.');
+                        }
                     }
+                    announce(`hop-${station.label}`, `${station.hopFromPreviousMm} mm to (${station.x}, ${station.y}) at Z${currentZ} `
+                        + `(last contact + ${plan.zSafeDeltaMm})`);
                 }
-                announce(`hop-${station.label}`, `${station.hopFromPreviousMm} mm to (${station.x}, ${station.y}) at Z${currentZ} `
-                    + `(last contact + ${plan.zSafeDeltaMm})`);
             }
 
-            const env = stationEnvelope(reference === null ? plan.startZMachine : reference, isFirst, plan.startZMachine, {
+            // With a profile the max_drop band hangs below the MODEL's expectation
+            // for this station (a cylinder falls away from the crown faster than
+            // max_drop below the previous contact would allow); hops still use
+            // the last real contact (the law-2 exception is unchanged).
+            const modelZ = plan.profile ? circleExpectedZ(plan.profile, station.x) : null;
+            let envReference = reference === null ? plan.startZMachine : reference;
+            if (modelZ !== null) {
+                envReference = modelZ;
+            }
+            const env = stationEnvelope(envReference, isFirst, plan.startZMachine, {
                 zSafeDeltaMm: plan.zSafeDeltaMm, maxDropMm: plan.maxDropMm, absoluteFloorZ: plan.absoluteFloorZ,
             });
             // Station 1 may search all the way to an EXPLICIT floor_z_machine
@@ -710,7 +837,10 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
             probeFeedService.setExpectedContact(['probe']);
             // Expected contact for the slow zone: the previous real contact,
             // or the caller's expected_z_machine for station 1.
-            const expectedContact = isFirst ? plan.expectedZMachine : reference;
+            let expectedContact = isFirst ? plan.expectedZMachine : reference;
+            if (modelZ !== null) {
+                expectedContact = modelZ;
+            }
             const outcome = await marchDownZ(plan, station, marchStartZ, stationFloorZ, expectedContact, announce);
             let retractTo: number;
             if (outcome === null) {
@@ -789,8 +919,12 @@ export async function runProbeSurfaceProcedure(plan: ProbeSurfacePlan): Promise<
             }
         }
         if (err instanceof ProcedureAbort) {
-            throw new McpToolError(`Surface ${plan.kind} scan aborted at station ${stationIndex}: ${err.message} `
-                + `Completed stations: ${JSON.stringify(results)} Phases: ${JSON.stringify(phases)}`);
+            // Keep the class (a program runner tells a requested stop from a
+            // fault) and carry the completed stations as the partial result.
+            const partial = { ...buildResult(plan, results, phases), aborted: true, abortedAtStation: stationIndex };
+            const Ctor = err instanceof ProcedureStopped ? ProcedureStopped : ProcedureAbort;
+            throw new Ctor(`Surface ${plan.kind} scan aborted at station ${stationIndex}: ${err.message} `
+                + `${results.filter((r) => r.status === 'contact').length} station(s) measured before the abort are on the job record.`, partial);
         }
         throw err;
     } finally {

--- a/src/server/services/mcp/probing.ts
+++ b/src/server/services/mcp/probing.ts
@@ -81,7 +81,63 @@ export function takeStepTrace(since: number | null): string | undefined {
     return text;
 }
 
-export class ProcedureAbort extends Error {}
+export class ProcedureAbort extends Error {
+    /** Partial result (completed stations / ops) so an abort never loses what was measured. */
+    public partial?: object;
+
+    public constructor(message: string, partial?: object) {
+        super(message);
+        this.partial = partial;
+    }
+}
+
+/** Thrown at the first step boundary after requestProcedureStop(): a graceful, operator/agent-initiated stop. */
+export class ProcedureStopped extends ProcedureAbort {}
+
+// ---------------------------------------------------------------- cooperative stop
+//
+// A procedure is a server-driven loop of <= 1-5 mm settled steps, not a
+// firmware print job: the machine's stop_print cannot end it (job
+// 5ad5fcce6b3a, 2026-09-06 - three stop_gcode_job calls answered ok:false
+// while the scan kept stepping). stop_gcode_job now records a stop REQUEST;
+// every motion primitive checks it before sending, so the procedure stops at
+// the next step boundary (within one <= 1 mm step or one sensor window),
+// throws ProcedureStopped, and the runner's normal abort path raises the head
+// to the traverse height and keeps every completed result. The first check
+// throws and marks the request acknowledged so the abort path's own moves
+// (raise, retreat) are not refused; a program runner sees the request and
+// stops regardless of on_fail.
+interface StopRequest {
+    reason: string;
+    requestedAt: number;
+    acknowledged: boolean;
+}
+
+let stopRequest: StopRequest | null = null;
+
+export function requestProcedureStop(reason: string): StopRequest {
+    if (!stopRequest) {
+        stopRequest = { reason, requestedAt: Date.now(), acknowledged: false };
+    }
+    return stopRequest;
+}
+
+export function clearProcedureStop(): void {
+    stopRequest = null;
+}
+
+export function procedureStopRequested(): StopRequest | null {
+    return stopRequest;
+}
+
+/** Called at every step boundary: throws ProcedureStopped once per request. */
+export function checkProcedureStop(): void {
+    if (stopRequest && !stopRequest.acknowledged) {
+        stopRequest.acknowledged = true;
+        throw new ProcedureStopped(`Stopped on request (${stopRequest.reason}) at a step boundary, `
+            + `${Date.now() - stopRequest.requestedAt} ms after the request. Raising to the traverse height; completed results kept.`);
+    }
+}
 
 export interface StepResult {
     contact: boolean;
@@ -421,6 +477,7 @@ export async function moveMachineSettled(
     feed: number,
     options: MoveOptions = {}
 ): Promise<void> {
+    checkProcedureStop();
     probeFeedService.motionBegin();
     try {
         await moveMachineSettledUnguarded(tool, target, feed, options);
@@ -448,6 +505,7 @@ export async function senseAfter(
     stepIssuedAt: number,
     delayMs: number
 ): Promise<StepResult> {
+    checkProcedureStop();
     const list = Array.isArray(channels) ? channels : [channels];
     const startedAt = Date.now();
     traceMark('sense-start');
@@ -589,6 +647,7 @@ const ROTATE_TIMEOUT_MS = 120000;
  * armed, no contact is expected).
  */
 export async function rotateB(tool: string, targetDeg: number, requireZAtLeast: number): Promise<{ from: number | null; to: number; verifiedBy: 'echo' | 'heartbeat' }> {
+    checkProcedureStop();
     probeFeedService.assertNoOvertravel();
     const known = knownMachinePosition();
     if (known.position.z === null || known.position.z < requireZAtLeast - 1e-9) {

--- a/src/server/services/mcp/programGroups.ts
+++ b/src/server/services/mcp/programGroups.ts
@@ -1,0 +1,127 @@
+/* eslint-disable camelcase */
+// Pure expansion of probe_program `group` ops (mcp/48 W5): the same
+// sub-program run at several rotary angles. Expanded BEFORE validation, so
+// the planner, the confirm page and the runner see plain ops only.
+//
+//   { id: "faces", kind: "group", for_b: [0, 90, 180, 270], ops: [ ...inner ops... ] }
+//
+// becomes, per angle: a rotate_b op `<gid>_rot_b<angle>`, then every inner
+// op with the literal `${b}` replaced by the angle in EVERY string (ids,
+// names, reference paths) and, for inner ids that carry no `${b}`, an
+// automatic `_b<angle>` suffix - references to those ids inside the same
+// group are rewritten to the suffixed id so the agent writes the sub-program
+// once. References to ops OUTSIDE the group are left alone.
+
+export class GroupExpandError extends Error {}
+
+// The literal "${b}" token agents write, without the linter reading it as a template literal.
+const B_TOKEN = ['$', '{b}'].join('');
+
+const REF_KEYS = ['from', 'mid', 'diff', 'min', 'max', 'plus', 'minus'];
+
+function substituteB(value: unknown, angle: number): unknown {
+    if (typeof value === 'string') {
+        return value.replace(/\$\{b\}/g, String(angle));
+    }
+    if (Array.isArray(value)) {
+        return value.map((v) => substituteB(v, angle));
+    }
+    if (value && typeof value === 'object') {
+        const out: { [k: string]: unknown } = {};
+        for (const [k, v] of Object.entries(value as object)) {
+            out[k] = substituteB(v, angle);
+        }
+        return out;
+    }
+    return value;
+}
+
+/** Rewrite "<id>.<path>" reference paths whose id is in `rename`. */
+function renameRefIds(value: unknown, rename: { [id: string]: string }, key: string | null = null): unknown {
+    if (typeof value === 'string' && key !== null && REF_KEYS.includes(key)) {
+        const dot = value.indexOf('.');
+        if (dot > 0) {
+            const id = value.slice(0, dot);
+            if (id in rename) {
+                return `${rename[id]}${value.slice(dot)}`;
+            }
+        }
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value.map((v) => renameRefIds(v, rename, key));
+    }
+    if (value && typeof value === 'object') {
+        const out: { [k: string]: unknown } = {};
+        for (const [k, v] of Object.entries(value as object)) {
+            out[k] = renameRefIds(v, rename, k);
+        }
+        return out;
+    }
+    return value;
+}
+
+export interface ExpandedGroup {
+    id: string;
+    angles: number[];
+    innerCount: number;
+}
+
+/**
+ * Expand every `group` op in place order. Returns the flat op list and a
+ * description of each group for the confirm page header.
+ */
+export function expandProgramGroups(rawOps: unknown[]): { ops: unknown[]; groups: ExpandedGroup[] } {
+    const ops: unknown[] = [];
+    const groups: ExpandedGroup[] = [];
+    rawOps.forEach((raw, index) => {
+        const op = raw as { [key: string]: unknown } | null;
+        if (!op || typeof op !== 'object' || op.kind !== 'group') {
+            ops.push(raw);
+            return;
+        }
+        const where = `ops[${index}] (group)`;
+        const gid = String(op.id || '');
+        if (!/^[A-Za-z][A-Za-z0-9_-]{0,31}$/.test(gid)) {
+            throw new GroupExpandError(`${where}: id is required (letters, digits, _ or -, max 32 chars).`);
+        }
+        const angles = Array.isArray(op.for_b) ? op.for_b.map(Number) : [];
+        if (angles.length < 1 || angles.length > 8 || angles.some((a) => !Number.isFinite(a) || a < -360 || a > 360)) {
+            throw new GroupExpandError(`${where}: for_b must list 1-8 absolute B angles in -360..360.`);
+        }
+        if (new Set(angles).size !== angles.length) {
+            throw new GroupExpandError(`${where}: for_b repeats an angle.`);
+        }
+        const inner = Array.isArray(op.ops) ? op.ops : [];
+        if (inner.length < 1 || inner.length > 20) {
+            throw new GroupExpandError(`${where}: ops must hold 1-20 inner operations.`);
+        }
+        const innerIds = inner.map((o) => String((o as { id?: unknown } | null)?.id || ''));
+        if (innerIds.some((id) => !id)) {
+            throw new GroupExpandError(`${where}: every inner op needs an id.`);
+        }
+        if (inner.some((o) => (o as { kind?: unknown } | null)?.kind === 'group')) {
+            throw new GroupExpandError(`${where}: groups do not nest.`);
+        }
+        for (const angle of angles) {
+            const rename: { [id: string]: string } = {};
+            for (const id of innerIds) {
+                if (!id.includes(B_TOKEN)) {
+                    rename[id] = `${id}_b${angle}`;
+                }
+            }
+            ops.push({ id: `${gid}_rot_b${angle}`, kind: 'rotate_b', b: angle });
+            for (const o of inner) {
+                const withB = substituteB(o, angle) as { [key: string]: unknown };
+                const renamed = renameRefIds(withB, rename) as { [key: string]: unknown };
+                const id = String(renamed.id);
+                if (id in rename) {
+                    renamed.id = rename[id];
+                }
+                ops.push(renamed);
+            }
+        }
+        groups.push({ id: gid, angles, innerCount: inner.length });
+    });
+    return { ops, groups };
+}

--- a/src/server/services/mcp/programRefs.ts
+++ b/src/server/services/mcp/programRefs.ts
@@ -1,20 +1,77 @@
 // Pure helpers for probe_program references (no machine, no server
 // imports) so they can be unit-tested: RefSpec parsing, dotted-path lookup
 // into earlier op results, bounded resolution, argument substitution.
+//
+// A reference names ONE operator (exactly one of from / mid / diff / min /
+// max), optional scale and plus/minus adjustments (numbers, or paths into
+// earlier results so "axis + half-width" is one reference), and REQUIRED
+// operator-approved bounds. Resolution stays one level deep on purpose: the
+// confirm page prints the whole formula on one line and the operator must be
+// able to read it at a glance.
 
 export class RefResolveError extends Error {}
 
+export type RefOperator = 'from' | 'mid' | 'diff' | 'min' | 'max';
+
+export const REF_OPERATORS: RefOperator[] = ['from', 'mid', 'diff', 'min', 'max'];
+
 export interface RefSpec {
     /** "<opId>.<path>" into an earlier op's result, e.g. "c90.top.z" (sequence probe by name) or "ns90.summary.zMean". */
-    from: string;
-    plus?: number;
-    minus?: number;
-    /** REQUIRED operator-approved bounds on the resolved value (after plus/minus). */
+    from?: string;
+    /** (a + b) / 2 of two paths, e.g. the stock centre from two side contacts. */
+    mid?: string[];
+    /** a - b of two paths (times scale), e.g. the width from two side contacts, half-width with scale 0.5. */
+    diff?: string[];
+    /** Smallest / largest of two or more paths. */
+    min?: string[];
+    max?: string[];
+    /** Multiplier applied to the operator result before plus/minus (default 1). */
+    scale?: number;
+    /** Added / subtracted after the operator: a number, or a path into earlier results. */
+    plus?: number | string;
+    minus?: number | string;
+    /** REQUIRED operator-approved bounds on the resolved value (after scale/plus/minus). */
     between: [number, number];
 }
 
+const PATH_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*\./;
+
+/** The operator a reference uses; null when it is not exactly one of them. */
+export function refOperator(value: unknown): RefOperator | null {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const present = REF_OPERATORS.filter((key) => (value as { [k: string]: unknown })[key] !== undefined);
+    return present.length === 1 ? present[0] : null;
+}
+
 export function isRef(value: unknown): value is RefSpec {
-    return !!value && typeof value === 'object' && typeof (value as RefSpec).from === 'string';
+    return refOperator(value) !== null;
+}
+
+/** Every path a reference reads (operator operands plus path-valued plus/minus). */
+export function refOperands(ref: RefSpec): string[] {
+    const op = refOperator(ref);
+    const paths: string[] = [];
+    if (op === 'from') {
+        paths.push(String(ref.from));
+    } else if (op) {
+        for (const p of (ref[op] as unknown[]) || []) {
+            paths.push(String(p));
+        }
+    }
+    if (typeof ref.plus === 'string') {
+        paths.push(ref.plus);
+    }
+    if (typeof ref.minus === 'string') {
+        paths.push(ref.minus);
+    }
+    return paths;
+}
+
+/** Op ids a reference depends on (first path segment of every operand). */
+export function refOpIds(ref: RefSpec): string[] {
+    return Array.from(new Set(refOperands(ref).map((p) => p.split('.')[0])));
 }
 
 export function round3(value: number): number {
@@ -46,20 +103,18 @@ export function lookupPath(root: unknown, path: string[]): unknown {
 }
 
 /**
- * Resolve one reference against the results so far. Sequence probe results
- * are addressable as "<seqId>.<probeName>.z" (contactMachine.z) as well as
- * by the raw shape.
+ * Read one numeric path from the results so far. Sequence probe results are
+ * addressable as "<seqId>.<probeName>.z" (contactMachine.z; likewise .x/.y)
+ * as well as by the raw shape.
  */
-export function resolveRef(ref: RefSpec, results: { [opId: string]: unknown }): { value: number; source: string } {
-    const parts = ref.from.split('.');
+export function lookupNumber(path: string, results: { [opId: string]: unknown }): number {
+    const parts = path.split('.');
     const opId = parts[0];
     if (!(opId in results)) {
-        throw new RefResolveError(`Reference "${ref.from}": op "${opId}" has no result yet (order the program so it runs first).`);
+        throw new RefResolveError(`Reference "${path}": op "${opId}" has no result yet (order the program so it runs first).`);
     }
     let raw = lookupPath(results[opId], parts.slice(1));
     if ((raw === undefined || raw === null) && parts.length >= 3) {
-        // Shorthands for sequence probes: "<seq>.<probe>.z" or
-        // "<seq>.results.<probe>.z" mean results[<probe>].contactMachine.z.
         const last = parts[parts.length - 1];
         const head = parts.slice(1, -1);
         const candidates = [
@@ -75,62 +130,145 @@ export function resolveRef(ref: RefSpec, results: { [opId: string]: unknown }): 
         }
     }
     const numeric = Number(raw);
-    if (raw === undefined || raw === null || !Number.isFinite(numeric)) {
-        throw new RefResolveError(`Reference "${ref.from}" did not resolve to a number (got ${JSON.stringify(raw)}).`);
+    if (raw === undefined || raw === null || typeof raw === 'boolean' || !Number.isFinite(numeric)) {
+        throw new RefResolveError(`Reference "${path}" did not resolve to a number (got ${JSON.stringify(raw)}).`);
     }
-    let value = numeric + (Number(ref.plus) || 0) - (Number(ref.minus) || 0);
+    return numeric;
+}
+
+function adjustmentText(ref: RefSpec, values?: { [path: string]: number }): string {
+    const show = (term: number | string | undefined) => {
+        if (term === undefined) {
+            return null;
+        }
+        if (typeof term === 'string') {
+            return values && term in values ? `${term}=${values[term]}` : term;
+        }
+        return Number(term) ? String(term) : null;
+    };
+    const plus = show(ref.plus);
+    const minus = show(ref.minus);
+    return `${plus ? ` + ${plus}` : ''}${minus ? ` - ${minus}` : ''}`;
+}
+
+/** Human-readable formula for the confirm page (no values). */
+export function describeRef(ref: RefSpec): string {
+    const op = refOperator(ref) as RefOperator;
+    const scale = ref.scale !== undefined && Number(ref.scale) !== 1 ? ` * ${ref.scale}` : '';
+    const head = op === 'from' ? String(ref.from) : `${op}(${(ref[op] as string[]).join(', ')})`;
+    return `${head}${scale}${adjustmentText(ref)}`;
+}
+
+/** Resolve one reference against the results so far. */
+export function resolveRef(ref: RefSpec, results: { [opId: string]: unknown }): { value: number; source: string } {
+    const op = refOperator(ref);
+    if (!op) {
+        throw new RefResolveError('A reference needs exactly one of from / mid / diff / min / max.');
+    }
+    const values: { [path: string]: number } = {};
+    for (const path of refOperands(ref)) {
+        values[path] = lookupNumber(path, results);
+    }
+    let base: number;
+    let head: string;
+    if (op === 'from') {
+        base = values[String(ref.from)];
+        head = String(ref.from);
+    } else {
+        const operands = (ref[op] as string[]).map((p) => values[p]);
+        if (op === 'mid') {
+            base = (operands[0] + operands[1]) / 2;
+        } else if (op === 'diff') {
+            base = operands[0] - operands[1];
+        } else if (op === 'min') {
+            base = Math.min(...operands);
+        } else {
+            base = Math.max(...operands);
+        }
+        head = `${op}(${(ref[op] as string[]).map((p) => `${p}=${values[p]}`).join(', ')})`;
+    }
+    const scale = ref.scale === undefined ? 1 : Number(ref.scale);
+    const term = (t: number | string | undefined) => (typeof t === 'string' ? values[t] : (Number(t) || 0));
+    let value = base * scale + term(ref.plus) - term(ref.minus);
     value = round3(value);
     const [lo, hi] = ref.between;
     if (value < lo - 1e-9 || value > hi + 1e-9) {
-        throw new RefResolveError(`Reference "${ref.from}" resolved to ${value}, outside the approved bounds [${lo}, ${hi}] - refusing the op.`);
+        throw new RefResolveError(`Reference ${describeRef(ref)} resolved to ${value}, outside the approved bounds [${lo}, ${hi}] - refusing the op.`);
     }
-    return { value, source: `${ref.from}${ref.plus ? ` + ${ref.plus}` : ''}${ref.minus ? ` - ${ref.minus}` : ''} = ${value}` };
+    const scaleText = scale !== 1 ? ` * ${scale}` : '';
+    return { value, source: `${head}${scaleText}${adjustmentText(ref, values)} = ${value}` };
 }
 
 export function refMidpoint(ref: RefSpec): number {
     return round3((ref.between[0] + ref.between[1]) / 2);
 }
 
-/** Replace every reference in an args object (one level deep, plus `steps[].z`) with `pick(ref)`. */
+function substituteDeep(
+    value: unknown,
+    path: string,
+    pick: (ref: RefSpec, path: string) => number,
+    refs: { path: string; ref: RefSpec }[]
+): unknown {
+    if (isRef(value)) {
+        refs.push({ path, ref: value });
+        return pick(value, path);
+    }
+    if (Array.isArray(value)) {
+        return value.map((item, index) => substituteDeep(item, `${path}[${index}]`, pick, refs));
+    }
+    if (value && typeof value === 'object') {
+        const out: { [k: string]: unknown } = {};
+        for (const [k, v] of Object.entries(value as object)) {
+            out[k] = substituteDeep(v, path ? `${path}.${k}` : k, pick, refs);
+        }
+        return out;
+    }
+    return value;
+}
+
+/**
+ * Replace every reference anywhere in an args object (any depth: top-level
+ * numbers, `steps[1].z`, `expected_profile.circle.center_x`) with `pick(ref)`
+ * and list them with their dotted paths for the confirm page.
+ */
 export function substituteRefs(
     args: { [key: string]: unknown },
     pick: (ref: RefSpec, path: string) => number
 ): { args: { [key: string]: unknown }; refs: { path: string; ref: RefSpec }[] } {
     const refs: { path: string; ref: RefSpec }[] = [];
-    const out: { [key: string]: unknown } = {};
-    for (const [key, value] of Object.entries(args)) {
-        if (isRef(value)) {
-            refs.push({ path: key, ref: value });
-            out[key] = pick(value, key);
-        } else if (key === 'steps' && Array.isArray(value)) {
-            out[key] = value.map((step, index) => {
-                if (step && typeof step === 'object') {
-                    const copy: { [k: string]: unknown } = { ...(step as object) };
-                    for (const [sk, sv] of Object.entries(copy)) {
-                        if (isRef(sv)) {
-                            refs.push({ path: `steps[${index}].${sk}`, ref: sv });
-                            copy[sk] = pick(sv, `steps[${index}].${sk}`);
-                        }
-                    }
-                    return copy;
-                }
-                return step;
-            });
-        } else {
-            out[key] = value;
-        }
-    }
+    const out = substituteDeep(args, '', pick, refs) as { [key: string]: unknown };
     return { args: out, refs };
 }
 
 export function validateRef(ref: RefSpec, where: string): void {
+    const op = refOperator(ref);
+    if (!op) {
+        throw new RefResolveError(`${where}: a reference needs exactly one of "from" (path), "mid" [a, b], "diff" [a, b], "min" [...], "max" [...].`);
+    }
+    if (op !== 'from') {
+        const operands = ref[op];
+        const need = op === 'mid' || op === 'diff' ? 'exactly 2' : 'at least 2';
+        const countOk = Array.isArray(operands) && (op === 'mid' || op === 'diff' ? operands.length === 2 : operands.length >= 2);
+        if (!countOk) {
+            throw new RefResolveError(`${where}: "${op}" needs ${need} paths.`);
+        }
+    }
+    if (ref.scale !== undefined && (!Number.isFinite(Number(ref.scale)) || Number(ref.scale) === 0)) {
+        throw new RefResolveError(`${where}: "scale" must be a non-zero number.`);
+    }
+    for (const term of [ref.plus, ref.minus]) {
+        if (term !== undefined && typeof term !== 'string' && !Number.isFinite(Number(term))) {
+            throw new RefResolveError(`${where}: "plus"/"minus" must be a number or a "<opId>.<path>" string.`);
+        }
+    }
     if (!Array.isArray(ref.between) || ref.between.length !== 2
         || !Number.isFinite(Number(ref.between[0])) || !Number.isFinite(Number(ref.between[1]))
         || Number(ref.between[0]) >= Number(ref.between[1])) {
         throw new RefResolveError(`${where}: a reference needs operator-approved bounds "between": [low, high] (law 3 - the page shows the range).`);
     }
-    if (!/^[A-Za-z][A-Za-z0-9_-]*\./.test(ref.from)) {
-        throw new RefResolveError(`${where}: "from" must be "<opId>.<path>" (e.g. "c90.top.z", "ns90.summary.zMean").`);
+    for (const path of refOperands(ref)) {
+        if (typeof path !== 'string' || !PATH_PATTERN.test(path)) {
+            throw new RefResolveError(`${where}: every reference path must be "<opId>.<path>" (e.g. "c90.top.z", "ns90.summary.zMean"); got ${JSON.stringify(path)}.`);
+        }
     }
 }
-

--- a/src/server/services/mcp/rotaryGeometry.ts
+++ b/src/server/services/mcp/rotaryGeometry.ts
@@ -1,0 +1,187 @@
+/* eslint-disable camelcase */
+// The `axis` namespace is read by agents through snake_case reference paths
+// (axis.z_contact), matching the MCP argument convention.
+import config from '../configstore';
+
+// Jig and tool constants the operator measures once and a rotary program can
+// reference (mcp/48): the rotary axis line and the touch probe's geometry.
+// Set through the MCP tool `set_probe_geometry` (like landmarks: operator
+// knowledge or a measurement, with a reason), overridable per box by
+// environment variables, read back in `get_stored_state`. NOT in the app's
+// settings pane and NEVER a prerequisite: only a reference to `axis.*`
+// needs them, and then a missing value is a staging error naming the tool.
+// Stock size is a property of the stock, not of the jig, so nothing about
+// the stock lives here - a rotation's swept radius is a per-program argument.
+
+export interface RotaryGeometry {
+    /** Machine X of the rotary axis line (the stock runs along machine Y on this jig). */
+    axisX: number;
+    /** PHYSICAL machine Z of the axis (not a toolhead-contact Z). */
+    axisZ: number;
+}
+
+export interface ProbeGeometry {
+    /** Toolhead Z at contact minus this = physical surface Z. Re-measure after any re-fit. */
+    effectiveLength: number;
+    /** Side contacts are centre +/- tipDiameter / 2. */
+    tipDiameter: number | null;
+}
+
+export const GEOMETRY_FIELDS = [
+    { field: 'rotary_axis_x', key: 'mcpRotaryAxisX', env: 'LUBAN_MCP_ROTARY_AXIS_X', min: -50, max: 400 },
+    { field: 'rotary_axis_z_physical', key: 'mcpRotaryAxisZ', env: 'LUBAN_MCP_ROTARY_AXIS_Z', min: 0, max: 400 },
+    { field: 'probe_effective_length', key: 'mcpProbeEffectiveLength', env: 'LUBAN_MCP_PROBE_LENGTH', min: 1, max: 300 },
+    { field: 'probe_tip_diameter', key: 'mcpProbeTipDiameter', env: 'LUBAN_MCP_PROBE_TIP_DIAMETER', min: 0.1, max: 30 },
+] as const;
+
+export type GeometryField = typeof GEOMETRY_FIELDS[number]['field'];
+
+export interface GeometryEntry {
+    value: number | null;
+    source: 'env' | 'config' | 'unset';
+    env: string;
+    range: [number, number];
+    note: string | null;
+    setAt: number | null;
+}
+
+function readSetting(spec: typeof GEOMETRY_FIELDS[number]): { value: number | null; source: 'env' | 'config' | 'unset' } {
+    const env = process.env[spec.env];
+    if (env !== undefined && String(env).trim() !== '') {
+        const n = Number(env);
+        return { value: Number.isFinite(n) ? n : null, source: 'env' };
+    }
+    const stored = config.get(spec.key);
+    if (stored === undefined || stored === null || stored === '') {
+        return { value: null, source: 'unset' };
+    }
+    const n = Number(stored);
+    return { value: Number.isFinite(n) ? n : null, source: 'config' };
+}
+
+export function geometryValue(field: GeometryField): number | null {
+    const spec = GEOMETRY_FIELDS.find((f) => f.field === field);
+    return spec ? readSetting(spec).value : null;
+}
+
+export function rotaryGeometry(): RotaryGeometry | null {
+    const axisX = geometryValue('rotary_axis_x');
+    const axisZ = geometryValue('rotary_axis_z_physical');
+    if (axisX === null || axisZ === null) {
+        return null;
+    }
+    return { axisX, axisZ };
+}
+
+export function probeGeometry(): ProbeGeometry | null {
+    const effectiveLength = geometryValue('probe_effective_length');
+    if (effectiveLength === null) {
+        return null;
+    }
+    return { effectiveLength, tipDiameter: geometryValue('probe_tip_diameter') };
+}
+
+/**
+ * Store operator-stated / measured values (set_probe_geometry). `null` or ''
+ * clears a field. Env-overridden fields are refused so the stored value and
+ * the live value never disagree silently.
+ */
+export function setGeometryValues(
+    values: { [field: string]: unknown },
+    note: string
+): { updated: string[]; cleared: string[] } {
+    const updated: string[] = [];
+    const cleared: string[] = [];
+    for (const spec of GEOMETRY_FIELDS) {
+        if (!(spec.field in values) || values[spec.field] === undefined) {
+            continue;
+        }
+        if (process.env[spec.env] !== undefined && String(process.env[spec.env]).trim() !== '') {
+            throw new Error(`${spec.field} is overridden by the environment variable ${spec.env} on this box; change it there.`);
+        }
+        const raw = values[spec.field];
+        if (raw === null || raw === '') {
+            config.unset(spec.key);
+            config.unset(`${spec.key}Note`);
+            config.unset(`${spec.key}At`);
+            cleared.push(spec.field);
+            continue;
+        }
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n < spec.min || n > spec.max) {
+            throw new Error(`${spec.field} must be a number in ${spec.min}..${spec.max} (got ${JSON.stringify(raw)}).`);
+        }
+        config.set(spec.key, n);
+        config.set(`${spec.key}Note`, note);
+        config.set(`${spec.key}At`, Date.now());
+        updated.push(spec.field);
+    }
+    return { updated, cleared };
+}
+
+/** Everything stored, with provenance, for get_stored_state / set_probe_geometry. */
+export function geometrySettings() {
+    const fields: { [field: string]: GeometryEntry } = {};
+    for (const spec of GEOMETRY_FIELDS) {
+        const note = config.get(`${spec.key}Note`);
+        const at = Number(config.get(`${spec.key}At`));
+        fields[spec.field] = {
+            ...readSetting(spec),
+            env: spec.env,
+            range: [spec.min, spec.max],
+            note: note ? String(note) : null,
+            setAt: Number.isFinite(at) && at > 0 ? at : null,
+        };
+    }
+    return {
+        fields,
+        rotary: rotaryGeometry(),
+        probe: probeGeometry(),
+        note: 'Only programs that reference axis.* need these; B0-only and non-rotary work needs none of them. '
+            + 'Set with set_probe_geometry after measuring (axis Z from an opposite-face pair, axis X from a side pair, '
+            + 'probe length from run_tool_setter accept_probe_contact).',
+    };
+}
+
+export interface AxisNamespace {
+    x: number;
+    z_physical: number;
+    /** Toolhead Z at which the probe tip is on the axis line (z_physical + probe length). */
+    z_contact: number;
+    tip_radius: number | null;
+    probe_length: number;
+}
+
+/**
+ * Namespaces seeded into a program's results before op 1. `axis` exists only
+ * when the rotary axis AND the probe length are known (z_contact needs both);
+ * otherwise a reference to axis.* is refused at staging with the tool named.
+ */
+export function programSeedNamespaces(): { axis?: AxisNamespace } {
+    const rotary = rotaryGeometry();
+    const probe = probeGeometry();
+    if (!rotary || !probe) {
+        return {};
+    }
+    return {
+        axis: {
+            x: rotary.axisX,
+            z_physical: rotary.axisZ,
+            z_contact: Number((rotary.axisZ + probe.effectiveLength).toFixed(3)),
+            tip_radius: probe.tipDiameter === null ? null : Number((probe.tipDiameter / 2).toFixed(3)),
+            probe_length: probe.effectiveLength,
+        },
+    };
+}
+
+/** What a staging error should tell the agent when axis.* is referenced without the values. */
+export function missingGeometryNote(): string {
+    const missing = GEOMETRY_FIELDS
+        .filter((f) => ['rotary_axis_x', 'rotary_axis_z_physical', 'probe_effective_length'].includes(f.field))
+        .filter((f) => readSetting(f).value === null)
+        .map((f) => f.field);
+    return missing.length
+        ? `The "axis" namespace needs ${missing.join(', ')}: measure them and store with set_probe_geometry `
+            + '(or drop the axis.* reference - a program that references only its own earlier ops needs no geometry).'
+        : '';
+}

--- a/src/server/services/mcp/stockGeometry.ts
+++ b/src/server/services/mcp/stockGeometry.ts
@@ -1,0 +1,173 @@
+/* eslint-disable camelcase */
+// Pure derivation of the stock section from a probe_program's results
+// (mcp/48 W4): the numbers the 2026-09-05 four-face report worked out by hand.
+// INFERENCE FOR PLANNING, never a clearance: every value is labelled with
+// the ops it came from and the assumptions (probe names, axis settings).
+//
+// Conventions the derivation relies on (documented in the cnc-probing skill):
+//   - sequence probes named `top` (a -Z probe on the face), `west` / `east`
+//     (+X / -X marches at the sides), `end` (a +Y march onto the free end);
+//   - surface_path ops carry `summary` and `lineFit` (slopeMmPer100Mm);
+//   - every op result is tagged with the B angle it ran at (`b`).
+
+export interface AxisLike {
+    x: number;
+    z_contact: number;
+    tip_radius: number | null;
+}
+
+export interface OpResultForDerivation {
+    id: string;
+    kind: string;
+    b: number | null;
+    result: unknown;
+}
+
+export interface DerivedSection {
+    note: string;
+    assumptions: string[];
+    /** Face height above the axis per B angle (toolhead contact Z - axis.z_contact). */
+    faceHeights: { b: number; op: string; topZ: number; aboveAxisMm: number }[];
+    /** Opposite-face pairs: thickness across the axis and the centring offset toward the first face. */
+    pairs: { b: [number, number]; thicknessMm: number; offsetTowardFirstMm: number }[];
+    /** Side contacts: centre-to-centre width and stock centre X per Y station; physical width = minus the tip diameter (external faces). */
+    widths: { op: string; b: number | null; y: number; westX: number; eastX: number; centreX: number; widthMm: number; widthPhysicalMm: number | null }[];
+    /** Yaw of the side pair: stock centre X change per 100 mm of Y (+ = toward +X as Y decreases, i.e. toward the free end). */
+    yawXPer100Mm: number | null;
+    /** End face Y per X station and its slope (mm per 100 mm of X). */
+    endFace: { op: string; b: number | null; x: number; y: number }[];
+    endSlopeYPer100Mm: number | null;
+    /** Top-face slopes along the path ops, per B. */
+    faceSlopes: { op: string; b: number | null; slopeMmPer100Mm: number; flatnessMm: number | null }[];
+}
+
+interface ProbeEntry { name: string; contactMachine: { x: number; y: number; z: number } }
+
+function probes(result: unknown): ProbeEntry[] {
+    const r = result as { results?: unknown } | null;
+    if (!r || !Array.isArray(r.results)) {
+        return [];
+    }
+    return r.results.filter((p): p is ProbeEntry => !!p && typeof p === 'object'
+        && typeof (p as ProbeEntry).name === 'string' && !!(p as ProbeEntry).contactMachine);
+}
+
+function round3(v: number): number {
+    return Number(v.toFixed(3));
+}
+
+function slopePer100(points: { s: number; v: number }[]): number | null {
+    if (points.length < 2) {
+        return null;
+    }
+    const n = points.length;
+    const ms = points.reduce((a, p) => a + p.s, 0) / n;
+    const mv = points.reduce((a, p) => a + p.v, 0) / n;
+    let num = 0;
+    let den = 0;
+    for (const p of points) {
+        num += (p.s - ms) * (p.v - mv);
+        den += (p.s - ms) * (p.s - ms);
+    }
+    return den < 1e-12 ? null : round3((num / den) * 100);
+}
+
+export function deriveStockSection(ops: OpResultForDerivation[], axis: AxisLike | null): DerivedSection {
+    const assumptions: string[] = [
+        'Probe names carry meaning: "top" = -Z probe on the face, "west"/"east" = side marches (+X / -X), "end" = +Y march onto the free end.',
+        'Every contact is a TOOLHEAD machine Z / tip-centre XY; physical surface = Z - probe length; each external face lies one tip radius INSIDE its contact, so physical width = centre-to-centre minus the tip diameter.',
+    ];
+    const faceHeights: DerivedSection['faceHeights'] = [];
+    const widths: DerivedSection['widths'] = [];
+    const endFace: DerivedSection['endFace'] = [];
+    const faceSlopes: DerivedSection['faceSlopes'] = [];
+    const tipD = axis && axis.tip_radius !== null ? axis.tip_radius * 2 : null;
+
+    for (const op of ops) {
+        if (op.kind === 'sequence') {
+            const list = probes(op.result);
+            for (const p of list.filter((q) => q.name === 'top' || q.name.startsWith('top_'))) {
+                if (axis && op.b !== null) {
+                    faceHeights.push({ b: op.b, op: op.id, topZ: p.contactMachine.z, aboveAxisMm: round3(p.contactMachine.z - axis.z_contact) });
+                }
+            }
+            const wests = list.filter((q) => q.name === 'west' || q.name.startsWith('west_'));
+            const easts = list.filter((q) => q.name === 'east' || q.name.startsWith('east_'));
+            for (const w of wests) {
+                const e = easts.find((q) => Math.abs(q.contactMachine.y - w.contactMachine.y) < 1);
+                if (e) {
+                    const width = round3(e.contactMachine.x - w.contactMachine.x);
+                    widths.push({
+                        op: op.id,
+                        b: op.b,
+                        y: w.contactMachine.y,
+                        westX: w.contactMachine.x,
+                        eastX: e.contactMachine.x,
+                        centreX: round3((w.contactMachine.x + e.contactMachine.x) / 2),
+                        widthMm: width,
+                        widthPhysicalMm: tipD === null ? null : round3(width - tipD),
+                    });
+                }
+            }
+            for (const p of list.filter((q) => q.name === 'end' || q.name.startsWith('end_'))) {
+                endFace.push({ op: op.id, b: op.b, x: p.contactMachine.x, y: p.contactMachine.y });
+            }
+        } else if (op.kind === 'surface_path') {
+            const r = op.result as { lineFit?: { slopeMmPer100Mm?: number; flatnessMm?: number } | null } | null;
+            if (r && r.lineFit && typeof r.lineFit.slopeMmPer100Mm === 'number') {
+                faceSlopes.push({ op: op.id, b: op.b, slopeMmPer100Mm: r.lineFit.slopeMmPer100Mm, flatnessMm: r.lineFit.flatnessMm ?? null });
+            }
+        }
+    }
+
+    const pairs: DerivedSection['pairs'] = [];
+    const seen = new Set<string>();
+    for (const a of faceHeights) {
+        const opposite = ((a.b + 180) % 360 + 360) % 360;
+        const partner = faceHeights.find((f) => (((f.b % 360) + 360) % 360) === opposite);
+        const key = [a.b, opposite].sort((p, q) => p - q).join('/');
+        if (partner && !seen.has(key)) {
+            seen.add(key);
+            pairs.push({
+                b: [a.b, partner.b],
+                thicknessMm: round3(a.aboveAxisMm + partner.aboveAxisMm),
+                offsetTowardFirstMm: round3((a.aboveAxisMm - partner.aboveAxisMm) / 2),
+            });
+        }
+    }
+    if (axis) {
+        assumptions.push(`Face heights use axis.z_contact ${axis.z_contact} (rotary axis Z + probe length from the settings).`);
+    } else {
+        assumptions.push('Rotary axis not configured: face heights and thicknesses are not derived.');
+    }
+
+    // Yaw: centre X vs Y across the side pairs (Y decreasing toward the free end).
+    const yaw = slopePer100(widths.map((w) => ({ s: -w.y, v: w.centreX })));
+    const endSlope = slopePer100(endFace.map((e) => ({ s: e.x, v: e.y })));
+
+    const parts: string[] = [];
+    for (const p of pairs) {
+        parts.push(`B${p.b[0]}/B${p.b[1]} thickness ${p.thicknessMm} mm (offset ${p.offsetTowardFirstMm} toward B${p.b[0]})`);
+    }
+    if (widths.length) {
+        const w0 = widths[0];
+        parts.push(`width ${w0.widthMm} mm centre-to-centre${w0.widthPhysicalMm === null ? '' : ` (${w0.widthPhysicalMm} physical, minus the tip)`}, centre X ${w0.centreX}`);
+    }
+    if (yaw !== null) {
+        parts.push(`yaw ${yaw} mm/100 mm in X toward the free end`);
+    }
+    if (endSlope !== null) {
+        parts.push(`end face ${endSlope} mm/100 mm in Y across X`);
+    }
+    return {
+        note: parts.length ? `Derived section (planning inference, NOT clearance): ${parts.join('; ')}.` : 'Derived section: not enough named probes to derive anything.',
+        assumptions,
+        faceHeights,
+        pairs,
+        widths,
+        yawXPer100Mm: yaw,
+        endFace,
+        endSlopeYPer100Mm: endSlope,
+        faceSlopes,
+    };
+}

--- a/src/server/services/mcp/surfaceScan.ts
+++ b/src/server/services/mcp/surfaceScan.ts
@@ -415,6 +415,9 @@ export interface ZSummary {
     zMean: number;
     highest: string;
     lowest: string;
+    /** Machine XY of the highest / lowest contact (mcp/48: locates a cylinder's crown or a face's high edge by reference). */
+    highestAt: { x: number; y: number };
+    lowestAt: { x: number; y: number };
 }
 
 export function summarizeZ(samples: ContactSample[]): ZSummary | null {
@@ -441,7 +444,41 @@ export function summarizeZ(samples: ContactSample[]): ZSummary | null {
         zMean: round3(sum / samples.length),
         highest: hi.label,
         lowest: lo.label,
+        highestAt: { x: hi.x, y: hi.y },
+        lowestAt: { x: lo.x, y: lo.y },
     };
+}
+
+// ---------------------------------------------------------------- expected profiles
+
+/**
+ * Expected contact profile of a CYLINDER lying along machine Y (the rotary
+ * axis): a circle in the XZ plane. `centerZContact` is the toolhead Z with
+ * the probe tip on the axis line (axis.z_contact); `radius` the stock
+ * radius; `tipRadius` the probe tip's. Toolhead Z at contact over lateral
+ * offset d from the axis: the tip sphere's centre rides a circle of radius
+ * R + rt about the axis, and the contact Z convention (toolhead Z with the
+ * tip's lowest point on the surface) subtracts rt again -
+ * z(d) = centerZContact + sqrt((R + rt)^2 - d^2) - rt, so z(0) = centre + R.
+ */
+export interface CircleProfile {
+    kind: 'circle';
+    centerX: number;
+    centerZContact: number;
+    radius: number;
+    tipRadius: number;
+}
+
+/** Contact angle limit: beyond ~45 deg from the crown the tip glances and the side channel would read a crash. */
+export const CIRCLE_MAX_OFFSET_FRACTION = 0.7;
+
+export function circleExpectedZ(profile: CircleProfile, x: number): number | null {
+    const d = x - profile.centerX;
+    const r = profile.radius + profile.tipRadius;
+    if (Math.abs(d) > profile.radius * CIRCLE_MAX_OFFSET_FRACTION + 1e-9 || Math.abs(d) >= r) {
+        return null;
+    }
+    return round3(profile.centerZContact + Math.sqrt(r * r - d * d) - profile.tipRadius);
 }
 
 export interface LineFit {

--- a/src/server/services/mcp/tools/gcode.ts
+++ b/src/server/services/mcp/tools/gcode.ts
@@ -4,10 +4,11 @@ import * as fs from 'fs-extra';
 
 import logger from '../../../lib/logger';
 import { connectionManager } from '../../machine/ConnectionManager';
-import { McpJob, approvalHandoff, jobManager } from '../jobs';
+import { McpJob, TERMINAL_JOB_STATES, approvalHandoff, jobManager } from '../jobs';
 import { summarizeJobTiming } from '../jobTiming';
 import { matchFrame } from '../positionOfRecord';
 import { probeFeedService } from '../probeFeed';
+import { clearProcedureStop, procedureStopRequested, requestProcedureStop } from '../probing';
 import { McpToolError, ToolRegistry } from '../registry';
 import { validateGcode } from '../validator';
 import { GcodeChannel, sendGcodeVisible } from './camera';
@@ -390,6 +391,7 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                 // result. The outcome lands on the job record; this call waits
                 // a bounded time and returns the result if it arrived, else a
                 // "running" status to long-poll with get_gcode_job_status.
+                clearProcedureStop();
                 const finished = job.runner()
                     .then((outcome) => {
                         // Where the time went, from the job's own events, so
@@ -402,14 +404,28 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
                         return { ok: true as const, outcome };
                     })
                     .catch((err: Error) => {
-                        job.state = 'start_failed';
+                        // What the procedure measured before it ended stays on
+                        // the record (stations, contacts, completed ops).
+                        const partial = (err as { partial?: object }).partial;
+                        if (partial) {
+                            job.result = { ...partial, timing: summarizeJobTiming(job.events) };
+                        }
                         job.error = err.message;
                         job.endedAt = Date.now();
-                        jobManager.appendEvent(job, 'failed', { note: err.message });
-                        log.error(`Procedure job ${job.id} failed: ${err.message}`);
+                        const stop = procedureStopRequested();
+                        if (stop) {
+                            job.state = 'stopped';
+                            jobManager.appendEvent(job, 'stopped', { note: `stopped on request (${stop.reason}): ${err.message}` });
+                            log.info(`Procedure job ${job.id} stopped on request: ${err.message}`);
+                        } else {
+                            job.state = 'start_failed';
+                            jobManager.appendEvent(job, 'failed', { note: err.message });
+                            log.error(`Procedure job ${job.id} failed: ${err.message}`);
+                        }
                         return { ok: false as const, error: err.message };
                     })
                     .finally(() => {
+                        clearProcedureStop();
                         if (jobManager.getActive() === job) {
                             jobManager.setActive(null);
                         }
@@ -806,19 +822,54 @@ export function registerGcodeTools(registry: ToolRegistry, getConfirmBaseUrl: ()
 
     registry.register({
         name: 'stop_gcode_job',
-        description: 'Stop the running job on the machine. Stopping needs no confirmation.',
+        description: 'Stop a running job. Stopping needs no confirmation. A PROCEDURE (probe_*, probe_program, '
+            + 'run_tool_setter, survey) is a server-driven loop, so it stops at the next step boundary (within one '
+            + '<= 1 mm step or sensor window), raises the head to the traverse height and keeps every completed '
+            + 'station / contact / op on the job record (result, state "stopped"); this call waits up to wait_ms for '
+            + 'that. A FILE job is stopped on the machine (firmware stop_print). Result: {ok, stopped, stopping, job}.',
         inputSchema: {
             type: 'object',
             properties: {
-                job_id: { type: 'string', description: 'Job to mark stopped; the machine stop is global.' },
+                job_id: { type: 'string', description: 'Job to stop (procedures: the running procedure; file jobs: the machine stop is global).' },
+                wait_ms: { type: 'number', description: 'Procedures: how long to wait for the stop to complete (default 20000, max 120000).' },
             },
             required: ['job_id'],
             additionalProperties: false,
         },
-        handler: async (args: { job_id?: string }) => {
+        handler: async (args: { job_id?: string; wait_ms?: number }) => {
             const job = jobManager.get(String(args.job_id || ''));
             if (!job) {
                 throw new McpToolError('Unknown job_id.');
+            }
+            if (job.kind === 'procedure') {
+                if (TERMINAL_JOB_STATES.includes(job.state)) {
+                    return { ok: true, stopped: true, stopping: false, note: `Procedure already ${job.state}.`, job: jobManager.describe(job) };
+                }
+                if (job.state !== 'started') {
+                    // Not running yet: withdraw it so the approval cannot start it later.
+                    job.state = 'stopped';
+                    job.endedAt = Date.now();
+                    jobManager.appendEvent(job, 'stopped', { note: 'withdrawn by the agent before it started' });
+                    return { ok: true, stopped: true, stopping: false, note: 'Procedure withdrawn before it started.', job: jobManager.describe(job) };
+                }
+                const request = requestProcedureStop('stop_gcode_job by the agent');
+                jobManager.appendEvent(job, 'stop-requested', { note: 'stop requested by the agent; the runner stops at the next step boundary and raises' });
+                const waitMs = Math.min(Math.max(Number(args.wait_ms) || 20000, 0), 120000);
+                const deadline = Date.now() + waitMs;
+                while (!TERMINAL_JOB_STATES.includes(job.state) && Date.now() < deadline) {
+                    await sleep(250);
+                }
+                const stopped = TERMINAL_JOB_STATES.includes(job.state);
+                return {
+                    ok: true,
+                    stopped,
+                    stopping: !stopped,
+                    requestedAt: request.requestedAt,
+                    note: stopped
+                        ? `Procedure ${job.state}; completed measurements are in result (${job.error || 'no error'}).`
+                        : `Stop requested ${Date.now() - request.requestedAt} ms ago; the runner is finishing its current step and raising. Long-poll get_gcode_job_status.`,
+                    job: jobManager.describe(job),
+                };
             }
             const channel = getJobChannel();
             if (typeof channel.stopGcodeJob !== 'function') {

--- a/src/server/services/mcp/tools/landmarks.ts
+++ b/src/server/services/mcp/tools/landmarks.ts
@@ -6,6 +6,7 @@ import { calibrationStore } from '../calibration';
 import { Landmark, landmarkStore } from '../landmarks';
 import { probeFeedService } from '../probeFeed';
 import { McpToolError, ToolRegistry } from '../registry';
+import { GEOMETRY_FIELDS, geometrySettings, setGeometryValues } from '../rotaryGeometry';
 import { getToolSetterConfig } from '../toolSetter';
 import { readAppMachineSettings } from './machine';
 
@@ -80,6 +81,51 @@ export function registerLandmarkTools(registry: ToolRegistry): void {
     });
 
     registry.register({
+        name: 'set_probe_geometry',
+        description: 'Store the jig/tool constants a rotary probe_program may reference as the "axis" namespace: '
+            + 'rotary_axis_x (machine X of the axis line), rotary_axis_z_physical (PHYSICAL machine Z of the axis, '
+            + 'e.g. from an opposite-face pair: (topA + topB)/2 - probe length), probe_effective_length (toolhead Z at '
+            + 'contact minus this = surface; run_tool_setter accept_probe_contact measures it), probe_tip_diameter. '
+            + 'Operator-stated or MEASURED values only, with the reason - like set_landmark. Omit a field to leave it; '
+            + 'null clears it. None of these is a prerequisite for probing: only a program that references axis.* '
+            + 'needs them; B0-only, stationary or off-rotary work needs nothing here. Stock size is never stored '
+            + '(a rotation\'s swept radius is a per-program argument).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                rotary_axis_x: { type: ['number', 'null'], description: 'Machine X of the rotary axis line.' },
+                rotary_axis_z_physical: { type: ['number', 'null'], description: 'Physical machine Z of the axis (not a contact Z).' },
+                probe_effective_length: { type: ['number', 'null'], description: 'Probe effective length in mm (this fitting).' },
+                probe_tip_diameter: { type: ['number', 'null'], description: 'Probe tip diameter in mm.' },
+                reason: { type: 'string', description: 'How the values were obtained (which job / measurement / operator statement).' },
+            },
+            required: ['reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            const reason = String(args.reason || '').trim();
+            if (!reason) {
+                throw new McpToolError('reason is required: say how the values were measured or who stated them.');
+            }
+            const values: { [field: string]: unknown } = {};
+            for (const spec of GEOMETRY_FIELDS) {
+                if (args[spec.field] !== undefined) {
+                    values[spec.field] = args[spec.field];
+                }
+            }
+            if (!Object.keys(values).length) {
+                throw new McpToolError(`Nothing to set: pass one or more of ${GEOMETRY_FIELDS.map((f) => f.field).join(', ')}.`);
+            }
+            try {
+                const outcome = setGeometryValues(values, reason);
+                return { ...outcome, geometry: geometrySettings() };
+            } catch (err) {
+                throw new McpToolError((err as Error).message);
+            }
+        },
+    });
+
+    registry.register({
         name: 'delete_landmark',
         description: 'Delete one stored landmark by id or name.',
         inputSchema: {
@@ -131,6 +177,9 @@ export function registerLandmarkTools(registry: ToolRegistry): void {
                 installedModules: (readAppMachineSettings() || { modules: [] }).modules,
                 probeFeed: probeFeedService.status(),
                 toolSetter: getToolSetterConfig(),
+                // Operator-measured jig/tool constants (Settings -> MCP Server ->
+                // Rotary and probe geometry); programs read them as `axis.*`.
+                geometry: geometrySettings(),
             };
         },
     });

--- a/src/server/services/mcp/tools/probing.ts
+++ b/src/server/services/mcp/tools/probing.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import DataStorage from '../../../DataStorage';
 import { connectionManager } from '../../machine/ConnectionManager';
 import { captureFrame } from '../camera';
-import { jobManager } from '../jobs';
+import { jobEventLimit, jobManager } from '../jobs';
 import { describeProbeCirclePlanAsGcode, planProbeCircle, runProbeCircleProcedure } from '../probeCircle';
 import { describeProbePlanAsGcode, planProbePoint, runProbePointProcedure } from '../probeTool';
 import { describeProbeSequencePlanAsGcode, planProbeSequence, runProbeSequenceProcedure } from '../probeSequence';
@@ -18,6 +18,7 @@ import {
     planProbeSurfacePath,
     runProbeSurfaceProcedure,
 } from '../probeSurface';
+import { describeProbeOutlinePlanAsGcode, planProbeOutline, runProbeOutlineProcedure } from '../probeOutline';
 import { describeProbeProgramAsGcode, planProbeProgram, runProbeProgramProcedure } from '../probeProgram';
 import { describeProbeVectorPlanAsGcode, planProbeVector, runProbeVectorProcedure } from '../probeVector';
 import { probeFeedService } from '../probeFeed';
@@ -182,6 +183,12 @@ ${describeProbeVectorPlanAsGcode(plan)}`;
                             dy: { type: 'number', description: 'probe: direction Y component.' },
                             dz: { type: 'number', description: 'probe: direction Z component (<= 0).' },
                             max_travel_mm: { type: 'number', description: 'probe: hard travel limit (1-150).' },
+                            on_miss: {
+                                type: 'string',
+                                enum: ['continue', 'abort'],
+                                description: 'probe: reaching max_travel_mm without contact records a no_contact result and continues '
+                                    + '(default) or aborts the sequence. A later reference to a missed probe is refused at that op.',
+                            },
                         },
                         required: ['kind'],
                         additionalProperties: false,
@@ -376,6 +383,24 @@ ${describeProbeCirclePlanAsGcode(plan)}`;
                 + 'expected_z_machine for station 1) and fine steps take over, down to slow_zone + 2 x coarse below it '
                 + '(coarse resumes lower). Caps the press into the probe at one fine step where the surface is where '
                 + 'expected. Default 1, min 0.3, max z_safe_delta_mm.',
+        },
+        hop_mode: {
+            type: 'string',
+            enum: ['guarded', 'stepped'],
+            description: 'Travel between stations: "guarded" (default) hops at last contact + z_safe_delta_mm expecting no contact '
+                + '(a contact aborts); "stepped" travels at last contact + hop_lift_mm as a touch-probing traverse (1 mm steps, '
+                + 'probe expected) that backs off, lifts hop_lift_mm and continues on contact - the height follows the surface '
+                + 'in steps, gentle over a slope or one lift at the wall of a hole, instead of a fixed clearance.',
+        },
+        hop_lift_mm: { type: 'number', description: 'stepped hop_mode: lift per contact and travel height above the last contact, default 2 (0.5-10).' },
+        expected_profile: {
+            type: 'object',
+            description: 'Optional surface MODEL for curved stock: {"circle": {"center_x", "center_z_contact", "radius", '
+                + '"tip_radius"?}} = a cylinder along machine Y (the rotary axis) with the given axis X, toolhead Z with the '
+                + 'tip on the axis (axis.z_contact when the geometry is configured) and stock radius (operator-bounded). '
+                + 'Every station then gets its own expected contact Z from the model (slow zone + max_drop band follow it, '
+                + 'not the previous station); stations more than 0.7 x radius off the axis are refused (the tip would '
+                + 'glance). In a probe_program the numbers may be references.',
         },
         expected_z_machine: {
             type: 'number',
@@ -651,15 +676,94 @@ ${describeProbeSurfacePlanAsGcode(plan)}`;
     });
 
     registry.register({
+        name: 'probe_stock_outline',
+        description: 'Stage ONE approved procedure that finds a block\'s top, true outline and CENTRE from an ESTIMATE of '
+            + 'where it is and how big it is - no re-probing the centre for every side. 1) TOP: -Z marches at top_points '
+            + '(default 3 along the longer axis around center_x/center_y) from the operator-stated start_z_machine to '
+            + 'floor_z_machine; the HIGHEST contact is the top and a sample lower by more than hole_tolerance_mm (default 2) '
+            + 'is a hole and ignored (a first probe landing in a drilled hole does not define the surface); between points '
+            + 'the probe travels close above the surface as a stepped traverse that lifts hop_lift_mm on contact. 2) SIDES '
+            + '(default all four): horizontal marches toward the stock from overextend_mm (default 5) OUTSIDE the estimate '
+            + 'at top - side_depth_mm (default 2), points_per_side (default 3, midpoint first) per side, each up to '
+            + 'side_max_travel_mm (default 25 - generous on purpose: the combined error of the centre and width estimate '
+            + 'must fit inside it, a short march silently misses the face); a march that finds nothing records no_contact '
+            + 'and the procedure continues. 3) FIT: per-side mean and slope -> centre (machine AND work frame), size '
+            + 'centre-to-centre and PHYSICAL (minus the tip diameter when set_probe_geometry stored it - external faces lie '
+            + 'one tip radius inside their contacts), yaw. Result: top, topSamples, sides, fit, centerMachine, centerWork, '
+            + 'sizeMm, sizePhysicalMm, yawDeg, lifts. Also available as probe_program op kind "stock_outline".',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                center_x: { type: 'number', description: 'Estimated stock centre, machine X (default: current X).' },
+                center_y: { type: 'number', description: 'Estimated stock centre, machine Y (default: current Y).' },
+                size_x_mm: { type: 'number', description: 'REQUIRED estimated size along machine X (2-400).' },
+                size_y_mm: { type: 'number', description: 'REQUIRED estimated size along machine Y (2-400).' },
+                overextend_mm: { type: 'number', description: 'Side marches start this far outside the estimated face, default 5 (3-60).' },
+                side_max_travel_mm: { type: 'number', description: 'Travel of each side march from its start, default max(25, 2 x overextend + 10) (5-150). Must cover overextend + width uncertainty + centre uncertainty + margin; 25 suits a few mm of each.' },
+                start_z_machine: { type: 'number', description: 'REQUIRED toolhead machine Z above the top where the -Z search starts (operator-stated or from an earlier contact; never a guess).' },
+                floor_z_machine: { type: 'number', description: 'REQUIRED deepest toolhead Z the top search may reach (<= 150 mm below start).' },
+                top_points: { type: 'number', description: 'Top samples: 1-5, default 3 (centre, +/- a quarter of the longer axis; 4-5 add the shorter axis).' },
+                hole_tolerance_mm: { type: 'number', description: 'A top sample lower than the highest by more than this is a hole, default 2.' },
+                side_depth_mm: { type: 'number', description: 'Side marches run at (measured top) - this, default 2 (1-40).' },
+                points_per_side: { type: 'number', description: '1-4 marches per side over the middle half of the side, midpoint first then away from the corners, default 3.' },
+                sides: { type: 'array', items: { type: 'string', enum: ['west', 'east', 'south', 'north'] }, description: 'Which sides to probe (west marches +X, east -X, south +Y, north -Y). Default all four.' },
+                hop_lift_mm: { type: 'number', description: 'Stepped traverse lift per contact and height above the last contact, default 2 (0.5-10).' },
+                coarse_step_mm: { type: 'number', description: 'Coarse step, default 1 (0.2-1; never larger).' },
+                fine_step_mm: { type: 'number', description: 'Fine step, default 0.1 (0.02-0.5).' },
+                backoff_mm: { type: 'number', description: 'Confirm-cycle lift, default 1.' },
+                sensor_delay_ms: { type: 'number', description: 'Contact-check window per step, default 300, floor 30 (GPIO: 50).' },
+                confirm_passes: { type: 'number', description: 'Lift-and-retest cycles per contact, default 3 (1-10).' },
+                reason: { type: 'string', description: 'Shown to the operator: what is being measured and why.' },
+            },
+            required: ['size_x_mm', 'size_y_mm', 'start_z_machine', 'floor_z_machine', 'reason'],
+            additionalProperties: false,
+        },
+        handler: async (args: { [key: string]: unknown }) => {
+            const reason = String(args.reason || '').trim();
+            if (!reason) {
+                throw new McpToolError('reason is required; it is shown to the operator.');
+            }
+            probeFeedService.assertNoOvertravel();
+            const plan = planProbeOutline(args as Parameters<typeof planProbeOutline>[0]);
+            const envelope = `; reason: ${reason}
+${describeProbeOutlinePlanAsGcode(plan)}`;
+            const validation = validateGcode(envelope);
+            const job = jobManager.submit(
+                envelope,
+                `stock-outline ${plan.topPoints.length}top/${plan.sidePoints.length}sides - ${reason.slice(0, 40)}`,
+                'cnc',
+                validation,
+                'procedure'
+            );
+            job.runner = async () => runProbeOutlineProcedure(plan);
+            return {
+                job: jobManager.describe(job),
+                plan,
+                confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
+                next_step: 'Ask the operator to open confirm_url and review the whole procedure (top points, every side start and '
+                    + 'travel limit, the stepped traverses), then start with start_gcode_job wait_for_approval_ms. The result '
+                    + 'carries centerMachine / centerWork and the fitted size; the true faces are one tip radius beyond the contacts.',
+            };
+        },
+    });
+
+    registry.register({
         name: 'probe_program',
         description: 'Stage a COMPOSITE probing program for ONE human approval: an ordered list of operations - '
             + 'rotate_b (turn the rotary axis to an absolute B, toolhead at/above the traverse height), '
             + 'surface_path, surface_grid and sequence (the same arguments as the standalone tools) - run by one '
             + 'runner that hands the machine from op to op, each ending raised at the traverse height. Numbers an op '
-            + 'cannot know at staging are REFERENCES to earlier results: {"from": "<opId>.<path>", "plus"?: n, '
-            + '"minus"?: n, "between": [low, high]} - e.g. expected_z_machine: {"from": "c90.top.z", "between": '
-            + '[195, 240]} where c90 is a sequence op with a probe named "top", or start_z_machine: {"from": '
-            + '"ns90.summary.zMean", "plus": 7, "between": [200, 250]}. The bounds are REQUIRED (law 3): the confirm '
+            + 'cannot know at staging are REFERENCES to earlier results: {"from": "<opId>.<path>", "plus"?, "minus"?, '
+            + '"between": [low, high]} - e.g. expected_z_machine: {"from": "c90.top.z", "between": [195, 240]} where c90 '
+            + 'is a sequence op with a probe named "top" (.x/.y/.z read contactMachine), or start_z_machine: {"from": '
+            + '"ns90.summary.zMean", "plus": 7, "between": [200, 250]}. Two-operand forms: {"mid": [a, b]} = (a+b)/2 '
+            + '(stock centre from two side contacts), {"diff": [a, b], "scale"?: 0.5} = (a-b)*scale (width, half-width), '
+            + '{"min"|"max": [a, b, ...]}; "plus"/"minus" may be a number or a path. Once set_probe_geometry has stored '
+            + 'the rotary axis and probe length, the seeded namespace "axis" offers axis.x, axis.z_physical, axis.z_contact '
+            + '(toolhead Z with the tip on the axis), axis.tip_radius, axis.probe_length - so the B90 face height is '
+            + '{"diff": ["s0.east.x", "s0.west.x"], "scale": 0.5, "plus": "axis.z_contact", "between": [...]}. A program that '
+            + 'references only its own earlier ops (any B0-only, stationary or off-rotary survey) needs NO geometry. '
+            + 'The bounds are REQUIRED (law 3): the confirm '
             + 'page shows them with a preview at the mid-point and the runner refuses the op (stopping the program '
             + 'raised, keeping earlier results) if the value resolves outside them. A failed op stops the program '
             + 'unless on_fail: "skip". Result: per-op status and the standalone tool\'s result object (stations, fits, '
@@ -671,14 +775,27 @@ ${describeProbeSurfacePlanAsGcode(plan)}`;
                 name: { type: 'string', description: 'Program name shown to the operator.' },
                 ops: {
                     type: 'array',
-                    description: 'Ordered operations. Each: {id, kind, on_fail?, ...args}. kinds: rotate_b {b, require_z_at_least?}; '
-                        + 'surface_path / surface_grid / sequence: the standalone tool arguments, where start_z_machine, '
-                        + 'expected_z_machine, floor_z_machine and sequence descend z may be references.',
+                    description: 'Ordered operations. Each: {id, kind, on_fail?, ...args}. kinds: rotate_b {b, require_z_at_least?, '
+                        + 'swept_radius_mm? (largest reach of THIS stock and clamping about the axis - adds a tip-outside-the-cylinder check)}; '
+                        + 'surface_path / surface_grid / sequence / stock_outline: the standalone tool arguments, where ANY number (start_z_machine, '
+                        + 'expected_z_machine, floor_z_machine, start_x/end_x, sequence hop x/y and descend z, expected_profile.circle.*) '
+                        + 'may be a reference; group {id, for_b: [0, 90, 180, 270], ops: [...]} = the inner ops run once per angle '
+                        + `after a rotate_b to it, with the token "${'$'}{b}" in any string replaced by the angle and inner ids without it `
+                        + 'suffixed "_b<angle>" (references between them are rewritten to match). Up to 80 ops after expansion.',
                     items: { type: 'object' },
                     minItems: 1,
-                    maxItems: 40,
+                    maxItems: 80,
                 },
                 reason: { type: 'string', description: 'Shown to the operator: what is being measured and why.' },
+                keep_out: {
+                    type: 'array',
+                    description: 'Transient obstacle boxes for THIS clamping (chuck jaws, tailstock): [{name, machine: {x0, y0, x1, y1}, '
+                        + 'clearance_z}] with clearance_z the minimum safe TOOLHEAD machine Z over the box. Checked together with '
+                        + 'the stored landmarks against every hop, descent column and march of every op at staging (law 4); shown on '
+                        + 'the confirm page; never persisted.',
+                    items: { type: 'object' },
+                    maxItems: 20,
+                },
             },
             required: ['name', 'ops', 'reason'],
             additionalProperties: false,
@@ -689,7 +806,15 @@ ${describeProbeSurfacePlanAsGcode(plan)}`;
                 throw new McpToolError('reason is required; it is shown to the operator.');
             }
             probeFeedService.assertNoOvertravel();
-            const plan = planProbeProgram({ name: args.name, ops: args.ops });
+            const plan = planProbeProgram({ name: args.name, ops: args.ops, keep_out: args.keep_out });
+            // W6: a program of 30+ minutes must fit its own job event log, or the
+            // record the operator approved is lost while it runs.
+            const limit = jobEventLimit();
+            if (plan.eventBudget > limit) {
+                throw new McpToolError(`This program will write about ${plan.eventBudget} job events but the job event log keeps ${limit}. `
+                    + `Raise it to at least ${Math.ceil(plan.eventBudget * 1.2 / 1000) * 1000} first (Settings -> MCP Server -> Diagnostic buffers, `
+                    + 'or LUBAN_MCP_JOB_EVENT_LIMIT), then stage again.');
+            }
             const envelope = `; reason: ${reason}
 ${describeProbeProgramAsGcode(plan)}`;
             const validation = validateGcode(envelope);
@@ -709,6 +834,11 @@ ${describeProbeProgramAsGcode(plan)}`;
                     rotations: plan.rotations,
                     hopZ: plan.hopZ,
                     staged: plan.staged,
+                    keepOut: plan.keepOut,
+                    axis: plan.seeds.axis || null,
+                    groups: plan.groups,
+                    eventBudget: plan.eventBudget,
+                    jobEventLimit: limit,
                 },
                 confirm_url: `${getConfirmBaseUrl()}/confirm/${job.id}`,
                 next_step: 'Ask the operator to open confirm_url and review the WHOLE program: every operation\'s envelope, every '


### PR DESCRIPTION
Stacked on #81 (`mcp/47-timing-inline-g53`).

Operator request after the manual four-face survey: everything that survey worked out by hand, in the program tooling, so freshly clamped stock of unknown size is surveyed with ONE approval from the jig geometry alone. Work plan and hardware test order: `docs/NEW_STOCK_SURVEY_TODO.md`.

## What landed

- **Two-operand references** (`programRefs.ts`): `{mid: [a, b]}`, `{diff: [a, b], scale}`, `{min|max: [...]}`; `plus`/`minus` accept a path, so "axis + half-width" is one bounded reference. References may sit at any depth of an op's arguments. The page prints the formula, the runner the values; bounds stay required.
- **Rotary axis and probe geometry through the MCP surface** (`rotaryGeometry.ts`, tool `set_probe_geometry` with a reason, like `set_landmark`; env overrides; `get_stored_state → geometry`): axis X, physical axis Z, probe effective length, tip diameter. Programs read them as the seeded `axis` namespace. Never a prerequisite: only an `axis.*` reference needs them. No stock size is stored (operator review): a rotation takes a per-program `swept_radius_mm` instead. The settings-pane version was removed.
- **Keep-out at plan time** (`envelopeChecks.ts`, law 4): every sequence hop / descend column / march and every surface-scan descent, hop (at its lowest possible height) and station column is checked at staging and again when references resolve. Stored landmarks are *crossing* obstacles (entering/leaving their box low is refused; probing wholly inside — the stock inside the rotary-axis landmark — is allowed), the program's transient `keep_out` boxes are *volumes*. `rotate_b swept_radius_mm` refuses with the tip inside that cylinder. The standalone tools get the same check.
- **Discovery**: `summary.highestAt/lowestAt`; `surface_path expected_profile.circle` for cylinders along the rotary axis (per-station expected Z, stations beyond 0.7 R refused); unknown-height pattern documented (no new op).
- **`group`** (`programGroups.ts`): `for_b: [0, 90, 180, 270]` expands to a rotation plus the inner ops per angle with `${b}` substitution and id suffixing; cap 80 ops.
- **Derived section** (`stockGeometry.ts`, `result.derived`): face heights above the axis, thickness and centring per face pair, width with tip, centre X, yaw, end slope, face slopes — unit-tested against the 2026-09-05 report's numbers. Every op result carries its `b`.
- **Event budget**: plan estimate on the page; staging refused when it exceeds the job event limit, naming the number to set.

## Also: `stop_gcode_job` now stops procedures (job 5ad5fcce6b3a, 2026-09-06)

Three stop calls on a running `probe_program` answered `ok: false` while the scan kept stepping: the tool only knew the firmware's `stop_print`, and a procedure is a server-driven loop. Now the tool records a stop request that every motion primitive checks before sending; the runner throws `ProcedureStopped` at the next step boundary (<= 1 mm step or one sensor window), its abort path raises to the traverse height, and the job ends in state `stopped`. `ProcedureAbort` carries `partial` (completed stations / contacts / ops) and the runner wrapper stores it as `job.result`, so every abort keeps what was measured. A program stops as a whole regardless of `on_fail`; a not-yet-started procedure is withdrawn. The call waits up to `wait_ms` (default 20 s) and returns `{ok: true, stopped | stopping, job}`.

## Also: a missed march no longer aborts a sequence (same job, final op)

The six-op centre-finding program aborted on its last op because the first south-side march started beyond a corner of the stock and found nothing within 25 mm, discarding five completed ops. `probe_sequence` probe steps take `on_miss`: `continue` (default) records `{status: "no_contact", limitMachine, maxTravelMm}`, retreats, raises and carries on; `abort` keeps the old behaviour. Every result entry carries `status`; the sequence result adds `contactCount` and `noContactProbes`. A later reference to a missed probe fails to resolve and refuses that op. The skill now tells agents to start side marches outside the largest possible size, cover the uncertainty with `max_travel_mm`, and probe mid-length first.

## Also: `probe_stock_outline`, stepped traverses, traverse-height exemption (operator requests 2026-09-06)

- **`probe_stock_outline`** (also `probe_program` op kind `stock_outline`): top at `top_points` with hole rejection (highest wins; a sample lower by more than `hole_tolerance_mm` is ignored), sides marched from `overextend_mm` outside the estimate at `top − side_depth_mm`, `points_per_side` over the middle half of each side, a miss recorded not fatal, fit to centre (machine + work), size (+ tip), yaw (`outlineFit.ts`, unit-tested). No re-probing the centre per side.
- **`march.ts`**: the shared coarse→release→fine→confirm march, and `steppedTraverse` — travel close to a surface as a touch-probing move that backs off, retreats `hop_lift_mm` along a retreat direction and continues (up over a top, capped at the traverse height; away from the face along a side, capped at the approved start line). Sides skip along the face at `side_standoff_mm` off the last contact with a dynamic march start. Surface scans get `hop_mode: "stepped"`.
- **Traverse height beats a landmark clearance above it** (job 34d787bdb2d7: the rotary landmark says 328, the traverse height is 320, a hop at 320 was refused and a six-op program lost its last op): segments at/above `mcpSafeTraverseZ` and sensor-gated marches are exempt from *crossing* landmarks; *volume* keep-outs still apply.

## Also: outline defaults and the tip sign, from the on-box agent's post-mortem

The first outline on the box lost its west side to an 11 mm march (face 13.6 mm away; centre estimate 3.85 mm off). Defaults are now generous: `points_per_side` 3 (midpoint first), `side_max_travel_mm` 25 (new argument, never below overextend + 5), `overextend_mm` 5, `side_depth_mm` 2. The tip correction sign was wrong: on opposite external faces each stylus centre stops one tip radius OUTSIDE its face, so physical size = centre-to-centre MINUS the tip diameter (`sizePhysicalMm`, `widthPhysicalMm`); the centre is unaffected. Unit-tested against the agent's measured block (centre 168.85 / 241.383, physical 44.27 × 69.0).

## Verification

- 28 unit checks (references, keep-out geometry incl. the end march toward the jaws, crossing vs volume, traverse-height exemption, circle profile, nested substitution, group expansion, derivation reproducing 71.9 × 47.2 / yaw 0.7 / end 1.25, outline top estimate with a hole, outline fit centre/size/yaw). tsc filtered to `services/mcp` clean; eslint clean on the MCP tree, the API and the settings pane.
- Hardware: not yet — order in the TODO: B0 half without rotations, then one rotation, then the whole program; compare `derived` with calipers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
