### PR TITLE
Feature: OAuth/DCR shim so Claude Code connects; LAN gate honoured on /mcp

### DIFF
--- a/src/server/services/mcp/McpServer.ts
+++ b/src/server/services/mcp/McpServer.ts
@@ -120,6 +120,26 @@ export function isLocalSubnetOrigin(origin: string | undefined): boolean {
     return !!match && isLocalSubnetAddress(match[1]);
 }
 
+/**
+ * The one trust boundary, shared by every route (/mcp, the OAuth shim, the
+ * confirm pages): a local process, or in LAN mode a host on one of this
+ * machine's own subnets.
+ */
+export function isTrustedAddress(address: string | undefined, allowLan: boolean): boolean {
+    return isLoopback(address) || (allowLan && isLocalSubnetAddress(address));
+}
+
+export function isTrustedOrigin(origin: string | undefined, allowLan: boolean): boolean {
+    return isAllowedOrigin(origin) || (allowLan && isLocalSubnetOrigin(origin));
+}
+
+export interface McpServerOptions {
+    /** mcpAllowLan: accept same-subnet clients, not only loopback. */
+    allowLan?: boolean;
+    /** Label for the caller (from its OAuth token) - for log lines only. */
+    identifyClient?: (req: http.IncomingMessage) => string | null;
+}
+
 export class McpServer {
     private registry: ToolRegistry;
 
@@ -129,25 +149,32 @@ export class McpServer {
 
     private onActivity: ((activity: object) => void) | null;
 
+    private options: McpServerOptions;
+
     public constructor(
         registry: ToolRegistry,
         serverName: string,
         serverVersion: string,
-        onActivity?: (activity: object) => void
+        onActivity?: (activity: object) => void,
+        options?: McpServerOptions
     ) {
         this.registry = registry;
         this.serverName = serverName;
         this.serverVersion = serverVersion;
         this.onActivity = onActivity || null;
+        this.options = options || {};
     }
 
     public handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): void => {
-        // Bound to loopback; re-check per request as defense in depth.
-        if (!isLoopback(req.socket.remoteAddress)) {
-            this.respond(res, 403, { error: 'loopback only' });
+        // index.ts gates every route already; re-check per request as
+        // defense in depth, with the SAME policy (a hard loopback check here
+        // used to refuse every LAN client that the outer gate had admitted).
+        const allowLan = !!this.options.allowLan;
+        if (!isTrustedAddress(req.socket.remoteAddress, allowLan)) {
+            this.respond(res, 403, { error: allowLan ? 'local subnet only' : 'loopback only' });
             return;
         }
-        if (!isAllowedOrigin(req.headers.origin)) {
+        if (!isTrustedOrigin(req.headers.origin, allowLan)) {
             log.warn(`MCP request with disallowed origin rejected: ${req.headers.origin}`);
             this.respond(res, 403, { error: 'origin not allowed' });
             return;
@@ -165,8 +192,9 @@ export class McpServer {
             return;
         }
 
+        const client = this.options.identifyClient ? this.options.identifyClient(req) : null;
         this.readBody(req, res, (body) => {
-            this.handlePost(body, res);
+            this.handlePost(body, res, client);
         });
     };
 
@@ -192,7 +220,7 @@ export class McpServer {
         });
     }
 
-    private async handlePost(body: string, res: http.ServerResponse): Promise<void> {
+    private async handlePost(body: string, res: http.ServerResponse, client: string | null): Promise<void> {
         let parsed: unknown;
         try {
             parsed = JSON.parse(body);
@@ -210,7 +238,7 @@ export class McpServer {
         const responses = [];
         for (const message of messages) {
             // eslint-disable-next-line no-await-in-loop
-            const response = await this.handleMessage(message);
+            const response = await this.handleMessage(message, client);
             if (response) {
                 responses.push(response);
             }
@@ -227,7 +255,7 @@ export class McpServer {
         }
     }
 
-    private async handleMessage(message: JsonRpcMessage): Promise<object | null> {
+    private async handleMessage(message: JsonRpcMessage, client: string | null): Promise<object | null> {
         if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') {
             return rpcError((message && message.id) || null, JSONRPC_INVALID_REQUEST, 'Invalid request');
         }
@@ -240,7 +268,13 @@ export class McpServer {
         const { id, method, params } = message;
         try {
             switch (method) {
-                case 'initialize':
+                case 'initialize': {
+                    const info = (params && params.clientInfo) as { name?: unknown; version?: unknown } | undefined;
+                    const described = info && typeof info.name === 'string'
+                        ? `${info.name}${typeof info.version === 'string' ? ` ${info.version}` : ''}`
+                        : 'unnamed client';
+                    log.info(`MCP initialize from ${described}${client ? ` [token: ${client}]` : ''} `
+                        + `(protocol ${(params && params.protocolVersion) || '?'})`);
                     return rpcResult(id, {
                         protocolVersion: PROTOCOL_VERSION,
                         capabilities: {
@@ -251,12 +285,13 @@ export class McpServer {
                             version: this.serverVersion,
                         },
                     });
+                }
                 case 'ping':
                     return rpcResult(id, {});
                 case 'tools/list':
                     return rpcResult(id, { tools: this.registry.list() });
                 case 'tools/call':
-                    return await this.handleToolCall(id, params);
+                    return await this.handleToolCall(id, params, client);
                 default:
                     return rpcError(id, JSONRPC_METHOD_NOT_FOUND, `Method not found: ${method}`);
             }
@@ -266,7 +301,7 @@ export class McpServer {
         }
     }
 
-    private async handleToolCall(id: number | string, params: JsonRpcMessage['params']): Promise<object> {
+    private async handleToolCall(id: number | string, params: JsonRpcMessage['params'], client: string | null): Promise<object> {
         const name = params && params.name;
         if (typeof name !== 'string') {
             return rpcError(id, JSONRPC_INVALID_PARAMS, 'tools/call requires a tool name');
@@ -294,7 +329,7 @@ export class McpServer {
         };
         const args = ((params && params.arguments) as object) || {};
         const startedAt = Date.now();
-        log.info(`tool ${name} <- ${summarize(args, 600)}`);
+        log.info(`tool ${name}${client ? ` [${client}]` : ''} <- ${summarize(args, 600)}`);
         try {
             const result = await this.registry.call(name, args);
             log.info(`tool ${name} ok in ${Date.now() - startedAt}ms -> ${summarize(result, 900)}`);

--- a/src/server/services/mcp/README.md
+++ b/src/server/services/mcp/README.md
@@ -16,7 +16,7 @@ serves them, and `LUBAN_MCP_PORT` (env) overrides everything for one run.
 | Key | Meaning |
 |---|---|
 | `mcpEnabled`, `mcpPort` | Start the server on 127.0.0.1:port (default 40889). Legacy: `mcpPort` alone enables when `mcpEnabled` was never written. |
-| `mcpAllowLan` | Default off = loopback only. On: bind every interface but accept only clients (and browser origins) on this machine's own IPv4 subnets; confirm-page links use the LAN address. **No authentication exists** — anyone on that subnet can command the machine; the pane warns in red. Env `LUBAN_MCP_ALLOW_LAN` overrides. Applies at the next start. |
+| `mcpAllowLan` | Default off = loopback only. On: bind every interface but accept only clients (and browser origins) on this machine's own IPv4 subnets; confirm-page links use the LAN address. **No authentication exists** — anyone on that subnet can command the machine; the pane warns in red (the OAuth endpoints in `oauth.ts` grant everyone, see Architecture). Env `LUBAN_MCP_ALLOW_LAN` overrides. Applies at the next start. |
 | `mcpToolSetterEnabled`, `mcpProbeToolEnabled` | Default on. Off = that sensor's channel is never bound on any transport (overtravel follows the tool setter): no pill, no readings, and procedures needing it refuse with a clear message. Use when the sensor or the USB bridge is not fitted. Env `LUBAN_MCP_TOOLSETTER_ENABLED` / `LUBAN_MCP_PROBE_ENABLED` override. |
 | `mcpCameraUrl` | HTTP(S) snapshot URL; takes precedence over ffmpeg. |
 | `mcpFfmpegPath`, `mcpCameraDevice`, `mcpCameraLastGood` | ffmpeg capture — DirectShow on Windows (device = friendly name), v4l2 on Linux (device = a `list_cameras` entry, preferably the stable `/dev/v4l/by-id/… (Name)` form; a bare `/dev/videoN` works but renumbers on replug). Device choice is sticky (last-good preferred); a vanished device is an error, never a silent substitution. |
@@ -77,10 +77,29 @@ transport is hand-rolled stateless Streamable HTTP (JSON-RPC over `POST /mcp`): 
 embeds Node 16 and the official SDK needs ≥ 18. Zero added dependencies anywhere —
 `jpeg-js` (tracking) was already in the tree; the lockfile has never changed.
 
+**OAuth shim, not authentication (2026-09-07).** Claude Code / Claude Desktop run the MCP
+authorization flow against an `http` server before their first JSON-RPC call — metadata
+discovery, Dynamic Client Registration, authorization code + PKCE, token exchange — and refused
+to connect when the steps 404'd ("Dynamic Client Registration rejected (HTTP 404)"). `oauth.ts`
+answers every step: `/.well-known/oauth-protected-resource[/mcp]`,
+`/.well-known/oauth-authorization-server[/mcp]` (+ `openid-configuration` alias), `POST
+/register`, `GET /authorize`, `POST /token`. It grants everyone: `/authorize` redirects straight
+back with a code (no login page — the human decision points are the job confirm pages), `/token`
+hands out an opaque bearer, and `/mcp` never checks tokens (never 401s, so clients without the
+flow — ChatGPT's tunnel-client, curl — and tokens from before a restart keep working). The
+trust boundary is unchanged: every route sits behind the same loopback / `mcpAllowLan` subnet
+gate in `index.ts`. What the flow buys is attribution — the registered `client_name` labels
+`tool …` log lines (`tool probe_point [Claude Code (luban_…)] <- …`) and the `initialize` line.
+Redirect URIs must be loopback http(s) or a private-use scheme; an unknown `client_id` (server
+restarted, client kept its registration) is still granted if its redirect URI is loopback. Same
+fix also made the server's own per-request address check honour `mcpAllowLan` — it hard-coded
+loopback, so LAN clients the outer gate admitted still got `403 loopback only` on `/mcp`.
+
 ```
 mcp/
-  index.ts       start/stop, config resolution, routing (/mcp, /confirm), mcpBroadcast
+  index.ts       start/stop, config resolution, routing (/mcp, /confirm, oauth), mcpBroadcast
   McpServer.ts   JSON-RPC transport, per-call logging + mcp:activity broadcast
+  oauth.ts       OAuth 2.1 / DCR shim for clients that insist on it; grants all, labels logs
   registry.ts    tool registration/dispatch; McpToolError = tool-level failure
   jobs.ts        JobManager + human confirm pages (/confirm/<id>); job kinds file|direct
   validator.ts   static gcode inspection (extents, spindle, distance-mode hazards)

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -4,7 +4,8 @@ import pkg from '../../../package.json';
 import logger from '../../lib/logger';
 import config from '../configstore';
 import { diagnosticsSnapshot, startDiagnostics } from './diagnostics';
-import { McpServer, isAllowedOrigin, isLocalSubnetAddress, isLocalSubnetOrigin, isLoopback, localSubnets } from './McpServer';
+import { McpServer, isTrustedAddress, isTrustedOrigin, localSubnets } from './McpServer';
+import { OAuthShim } from './oauth';
 import { jobManager } from './jobs';
 import { probeFeedService, resolveActiveProbeConfig } from './probeFeed';
 import { ToolRegistry } from './registry';
@@ -187,17 +188,22 @@ export function startMcpService(socketServer?: McpBroadcaster): void {
         mcpBroadcast('mcp:activity', activity);
     };
 
-    const mcpServer = new McpServer(registry, 'snapmaker-luban', pkg.version, onActivity);
+    // OAuth-shaped handshake for clients that insist on one (oauth.ts). It
+    // authenticates nobody - it exists so those clients connect at all, and
+    // so their registered name can label the log.
+    const oauth = new OAuthShim(port);
+    const mcpServer = new McpServer(registry, 'snapmaker-luban', pkg.version, onActivity, {
+        allowLan: settings.allowLan,
+        identifyClient: (req) => oauth.identifyClient(req),
+    });
 
     httpServer = http.createServer((req, res) => {
         // Same trust boundary for every route: local processes only (plus, in
         // LAN mode, hosts on this machine's own subnets), and no browser
         // contexts other than localhost / the app's own scheme (or, in LAN
         // mode, a same-subnet host).
-        const remote = req.socket.remoteAddress;
-        const addressOk = isLoopback(remote) || (settings.allowLan && isLocalSubnetAddress(remote));
-        const originOk = isAllowedOrigin(req.headers.origin) || (settings.allowLan && isLocalSubnetOrigin(req.headers.origin));
-        if (!addressOk || !originOk) {
+        if (!isTrustedAddress(req.socket.remoteAddress, settings.allowLan)
+            || !isTrustedOrigin(req.headers.origin, settings.allowLan)) {
             res.writeHead(403, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'forbidden' }));
             return;
@@ -207,6 +213,9 @@ export function startMcpService(socketServer?: McpBroadcaster): void {
         if (url.pathname.startsWith('/confirm')) {
             // Human job-confirmation pages (jobs.ts)
             jobManager.handleConfirmRequest(req, res, url.pathname);
+            return;
+        }
+        if (oauth.handleRequest(req, res, url)) {
             return;
         }
 

--- a/src/server/services/mcp/oauth.ts
+++ b/src/server/services/mcp/oauth.ts
@@ -1,0 +1,499 @@
+import crypto from 'crypto';
+import http from 'http';
+
+import logger from '../../lib/logger';
+
+const log = logger('service:mcp:oauth');
+
+// OAuth 2.1 compatibility shim for MCP clients.
+//
+// The trust boundary of this server is the network (loopback, or the
+// machine's own subnets with mcpAllowLan) plus the human confirm pages; the
+// README says "no authentication exists" and that stays true. But some MCP
+// clients (Claude Code / Claude Desktop with an `http` server entry) run the
+// MCP authorization flow before their first JSON-RPC call - metadata
+// discovery, Dynamic Client Registration (RFC 7591), authorization code +
+// PKCE (RFC 7636), token exchange - and refuse to connect when any step
+// 404s. This module answers every step of that dance and grants it to
+// everyone who reaches it: /authorize redirects straight back with a code,
+// /token hands out an opaque bearer token, and /mcp never checks tokens.
+//
+// What the flow buys us is attribution: the client_name registered by a
+// client travels with its token, so the server log can say WHICH agent
+// called a tool.
+//
+// Every route here sits behind the same address / Origin gate as /mcp
+// (index.ts applies it before routing), so the LAN setting is respected.
+
+const CODE_TTL_MS = 5 * 60 * 1000;
+const MAX_CLIENTS = 256;
+const MAX_CODES = 256;
+const MAX_TOKENS = 1024;
+const MAX_BODY_BYTES = 64 * 1024;
+
+interface RegisteredClient {
+    clientId: string;
+    clientName: string;
+    redirectUris: string[];
+    software: string | null;
+    registeredAt: number;
+    registeredFrom: string;
+}
+
+interface PendingCode {
+    clientId: string;
+    redirectUri: string;
+    codeChallenge: string;
+    createdAt: number;
+}
+
+interface IssuedToken {
+    kind: 'access' | 'refresh';
+    clientId: string;
+    issuedAt: number;
+}
+
+/** Client label for log lines: "Claude Code (luban-3f9a…)" or the bare id. */
+export function describeClient(client: { clientId: string; clientName: string } | undefined, clientId: string): string {
+    if (client && client.clientName && client.clientName !== client.clientId) {
+        return `${client.clientName} (${client.clientId})`;
+    }
+    return clientId;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+    const host = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.localhost');
+}
+
+/**
+ * Redirect URIs a client may register: loopback http(s) (the SDKs' local
+ * callback listener) or a private-use scheme (desktop apps). An http(s) URI
+ * to some other host is refused - there is no reason for a code minted on
+ * this LAN to leave it.
+ */
+export function isAcceptableRedirectUri(value: string): boolean {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch (err) {
+        return false;
+    }
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+        return isLoopbackHost(url.hostname);
+    }
+    return /^[a-z][a-z0-9+.-]*:$/i.test(url.protocol);
+}
+
+function base64url(buffer: Buffer): string {
+    return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function pkceChallenge(verifier: string): string {
+    return base64url(crypto.createHash('sha256').update(verifier).digest());
+}
+
+function randomToken(prefix: string, bytes = 24): string {
+    return `${prefix}_${crypto.randomBytes(bytes).toString('hex')}`;
+}
+
+/** Drop the oldest entries of an insertion-ordered Map beyond a cap. */
+function trim<K, V>(map: Map<K, V>, max: number): void {
+    while (map.size > max) {
+        const oldest = map.keys().next().value;
+        map.delete(oldest);
+    }
+}
+
+export class OAuthShim {
+    private clients = new Map<string, RegisteredClient>();
+
+    private codes = new Map<string, PendingCode>();
+
+    private tokens = new Map<string, IssuedToken>();
+
+    private port: number;
+
+    public constructor(port: number) {
+        this.port = port;
+    }
+
+    /**
+     * Serve an OAuth / metadata route. Returns false when the path is not one
+     * of ours so the caller can fall through to /mcp and the confirm pages.
+     */
+    public handleRequest(req: http.IncomingMessage, res: http.ServerResponse, url: URL): boolean {
+        const { pathname } = url;
+        if (/^\/\.well-known\/oauth-protected-resource(\/mcp)?$/.test(pathname)) {
+            this.methodGuard(req, res, 'GET', () => this.protectedResourceMetadata(req, res));
+            return true;
+        }
+        if (/^\/\.well-known\/(oauth-authorization-server|openid-configuration)(\/mcp)?$/.test(pathname)) {
+            this.methodGuard(req, res, 'GET', () => this.authorizationServerMetadata(req, res));
+            return true;
+        }
+        if (pathname === '/register') {
+            this.methodGuard(req, res, 'POST', () => this.readBody(req, res, (body) => this.register(req, res, body)));
+            return true;
+        }
+        if (pathname === '/authorize') {
+            this.methodGuard(req, res, 'GET', () => this.authorize(req, res, url));
+            return true;
+        }
+        if (pathname === '/token') {
+            this.methodGuard(req, res, 'POST', () => this.readBody(req, res, (body) => this.token(req, res, body)));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Who is calling, from the Authorization header - for LOG LINES ONLY.
+     * A missing or unknown token is not refused: the network is the trust
+     * boundary, and clients that never ran the flow (or hold a token from
+     * before a restart) must keep working.
+     */
+    public identifyClient(req: http.IncomingMessage): string | null {
+        const header = req.headers.authorization;
+        if (typeof header !== 'string') {
+            return null;
+        }
+        const match = header.match(/^Bearer\s+(\S+)$/i);
+        if (!match) {
+            return null;
+        }
+        const token = this.tokens.get(match[1]);
+        if (!token || token.kind !== 'access') {
+            return 'unknown token';
+        }
+        return describeClient(this.clients.get(token.clientId), token.clientId);
+    }
+
+    // ---- metadata -------------------------------------------------------
+
+    /**
+     * The URL the client reached us by, so the endpoints we advertise are the
+     * ones it can actually use (127.0.0.1 vs a LAN address). The Host header
+     * is only ever echoed back to the client that sent it.
+     */
+    private issuer(req: http.IncomingMessage): string {
+        const host = req.headers.host;
+        if (typeof host === 'string' && /^[A-Za-z0-9.\-[\]:]{1,253}$/.test(host)) {
+            return `http://${host}`;
+        }
+        return `http://127.0.0.1:${this.port}`;
+    }
+
+    private protectedResourceMetadata(req: http.IncomingMessage, res: http.ServerResponse): void {
+        const issuer = this.issuer(req);
+        this.json(res, 200, {
+            resource: `${issuer}/mcp`,
+            authorization_servers: [issuer],
+            bearer_methods_supported: ['header'],
+            scopes_supported: [],
+        });
+    }
+
+    private authorizationServerMetadata(req: http.IncomingMessage, res: http.ServerResponse): void {
+        const issuer = this.issuer(req);
+        this.json(res, 200, {
+            issuer,
+            authorization_endpoint: `${issuer}/authorize`,
+            token_endpoint: `${issuer}/token`,
+            registration_endpoint: `${issuer}/register`,
+            response_types_supported: ['code'],
+            response_modes_supported: ['query'],
+            grant_types_supported: ['authorization_code', 'refresh_token'],
+            code_challenge_methods_supported: ['S256'],
+            token_endpoint_auth_methods_supported: ['none'],
+            scopes_supported: [],
+        });
+    }
+
+    // ---- dynamic client registration (RFC 7591) -------------------------
+
+    private register(req: http.IncomingMessage, res: http.ServerResponse, body: string): void {
+        let metadata: { [key: string]: unknown };
+        try {
+            metadata = JSON.parse(body);
+        } catch (err) {
+            this.json(res, 400, { error: 'invalid_client_metadata', error_description: 'body must be JSON' });
+            return;
+        }
+        if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+            this.json(res, 400, { error: 'invalid_client_metadata', error_description: 'body must be a JSON object' });
+            return;
+        }
+
+        const redirectUris = Array.isArray(metadata.redirect_uris)
+            ? metadata.redirect_uris.filter((u): u is string => typeof u === 'string')
+            : [];
+        const refused = redirectUris.filter(u => !isAcceptableRedirectUri(u));
+        if (refused.length > 0) {
+            this.json(res, 400, {
+                error: 'invalid_redirect_uri',
+                error_description: `redirect URIs must be loopback http(s) or a private-use scheme: ${refused.join(', ')}`,
+            });
+            return;
+        }
+
+        // Short: it appears on every tool log line for this client.
+        const clientId = randomToken('luban', 6);
+        const clientName = typeof metadata.client_name === 'string' && metadata.client_name.trim()
+            ? metadata.client_name.trim().slice(0, 120)
+            : clientId;
+        const software = typeof metadata.software_id === 'string'
+            ? `${metadata.software_id}${typeof metadata.software_version === 'string' ? ` ${metadata.software_version}` : ''}`
+            : null;
+        const client: RegisteredClient = {
+            clientId,
+            clientName,
+            redirectUris,
+            software,
+            registeredAt: Date.now(),
+            registeredFrom: req.socket.remoteAddress || '?',
+        };
+        this.clients.set(clientId, client);
+        trim(this.clients, MAX_CLIENTS);
+        log.info(`oauth client registered: ${describeClient(client, clientId)}${software ? ` [${software}]` : ''} `
+            + `redirect_uris=${JSON.stringify(redirectUris)} from ${client.registeredFrom}`);
+
+        this.json(res, 201, {
+            ...metadata,
+            client_id: clientId,
+            client_id_issued_at: Math.floor(client.registeredAt / 1000),
+            client_name: clientName,
+            redirect_uris: redirectUris,
+            grant_types: ['authorization_code', 'refresh_token'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'none',
+        });
+    }
+
+    // ---- authorization endpoint -----------------------------------------
+
+    /**
+     * Grants immediately: whoever can reach this page is already inside the
+     * trust boundary, and the human decision points that matter are the job
+     * confirm pages, not a login. Nothing is sent to a redirect URI that is
+     * not registered for the client or loopback.
+     */
+    private authorize(req: http.IncomingMessage, res: http.ServerResponse, url: URL): void {
+        const q = url.searchParams;
+        const clientId = q.get('client_id') || '';
+        const redirectUri = q.get('redirect_uri') || '';
+        const state = q.get('state');
+        const client = this.clients.get(clientId);
+
+        if (!redirectUri) {
+            this.page(res, 400, 'Missing redirect_uri.');
+            return;
+        }
+        const redirectKnown = client ? client.redirectUris.includes(redirectUri) : false;
+        if (!redirectKnown && !isAcceptableRedirectUri(redirectUri)) {
+            this.page(res, 400, 'redirect_uri is neither registered for this client nor a loopback / private-scheme URI.');
+            return;
+        }
+        // From here on errors go back to the client the OAuth way.
+        const fail = (error: string, description: string) => {
+            log.warn(`oauth authorize refused for ${describeClient(client, clientId || '(no client_id)')}: ${description}`);
+            this.redirect(res, redirectUri, { error, error_description: description, state });
+        };
+        if (!clientId) {
+            fail('invalid_request', 'client_id is required');
+            return;
+        }
+        if (q.get('response_type') !== 'code') {
+            fail('unsupported_response_type', 'only response_type=code is supported');
+            return;
+        }
+        const codeChallenge = q.get('code_challenge') || '';
+        if (!codeChallenge || (q.get('code_challenge_method') || 'S256') !== 'S256') {
+            fail('invalid_request', 'PKCE with code_challenge_method=S256 is required');
+            return;
+        }
+
+        this.pruneCodes();
+        const code = randomToken('code');
+        this.codes.set(code, { clientId, redirectUri, codeChallenge, createdAt: Date.now() });
+        trim(this.codes, MAX_CODES);
+        log.info(`oauth authorize granted to ${describeClient(client, clientId)} from ${req.socket.remoteAddress} `
+            + `-> ${redirectUri}${client ? '' : ' (client_id not registered here; token still issued)'}`);
+        this.redirect(res, redirectUri, { code, state });
+    }
+
+    // ---- token endpoint -------------------------------------------------
+
+    private token(req: http.IncomingMessage, res: http.ServerResponse, body: string): void {
+        const params = this.parseForm(req, body);
+        if (!params) {
+            this.json(res, 400, { error: 'invalid_request', error_description: 'body must be form-encoded or JSON' });
+            return;
+        }
+        const grantType = params.get('grant_type');
+        if (grantType === 'authorization_code') {
+            this.tokenFromCode(req, res, params);
+            return;
+        }
+        if (grantType === 'refresh_token') {
+            this.tokenFromRefresh(req, res, params);
+            return;
+        }
+        this.json(res, 400, { error: 'unsupported_grant_type', error_description: `grant_type ${grantType || '(missing)'}` });
+    }
+
+    private tokenFromCode(req: http.IncomingMessage, res: http.ServerResponse, params: URLSearchParams): void {
+        this.pruneCodes();
+        const code = params.get('code') || '';
+        const pending = this.codes.get(code);
+        // Single use, whatever the outcome.
+        this.codes.delete(code);
+        if (!pending) {
+            this.json(res, 400, { error: 'invalid_grant', error_description: 'unknown or expired authorization code' });
+            return;
+        }
+        const clientId = params.get('client_id');
+        if (clientId && clientId !== pending.clientId) {
+            this.json(res, 400, { error: 'invalid_grant', error_description: 'code was issued to a different client' });
+            return;
+        }
+        const redirectUri = params.get('redirect_uri');
+        if (redirectUri && redirectUri !== pending.redirectUri) {
+            this.json(res, 400, { error: 'invalid_grant', error_description: 'redirect_uri does not match the authorization request' });
+            return;
+        }
+        const verifier = params.get('code_verifier') || '';
+        if (!verifier || pkceChallenge(verifier) !== pending.codeChallenge) {
+            log.warn(`oauth token refused for ${pending.clientId}: PKCE verifier mismatch`);
+            this.json(res, 400, { error: 'invalid_grant', error_description: 'PKCE code_verifier does not match' });
+            return;
+        }
+        this.issueTokens(req, res, pending.clientId);
+    }
+
+    private tokenFromRefresh(req: http.IncomingMessage, res: http.ServerResponse, params: URLSearchParams): void {
+        const refresh = params.get('refresh_token') || '';
+        const known = this.tokens.get(refresh);
+        if (!known || known.kind !== 'refresh') {
+            // After a restart nothing is known; the client redoes the (automatic) flow.
+            this.json(res, 400, { error: 'invalid_grant', error_description: 'unknown refresh token' });
+            return;
+        }
+        const clientId = params.get('client_id');
+        if (clientId && clientId !== known.clientId) {
+            this.json(res, 400, { error: 'invalid_grant', error_description: 'refresh token belongs to a different client' });
+            return;
+        }
+        this.tokens.delete(refresh);
+        this.issueTokens(req, res, known.clientId);
+    }
+
+    private issueTokens(req: http.IncomingMessage, res: http.ServerResponse, clientId: string): void {
+        const accessToken = randomToken('at');
+        const refreshToken = randomToken('rt');
+        const issuedAt = Date.now();
+        this.tokens.set(accessToken, { kind: 'access', clientId, issuedAt });
+        this.tokens.set(refreshToken, { kind: 'refresh', clientId, issuedAt });
+        trim(this.tokens, MAX_TOKENS);
+        log.info(`oauth token issued to ${describeClient(this.clients.get(clientId), clientId)} from ${req.socket.remoteAddress}`);
+        // No expires_in: the token never has to be refreshed because /mcp
+        // never rejects one. It only labels log lines.
+        this.json(res, 200, {
+            access_token: accessToken,
+            token_type: 'Bearer',
+            refresh_token: refreshToken,
+            scope: '',
+        });
+    }
+
+    // ---- plumbing -------------------------------------------------------
+
+    private pruneCodes(): void {
+        const now = Date.now();
+        for (const [code, pending] of this.codes) {
+            if (now - pending.createdAt > CODE_TTL_MS) {
+                this.codes.delete(code);
+            }
+        }
+    }
+
+    private parseForm(req: http.IncomingMessage, body: string): URLSearchParams | null {
+        const contentType = String(req.headers['content-type'] || '');
+        if (contentType.includes('application/json')) {
+            try {
+                const parsed = JSON.parse(body);
+                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                    return null;
+                }
+                const params = new URLSearchParams();
+                for (const key of Object.keys(parsed)) {
+                    if (parsed[key] !== undefined && parsed[key] !== null) {
+                        params.set(key, String(parsed[key]));
+                    }
+                }
+                return params;
+            } catch (err) {
+                return null;
+            }
+        }
+        return new URLSearchParams(body);
+    }
+
+    private methodGuard(req: http.IncomingMessage, res: http.ServerResponse, method: string, next: () => void): void {
+        if (req.method !== method) {
+            res.writeHead(405, { Allow: method });
+            res.end();
+            return;
+        }
+        next();
+    }
+
+    private readBody(req: http.IncomingMessage, res: http.ServerResponse, callback: (body: string) => void): void {
+        const chunks: Buffer[] = [];
+        let size = 0;
+        req.on('data', (chunk: Buffer) => {
+            size += chunk.length;
+            if (size > MAX_BODY_BYTES) {
+                req.destroy();
+                this.json(res, 413, { error: 'invalid_request', error_description: 'body too large' });
+                return;
+            }
+            chunks.push(chunk);
+        });
+        req.on('end', () => {
+            if (!res.writableEnded) {
+                callback(Buffer.concat(chunks).toString('utf8'));
+            }
+        });
+        req.on('error', (err) => {
+            log.warn(`oauth request error: ${err.message}`);
+        });
+    }
+
+    private redirect(res: http.ServerResponse, redirectUri: string, params: { [key: string]: string | null }): void {
+        const target = new URL(redirectUri);
+        for (const key of Object.keys(params)) {
+            if (params[key] !== null && params[key] !== undefined) {
+                target.searchParams.set(key, params[key] as string);
+            }
+        }
+        res.writeHead(302, { Location: target.toString(), 'Cache-Control': 'no-store' });
+        res.end();
+    }
+
+    private json(res: http.ServerResponse, status: number, payload: object): void {
+        const body = JSON.stringify(payload);
+        res.writeHead(status, {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+            'Cache-Control': 'no-store',
+        });
+        res.end(body);
+    }
+
+    private page(res: http.ServerResponse, status: number, message: string): void {
+        const body = `<!doctype html><meta charset="utf-8"><title>Luban MCP</title><p>${message}</p>`;
+        res.writeHead(status, { 'Content-Type': 'text/html; charset=utf-8', 'Content-Length': Buffer.byteLength(body) });
+        res.end(body);
+    }
+}


### PR DESCRIPTION
## Why

Claude Code / Claude Desktop with an `http` MCP entry run the OAuth authorization flow before their first JSON-RPC call, and refuse to connect when any step 404s:

- `http://127.0.0.1:40889/mcp` → `Dynamic Client Registration rejected (HTTP 404): {"error":"not found"}`
- `http://192.168.1.x:40889/mcp` (LAN mode) → `Dynamic Client Registration rejected (HTTP 403): {"error":"loopback only"}`

ChatGPT's tunnel-client never ran the flow, so it worked all along.

## What

**`oauth.ts` — an OAuth 2.1 shim, not authentication.** Answers every step of the dance and grants everyone who reaches it:

- `/.well-known/oauth-protected-resource[/mcp]`, `/.well-known/oauth-authorization-server[/mcp]`, `openid-configuration` alias. Endpoints built from the `Host` header so a LAN client gets LAN URLs.
- `POST /register` (RFC 7591): any metadata accepted, short `luban_…` client id minted. Redirect URIs must be loopback http(s) or a private-use scheme.
- `GET /authorize`: PKCE S256 required, 302 straight back with the code. No login page — the job confirm pages remain the human decision points. Codes single-use, 5 min TTL. Unknown `client_id` (server restarted) still granted for a loopback redirect.
- `POST /token`: `authorization_code` and `refresh_token` grants, refresh rotation, form or JSON body. Opaque tokens, no expiry.
- `/mcp` **never checks tokens and never 401s.** Clients that skip the flow and tokens from before a restart keep working.

**Attribution** is the payoff: the registered `client_name` labels every tool call and the initialize line:

```
MCP initialize from claude-code 2.1 [token: Claude Code (luban_00996696bb34)] (protocol 2025-03-26)
tool probe_point [Claude Code (luban_00996696bb34)] <- {...}
```

**LAN-mode fix.** `McpServer.handleRequest` hard-coded a loopback re-check, so a same-subnet client the `index.ts` gate had admitted still got `403 loopback only`. Both gates now share `isTrustedAddress` / `isTrustedOrigin` with `mcpAllowLan`. Every OAuth route sits behind that same gate, so the UI setting is respected.

README: `mcpAllowLan` row and a new Architecture paragraph.

## Verification

- `npx tsc -p tsconfig-server.json --noEmit` filtered to `services/mcp`: clean.
- eslint on the three touched files: clean.
- 41-check ts-node harness against the real router: metadata (incl. Host echo), register (incl. remote-redirect refusal), authorize (302 with code+state; 400 for unregistered remote redirect; error redirect without PKCE; unknown client tolerated), token (wrong verifier → `invalid_grant`, code single-use even after a failed attempt, refresh rotation, unsupported grant), `/mcp` with / without / with a stale bearer all 200, tool log line carries the client label. All pass.
- Not yet exercised against the live Claude Code client — next step after restarting Luban is to run the luban server auth in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
